### PR TITLE
Proposal: Add Pull Request Templates for Feature and Singular Branches

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/feature_branch_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature_branch_template.md
@@ -1,0 +1,24 @@
+# Feature Branch Pull Request
+
+## Description
+<!-- Provide a concise description of the feature and its purpose. -->
+
+## Related Smaller PRs
+<!-- List the smaller PRs that make up this feature branch. Include links and corresponding JIRA tickets.
+     Check the box once QA has tested the smaller PR. -->
+
+- [ ] [JIRA-1234: Add user authentication](https://github.com/your-repo/your-project/pull/45)
+- [ ] [JIRA-1234: Implement password reset](https://github.com/your-repo/your-project/pull/46)
+- [ ] [JIRA-1234: Update user profile UI](https://github.com/your-repo/your-project/pull/47)
+
+## JIRA Ticket
+[PROJECT-1234](https://your-jira-instance.atlassian.net/browse/PROJECT-1234)
+
+## Checklist
+- [ ] Code follows the project's style guidelines
+- [ ] All relevant tests have been added or updated
+- [ ] Documentation has been updated accordingly
+- [ ] QA has verified the feature as a whole
+
+## Additional Notes
+<!-- Add any additional information or context here. -->

--- a/.github/PULL_REQUEST_TEMPLATE/singular_branch_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/singular_branch_template.md
@@ -1,0 +1,15 @@
+# Subtask Branch Pull Request
+
+## Description
+<!-- Provide a brief description of the change. -->
+
+## JIRA Ticket
+[PROJECT-1234-ADD_AUTH](https://your-jira-instance.atlassian.net/browse/PROJECT-1234-ADD_AUTH)
+
+## Checklist
+- [ ] Code follows the project's style guidelines
+- [ ] Relevant tests have been added or updated
+- [ ] Documentation has been updated if necessary
+
+## Additional Notes
+<!-- Add any additional information or context here. -->


### PR DESCRIPTION
**Overview**

To improve our development workflow and maintain consistency, I propose adding two GitHub Pull Request (PR) templates:

1. **Feature Branch PR Template**
   - **Purpose:** For feature branches that consist of multiple smaller changes.
   - **Includes:** Links to related singular PRs with checkboxes for QA confirmation.

2. **Singular Branch PR Template**
   - **Purpose:** For individual small tickets that don't require multiple PRs or as part of a larger feature.
   - **Includes:** A checklist to ensure QA has tested the changes.

**Benefits**

- **Consistency:** Standardises how PRs are created and documented across the team.
- **Traceability:** Easily track which singular PRs are part of a larger feature.
- **Quality Assurance:** Ensures each singular PR is tested by QA before merging.

**Usage:**
  - When creating a new PR, choose the appropriate template based on whether it's a feature branch or a singular branch.

**Notes**
  - The names "feature" and "singular" are open for discussion. If anyone has better naming suggestions, feel free to propose them. Additionally, the checklists included in the PR templates are suggestions and can be modified to better fit our workflow.