### PR TITLE
PIL-884 Update start/end date Change link position

### DIFF
--- a/app/viewmodels/checkAnswers/GroupAccountingPeriodEndDateSummary.scala
+++ b/app/viewmodels/checkAnswers/GroupAccountingPeriodEndDateSummary.scala
@@ -25,6 +25,7 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import utils.ViewHelpers
 import viewmodels.govuk.summarylist._
 import viewmodels.implicits._
+import models.CheckMode
 
 object GroupAccountingPeriodEndDateSummary {
   val dateHelper = new ViewHelpers()
@@ -33,7 +34,12 @@ object GroupAccountingPeriodEndDateSummary {
       val startDate = HtmlFormat.escape(dateHelper.formatDateGDS(answer.endDate))
       SummaryListRowViewModel(
         key = "groupAccountingEndDatePeriod.checkYourAnswersLabel",
-        value = ValueViewModel(HtmlContent(startDate))
+        value = ValueViewModel(HtmlContent(startDate)),
+        actions = Seq(
+          ActionItemViewModel("site.change", controllers.subscription.routes.GroupAccountingPeriodController.onPageLoad(CheckMode).url)
+            .withVisuallyHiddenText(messages("groupAccountingPeriod.change.hidden"))
+            .withCssClass("govuk-!-display-none-print")
+        )
       )
 
     }

--- a/app/viewmodels/checkAnswers/GroupAccountingPeriodSummary.scala
+++ b/app/viewmodels/checkAnswers/GroupAccountingPeriodSummary.scala
@@ -30,12 +30,7 @@ object GroupAccountingPeriodSummary {
     answers.get(SubAccountingPeriodPage).map { answer =>
       SummaryListRowViewModel(
         key = "groupAccountingPeriod.checkYourAnswersLabel",
-        value = ValueViewModel(HtmlContent("")),
-        actions = Seq(
-          ActionItemViewModel("site.change", controllers.subscription.routes.GroupAccountingPeriodController.onPageLoad(CheckMode).url)
-            .withVisuallyHiddenText(messages("groupAccountingPeriod.change.hidden"))
-            .withCssClass("govuk-!-display-none-print")
-        )
+        value = ValueViewModel(HtmlContent(""))
       ).withCssClass("no-border-bottom")
     }
 

--- a/app/viewmodels/checkAnswers/manageAccount/GroupAccountingPeriodEndDateSummary.scala
+++ b/app/viewmodels/checkAnswers/manageAccount/GroupAccountingPeriodEndDateSummary.scala
@@ -33,7 +33,14 @@ object GroupAccountingPeriodEndDateSummary {
       val startDate = HtmlFormat.escape(dateHelper.formatDateGDS(answer.endDate))
       SummaryListRowViewModel(
         key = "groupAccountingEndDatePeriod.checkYourAnswersLabel",
-        value = ValueViewModel(HtmlContent(startDate))
+        value = ValueViewModel(HtmlContent(startDate)),
+        actions = Seq(
+          ActionItemViewModel(
+            "site.change",
+            controllers.subscription.manageAccount.routes.GroupAccountingPeriodController.onPageLoad.url
+          )
+            .withVisuallyHiddenText(messages("groupAccountingPeriod.change.hidden"))
+        )
       )
 
     }

--- a/app/viewmodels/checkAnswers/manageAccount/GroupAccountingPeriodSummary.scala
+++ b/app/viewmodels/checkAnswers/manageAccount/GroupAccountingPeriodSummary.scala
@@ -30,14 +30,7 @@ object GroupAccountingPeriodSummary {
     request.subscriptionLocalData.get(SubAccountingPeriodPage).map { _ =>
       SummaryListRowViewModel(
         key = "groupAccountingPeriod.amend.checkYourAnswersLabel",
-        value = ValueViewModel(HtmlContent("")),
-        actions = Seq(
-          ActionItemViewModel(
-            "site.change",
-            controllers.subscription.manageAccount.routes.GroupAccountingPeriodController.onPageLoad.url
-          )
-            .withVisuallyHiddenText(messages("groupAccountingPeriod.change.hidden"))
-        )
+        value = ValueViewModel(HtmlContent(""))
       ).withCssClass("no-border-bottom")
 
     }


### PR DESCRIPTION
This repositions the 'Change' link to come after the end date on 'Check Your Answers' on both the registration and manage account flows, rather than the groupAccountingPeriod.checkYourAnswersLabel. resolving the concern raised by the accessibility audit team ([GitHub issue #7581](https://github.com/hmrc/accessibility-audits-external/issues/7581)).