### PR TITLE
PIL-1253 - Make dateOfIncorporation optional

### DIFF
--- a/app/models/registration/IncorporatedEntityRegistrationData.scala
+++ b/app/models/registration/IncorporatedEntityRegistrationData.scala
@@ -37,7 +37,7 @@ object IncorporatedEntityRegistrationData {
 final case class CompanyProfile(
   companyName:            String,
   companyNumber:          String,
-  dateOfIncorporation:    LocalDate,
+  dateOfIncorporation:    Option[LocalDate],
   unsanitisedCHROAddress: IncorporatedEntityAddress
 )
 

--- a/app/stubsonly/data/GrsStubData.scala
+++ b/app/stubsonly/data/GrsStubData.scala
@@ -57,7 +57,7 @@ trait GrsStubData {
   private def validCompanyProfile(partnership: Boolean): CompanyProfile = CompanyProfile(
     companyName = if (partnership) "Test Example Partnership Name" else "Test Example Company Name",
     companyNumber = "76543210",
-    dateOfIncorporation = LocalDate.parse("2010-12-12"),
+    dateOfIncorporation = Some(LocalDate.parse("2010-12-12")),
     unsanitisedCHROAddress = IncorporatedEntityAddress(
       address_line_1 = Some("Address Line 1"),
       address_line_2 = Some("Address Line 2"),

--- a/test/controllers/CheckYourAnswersControllerSpec.scala
+++ b/test/controllers/CheckYourAnswersControllerSpec.scala
@@ -51,7 +51,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency {
         companyProfile = CompanyProfile(
           companyName = "ABC Limited",
           companyNumber = "1234",
-          dateOfIncorporation = date,
+          dateOfIncorporation = Some(date),
           unsanitisedCHROAddress = IncorporatedEntityAddress(address_line_1 = Some("line 1"), None, None, None, None, None, None, None)
         ),
         ctutr = "1234567890",

--- a/test/controllers/TaskListControllerSpec.scala
+++ b/test/controllers/TaskListControllerSpec.scala
@@ -49,7 +49,7 @@ class TaskListControllerSpec extends SpecBase {
         companyProfile = CompanyProfile(
           companyName = "ABC Limited",
           companyNumber = "1234",
-          dateOfIncorporation = LocalDate.now(),
+          dateOfIncorporation = Some(LocalDate.now()),
           unsanitisedCHROAddress = IncorporatedEntityAddress(address_line_1 = Some("line 1"), None, None, None, None, None, None, None)
         ),
         ctutr = "1234567890",

--- a/test/helpers/UserAnswersFixture.scala
+++ b/test/helpers/UserAnswersFixture.scala
@@ -67,7 +67,7 @@ trait UserAnswersFixture extends TryValues {
         companyProfile = CompanyProfile(
           companyName = "ABC Limited",
           companyNumber = "1234",
-          dateOfIncorporation = LocalDate.now(),
+          dateOfIncorporation = Some(LocalDate.now()),
           unsanitisedCHROAddress = IncorporatedEntityAddress(address_line_1 = Some("line 1"), None, None, None, None, None, None, None)
         ),
         ctutr = "1234567890",
@@ -85,7 +85,7 @@ trait UserAnswersFixture extends TryValues {
     companyProfile = CompanyProfile(
       companyName = "ABC Limited",
       companyNumber = "1234",
-      dateOfIncorporation = LocalDate.now(),
+      dateOfIncorporation = Some(LocalDate.now()),
       unsanitisedCHROAddress = IncorporatedEntityAddress(address_line_1 = Some("line 1"), None, None, None, None, None, None, None)
     ),
     ctutr = "1234567890",

--- a/test/models/registration/GrsResponseSpec.scala
+++ b/test/models/registration/GrsResponseSpec.scala
@@ -245,16 +245,13 @@ class GrsResponseSpec extends AnyFreeSpec with Matchers {
                 "companyName": "Test Company",
                 "companyNumber": "12345678",
                 "unsanitisedCHROAddress": {
-                  "address_line_1": "123 Test Street",
-                  "country": "United Kingdom",
                   "postal_code": "TE1 1ST"
                 }
               },
               "ctutr": "1234567890",
               "identifiersMatch": true,
               "registration": {
-                "registrationStatus": "REGISTERED",
-                "registeredBusinessPartnerId": "X1234567"
+                "registrationStatus": "REGISTERED"
               }
             }
           }
@@ -269,12 +266,11 @@ class GrsResponseSpec extends AnyFreeSpec with Matchers {
           data.companyProfile.companyName mustBe "Test Company"
           data.companyProfile.companyNumber mustBe "12345678"
           data.companyProfile.dateOfIncorporation mustBe None
-          data.companyProfile.unsanitisedCHROAddress.address_line_1 mustBe Some("123 Test Street")
           data.ctutr mustBe "1234567890"
           data.identifiersMatch mustBe true
           data.businessVerification mustBe None
           data.registration.registrationStatus mustBe RegistrationStatus.Registered
-          data.registration.registeredBusinessPartnerId mustBe Some("X1234567")
+          data.registration.registeredBusinessPartnerId mustBe None
         }
       }
     }

--- a/test/models/registration/GrsResponseSpec.scala
+++ b/test/models/registration/GrsResponseSpec.scala
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+package models.registration
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import play.api.libs.json.Json
@@ -59,7 +60,6 @@ class GrsResponseSpec extends AnyFreeSpec with Matchers {
         val result = json.as[GrsResponse]
         result.incorporatedEntityRegistrationData must not be None
         result.partnershipEntityRegistrationData mustBe None
-        // More specific assertions
         result.incorporatedEntityRegistrationData.foreach { data =>
           data.companyProfile.companyName mustBe "Test Company"
           data.companyProfile.companyNumber mustBe "12345678"
@@ -97,7 +97,6 @@ class GrsResponseSpec extends AnyFreeSpec with Matchers {
         result.incorporatedEntityRegistrationData mustBe None
         result.partnershipEntityRegistrationData must not be None
 
-        // Specific assertions about the partnershipEntityRegistrationData
         result.partnershipEntityRegistrationData.foreach { data =>
           data.sautr mustBe Some("1234567890")
           data.postcode mustBe Some("AB1 2CD")
@@ -219,7 +218,6 @@ class GrsResponseSpec extends AnyFreeSpec with Matchers {
         result.incorporatedEntityRegistrationData must not be None
         result.partnershipEntityRegistrationData  must be(None)
 
-        // More specific assertions
         result.incorporatedEntityRegistrationData.foreach { data =>
           data.companyProfile.companyName mustBe "Test Company"
           data.companyProfile.companyNumber mustBe "12345678"
@@ -232,7 +230,6 @@ class GrsResponseSpec extends AnyFreeSpec with Matchers {
           data.registration.registeredBusinessPartnerId mustBe Some("X1234567")
         }
 
-        // Ensure unexpected field is ignored
         (json \ "unexpectedField").as[String] mustBe "Some value"
       }
 

--- a/test/models/registration/GrsResponseSpec.scala
+++ b/test/models/registration/GrsResponseSpec.scala
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import play.api.libs.json.Json
+import models.registration.GrsResponse
+import java.time.LocalDate
+import models.grs.{BusinessVerificationResult, RegistrationStatus, VerificationStatus}
+
+class GrsResponseSpec extends AnyFreeSpec with Matchers {
+
+  "GrsResponse" - {
+    "must decode correctly" - {
+      "when JSON contains only incorporatedEntityRegistrationData" in {
+        val json = Json.parse(
+          """
+          {
+            "incorporatedEntityRegistrationData": {
+              "companyProfile": {
+                "companyName": "Test Company",
+                "companyNumber": "12345678",
+                "dateOfIncorporation": "2021-01-01",
+                "unsanitisedCHROAddress": {
+                  "address_line_1": "123 Test Street",
+                  "address_line_2": "Test Area",
+                  "country": "United Kingdom",
+                  "locality": "Test City",
+                  "postal_code": "TE1 1ST"
+                }
+              },
+              "ctutr": "1234567890",
+              "identifiersMatch": true,
+              "businessVerification": {
+                "verificationStatus": "PASS"
+              },
+              "registration": {
+                "registrationStatus": "REGISTERED",
+                "registeredBusinessPartnerId": "X1234567"
+              }
+            }
+          }
+          """
+        )
+
+        val result = json.as[GrsResponse]
+        result.incorporatedEntityRegistrationData must not be None
+        result.partnershipEntityRegistrationData mustBe None
+        // More specific assertions
+        result.incorporatedEntityRegistrationData.foreach { data =>
+          data.companyProfile.companyName mustBe "Test Company"
+          data.companyProfile.companyNumber mustBe "12345678"
+          data.companyProfile.dateOfIncorporation mustBe Some(LocalDate.of(2021, 1, 1))
+          data.companyProfile.unsanitisedCHROAddress.address_line_1 mustBe Some("123 Test Street")
+          data.ctutr mustBe "1234567890"
+          data.identifiersMatch mustBe true
+          data.businessVerification mustBe Some(BusinessVerificationResult(VerificationStatus.Pass))
+          data.registration.registrationStatus mustBe RegistrationStatus.Registered
+          data.registration.registeredBusinessPartnerId mustBe Some("X1234567")
+        }
+      }
+
+      "when JSON contains only partnershipEntityRegistrationData" in {
+        val json = Json.parse(
+          """
+          {
+            "partnershipEntityRegistrationData": {
+              "sautr": "1234567890",
+              "postcode": "AB1 2CD",
+              "identifiersMatch": true,
+              "businessVerification": {
+                "verificationStatus": "PASS"
+              },
+              "registration": {
+                "registrationStatus": "REGISTERED",
+                "registeredBusinessPartnerId": "X1234567"
+              }
+            }
+          }
+          """
+        )
+
+        val result = json.as[GrsResponse]
+        result.incorporatedEntityRegistrationData mustBe None
+        result.partnershipEntityRegistrationData must not be None
+
+        // Specific assertions about the partnershipEntityRegistrationData
+        result.partnershipEntityRegistrationData.foreach { data =>
+          data.sautr mustBe Some("1234567890")
+          data.postcode mustBe Some("AB1 2CD")
+          data.identifiersMatch mustBe true
+          data.businessVerification mustBe Some(BusinessVerificationResult(VerificationStatus.Pass))
+          data.registration.registrationStatus mustBe RegistrationStatus.Registered
+          data.registration.registeredBusinessPartnerId mustBe Some("X1234567")
+        }
+      }
+
+      "when JSON contains both entity types" in {
+        val json = Json.parse(
+          """
+          {
+            "incorporatedEntityRegistrationData": {
+              "companyProfile": {
+                "companyName": "Test Company",
+                "companyNumber": "12345678",
+                "dateOfIncorporation": "2021-01-01",
+                "unsanitisedCHROAddress": {
+                  "address_line_1": "123 Test Street",
+                  "address_line_2": "Test Area",
+                  "country": "United Kingdom",
+                  "locality": "Test City",
+                  "postal_code": "TE1 1ST"
+                }
+              },
+              "ctutr": "1234567890",
+              "identifiersMatch": true,
+              "businessVerification": {
+                "verificationStatus": "PASS"
+              },
+              "registration": {
+                "registrationStatus": "REGISTERED",
+                "registeredBusinessPartnerId": "X1234567"
+              }
+            },
+            "partnershipEntityRegistrationData": {
+              "sautr": "0987654321",
+              "postcode": "XY9 8ZW",
+              "identifiersMatch": true,
+              "businessVerification": {
+                "verificationStatus": "PASS"
+              },
+              "registration": {
+                "registrationStatus": "REGISTERED",
+                "registeredBusinessPartnerId": "Y9876543"
+              }
+            }
+          }
+          """
+        )
+
+        val result = json.as[GrsResponse]
+        result.incorporatedEntityRegistrationData must not be None
+        result.partnershipEntityRegistrationData  must not be None
+        result.incorporatedEntityRegistrationData.foreach { data =>
+          data.companyProfile.companyName mustBe "Test Company"
+          data.companyProfile.companyNumber mustBe "12345678"
+          data.companyProfile.dateOfIncorporation mustBe Some(LocalDate.of(2021, 1, 1))
+          data.companyProfile.unsanitisedCHROAddress.address_line_1 mustBe Some("123 Test Street")
+          data.ctutr mustBe "1234567890"
+          data.identifiersMatch mustBe true
+          data.businessVerification mustBe Some(BusinessVerificationResult(VerificationStatus.Pass))
+          data.registration.registrationStatus mustBe RegistrationStatus.Registered
+          data.registration.registeredBusinessPartnerId mustBe Some("X1234567")
+        }
+        result.partnershipEntityRegistrationData.foreach { data =>
+          data.sautr mustBe Some("0987654321")
+          data.postcode mustBe Some("XY9 8ZW")
+          data.identifiersMatch mustBe true
+          data.businessVerification mustBe Some(BusinessVerificationResult(VerificationStatus.Pass))
+          data.registration.registrationStatus mustBe RegistrationStatus.Registered
+          data.registration.registeredBusinessPartnerId mustBe Some("Y9876543")
+        }
+      }
+
+      "when JSON is empty" in {
+        val json = Json.parse("{}")
+
+        val result = json.as[GrsResponse]
+        result.incorporatedEntityRegistrationData must be(None)
+        result.partnershipEntityRegistrationData  must be(None)
+      }
+
+      "when JSON contains unexpected fields" in {
+        val json = Json.parse(
+          """
+          {
+            "unexpectedField": "Some value",
+            "incorporatedEntityRegistrationData": {
+              "companyProfile": {
+                "companyName": "Test Company",
+                "companyNumber": "12345678",
+                "dateOfIncorporation": "2021-01-01",
+                "unsanitisedCHROAddress": {
+                  "address_line_1": "123 Test Street",
+                  "address_line_2": "Test Area",
+                  "country": "United Kingdom",
+                  "locality": "Test City",
+                  "postal_code": "TE1 1ST"
+                }
+              },
+              "ctutr": "1234567890",
+              "identifiersMatch": true,
+              "businessVerification": {
+                "verificationStatus": "PASS"
+              },
+              "registration": {
+                "registrationStatus": "REGISTERED",
+                "registeredBusinessPartnerId": "X1234567"
+              }
+            }
+          }
+          """
+        )
+
+        val result = json.as[GrsResponse]
+        result.incorporatedEntityRegistrationData must not be None
+        result.partnershipEntityRegistrationData  must be(None)
+
+        // More specific assertions
+        result.incorporatedEntityRegistrationData.foreach { data =>
+          data.companyProfile.companyName mustBe "Test Company"
+          data.companyProfile.companyNumber mustBe "12345678"
+          data.companyProfile.dateOfIncorporation mustBe Some(LocalDate.of(2021, 1, 1))
+          data.companyProfile.unsanitisedCHROAddress.address_line_1 mustBe Some("123 Test Street")
+          data.ctutr mustBe "1234567890"
+          data.identifiersMatch mustBe true
+          data.businessVerification mustBe Some(BusinessVerificationResult(VerificationStatus.Pass))
+          data.registration.registrationStatus mustBe RegistrationStatus.Registered
+          data.registration.registeredBusinessPartnerId mustBe Some("X1234567")
+        }
+
+        // Ensure unexpected field is ignored
+        (json \ "unexpectedField").as[String] mustBe "Some value"
+      }
+    }
+  }
+}

--- a/test/models/subscription/SubscriptionJourneyModelSpec.scala
+++ b/test/models/subscription/SubscriptionJourneyModelSpec.scala
@@ -40,7 +40,7 @@ class SubscriptionJourneyModelSpec extends SpecBase with Matchers with OptionVal
         companyProfile = CompanyProfile(
           companyName = "ABC Limited",
           companyNumber = "1234",
-          dateOfIncorporation = date,
+          dateOfIncorporation = Some(date),
           unsanitisedCHROAddress = IncorporatedEntityAddress(address_line_1 = Some("line 1"), None, None, None, None, None, None, None)
         ),
         ctutr = "1234567890",
@@ -63,7 +63,7 @@ class SubscriptionJourneyModelSpec extends SpecBase with Matchers with OptionVal
           CompanyProfile(
             companyName = "ABC Limited",
             companyNumber = "1234",
-            dateOfIncorporation = date,
+            dateOfIncorporation = Some(date),
             unsanitisedCHROAddress = IncorporatedEntityAddress(address_line_1 = Some("line 1"), None, None, None, None, None, None, None)
           )
         ),

--- a/test/pages/DuplicateSafeIdPageSpec.scala
+++ b/test/pages/DuplicateSafeIdPageSpec.scala
@@ -33,7 +33,7 @@ class DuplicateSafeIdPageSpec extends PageBehaviours {
         companyProfile = CompanyProfile(
           companyName = "ABC Limited",
           companyNumber = "1234",
-          dateOfIncorporation = LocalDate.now(),
+          dateOfIncorporation = Some(LocalDate.now()),
           unsanitisedCHROAddress = IncorporatedEntityAddress(address_line_1 = Some("line 1"), None, None, None, None, None, None, None)
         ),
         ctutr = "1234567890",

--- a/test/services/SubscriptionServiceSpec.scala
+++ b/test/services/SubscriptionServiceSpec.scala
@@ -811,41 +811,6 @@ class SubscriptionServiceSpec extends SpecBase {
 
         result shouldEqual Some("ABC Limited")
       }
-      "return the company name if it is stored in the session and dateOfIncorporation is None" in {
-        val grsResponse = GrsResponse(
-          Some(
-            IncorporatedEntityRegistrationData(
-              companyProfile = CompanyProfile(
-                companyName = "ABC Limited",
-                companyNumber = "1234",
-                dateOfIncorporation = None,
-                unsanitisedCHROAddress = IncorporatedEntityAddress(address_line_1 = Some("line 1"), None, None, None, None, None, None, None)
-              ),
-              ctutr = "1234567890",
-              identifiersMatch = true,
-              businessVerification = None,
-              registration = GrsRegistrationResult(
-                registrationStatus = RegistrationStatus.Registered,
-                registeredBusinessPartnerId = Some("XB0000000000001"),
-                failures = None
-              )
-            )
-          )
-        )
-        val userAnswers = emptyUserAnswers
-          .setOrException(FmGRSResponsePage, grsResponse)
-
-        val application = applicationBuilder(userAnswers = Some(userAnswers))
-          .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
-          .build()
-
-        when(mockUserAnswersConnectors.getUserAnswer(any())(any())).thenReturn(Future.successful(Some(userAnswers)))
-
-        val service: SubscriptionService = application.injector.instanceOf[SubscriptionService]
-        val result = service.getCompanyNameFromGRS(grsResponse)
-
-        result shouldEqual Some("ABC Limited")
-      }
       "return an error redirect if the retrieval of the company name fails" in {
         val grsResponse = GrsResponse(None, None)
 

--- a/test/services/SubscriptionServiceSpec.scala
+++ b/test/services/SubscriptionServiceSpec.scala
@@ -783,7 +783,42 @@ class SubscriptionServiceSpec extends SpecBase {
               companyProfile = CompanyProfile(
                 companyName = "ABC Limited",
                 companyNumber = "1234",
-                dateOfIncorporation = date,
+                dateOfIncorporation = Some(date),
+                unsanitisedCHROAddress = IncorporatedEntityAddress(address_line_1 = Some("line 1"), None, None, None, None, None, None, None)
+              ),
+              ctutr = "1234567890",
+              identifiersMatch = true,
+              businessVerification = None,
+              registration = GrsRegistrationResult(
+                registrationStatus = RegistrationStatus.Registered,
+                registeredBusinessPartnerId = Some("XB0000000000001"),
+                failures = None
+              )
+            )
+          )
+        )
+        val userAnswers = emptyUserAnswers
+          .setOrException(FmGRSResponsePage, grsResponse)
+
+        val application = applicationBuilder(userAnswers = Some(userAnswers))
+          .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
+          .build()
+
+        when(mockUserAnswersConnectors.getUserAnswer(any())(any())).thenReturn(Future.successful(Some(userAnswers)))
+
+        val service: SubscriptionService = application.injector.instanceOf[SubscriptionService]
+        val result = service.getCompanyNameFromGRS(grsResponse)
+
+        result shouldEqual Some("ABC Limited")
+      }
+      "return the company name if it is stored in the session and dateOfIncorporation is None" in {
+        val grsResponse = GrsResponse(
+          Some(
+            IncorporatedEntityRegistrationData(
+              companyProfile = CompanyProfile(
+                companyName = "ABC Limited",
+                companyNumber = "1234",
+                dateOfIncorporation = None,
                 unsanitisedCHROAddress = IncorporatedEntityAddress(address_line_1 = Some("line 1"), None, None, None, None, None, None, None)
               ),
               ctutr = "1234567890",


### PR DESCRIPTION
## Changes

- Updated `CompanyProfile` to make `dateOfIncorporation` an `Option[LocalDate]`
- Adjusted test cases and stub data to reflect this change
- Added new `GrsResponseSpec` to test JSON decoding