### PR TITLE
PIL-1345: improvements on /second-contact page in Registration and RFM

### DIFF
--- a/app/views/rfm/RfmAddSecondaryContactView.scala.html
+++ b/app/views/rfm/RfmAddSecondaryContactView.scala.html
@@ -15,15 +15,19 @@
  *@
 
 @import config.FrontendAppConfig
-@import viewmodels.LegendSize.Large
+@import viewmodels.LegendSize.Medium
+@import views.html.components.gds.{heading, paragraphBody, sectionHeader}
 
 @this(
     layout: templates.Layout,
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
     govukRadios: GovukRadios,
-    govukButton: GovukButton
-    )
+    govukButton: GovukButton,
+    sectionHeader: sectionHeader,
+    paragraphBody: paragraphBody,
+    h1: heading
+)
 
 @(form: Form[_], contactName: String, mode: Mode)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
@@ -32,16 +36,20 @@
     @formHelper(action = controllers.rfm.routes.RfmAddSecondaryContactController.onSubmit(mode), 'autoComplete -> "off") {
 
         @if(form.errors.nonEmpty) {
-            @govukErrorSummary(ErrorSummaryViewModel(form,  errorLinkOverrides = Map("value" -> "value_0")))
-    }
-        <span class="govuk-caption-l">@messages("taskList.task.contact.heading")</span>
+            @govukErrorSummary(ErrorSummaryViewModel(form, errorLinkOverrides = Map("value" -> "value_0")))
+        }
+
+        @sectionHeader(messages("taskList.task.contact.heading"))
+        @h1(messages("rfm.addSecondaryContact.title"), classes = "govuk-heading-l")
+
+        @paragraphBody(messages("rfm.addSecondaryContact.p1"))
+        @paragraphBody(messages("rfm.addSecondaryContact.p2"))
 
         @govukRadios(
             RadiosViewModel.yesNo(
                 field = form("value"),
-                legend = LegendViewModel(messages("rfm.addSecondaryContact.heading", contactName)).asPageHeading(Large)
+                legend = LegendViewModel(messages("rfm.addSecondaryContact.checkYourAnswersLabel", contactName)).asPageHeading(Medium)
             )
-            .withHint(Hint(content = Text(messages("rfm.addSecondaryContact.hint"))))
         )
 
         @govukButton(

--- a/app/views/subscriptionview/AddSecondaryContactView.scala.html
+++ b/app/views/subscriptionview/AddSecondaryContactView.scala.html
@@ -15,8 +15,8 @@
  *@
 
 @import config.FrontendAppConfig
-@import viewmodels.LegendSize.Large
-@import views.html.components.gds.sectionHeader
+@import viewmodels.LegendSize.Medium
+@import views.html.components.gds.{heading, paragraphBody, sectionHeader}
 
 @this(
         layout: templates.Layout,
@@ -24,7 +24,9 @@
         sectionHeader: sectionHeader,
         govukErrorSummary: GovukErrorSummary,
         govukRadios: GovukRadios,
-        govukButton: GovukButton
+        govukButton: GovukButton,
+        paragraphBody: paragraphBody,
+        h1: heading,
 )
 
 @(form: Form[_], contactName: String, mode: Mode)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
@@ -39,13 +41,16 @@
         }
 
         @sectionHeader(messages("taskList.task.contact.heading"))
+        @h1(messages("addSecondaryContact.title"), classes = "govuk-heading-l")
+
+        @paragraphBody(messages("addSecondaryContact.p1"))
+        @paragraphBody(messages("addSecondaryContact.p2"))
 
         @govukRadios(
             RadiosViewModel.yesNo(
                 field = form("value"),
-                legend = LegendViewModel(messages("addSecondaryContact.heading", contactName)).asPageHeading(Large)
+                legend = LegendViewModel(messages("addSecondaryContact.checkYourAnswersLabel", contactName)).asPageHeading(Medium)
             )
-            .withHint(Hint(content = Text(messages("addSecondaryContact.hint"))))
         )
 
         @govukButton(

--- a/app/views/subscriptionview/manageAccount/AddSecondaryContactView.scala.html
+++ b/app/views/subscriptionview/manageAccount/AddSecondaryContactView.scala.html
@@ -15,8 +15,8 @@
  *@
 
 @import config.FrontendAppConfig
-@import viewmodels.LegendSize.Large
-@import views.html.components.gds.sectionHeader
+@import viewmodels.LegendSize.Medium
+@import views.html.components.gds.{heading, paragraphBody, sectionHeader}
 
 @this(
         layout: templates.Layout,
@@ -24,7 +24,9 @@
         sectionHeader: sectionHeader,
         govukErrorSummary: GovukErrorSummary,
         govukRadios: GovukRadios,
-        govukButton: GovukButton
+        govukButton: GovukButton,
+        paragraphBody: paragraphBody,
+        h1: heading,
 )
 
 @(form: Form[_], contactName: String)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
@@ -39,12 +41,16 @@
         }
 
         @sectionHeader(messages("taskList.task.contact.heading"))
+        @h1(messages("addSecondaryContact.title"), classes = "govuk-heading-l")
+
+        @paragraphBody(messages("addSecondaryContact.p1"))
+        @paragraphBody(messages("addSecondaryContact.p2"))
 
         @govukRadios(
             RadiosViewModel.yesNo(
                 field = form("value"),
-                legend = LegendViewModel(messages("addSecondaryContact.heading", contactName)).asPageHeading(Large)
-            ).withHint(Hint(content = Text(messages("addSecondaryContact.hint"))))
+                legend = LegendViewModel(messages("addSecondaryContact.checkYourAnswersLabel", contactName)).asPageHeading(Medium)
+            )
         )
 
         @govukButton(

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -758,11 +758,11 @@ checkYourAnswers.heading.caption = Review and submit
 checkYourAnswers.upe = Ultimate parent
 checkYourAnswers.nfm = Nominated filing member
 
-addSecondaryContact.title = Is there someone else we can contact?
-addSecondaryContact.heading = Is there someone else we can contact if {0} is not available?
-addSecondaryContact.hint = This can be a team mailbox or another contact who is able to deal with enquiries about the group’s management of Pillar 2 top-up taxes.
+addSecondaryContact.title = Add a secondary contact
+addSecondaryContact.p1 = We use the secondary contact if we do not get a response from the primary contact. We encourage you to provide a secondary contact, if possible.
+addSecondaryContact.p2 = This can be a team mailbox or another contact who is able to deal with enquiries about the group’s management of Pillar 2 top-up taxes.
 addSecondaryContact.error.required = Select yes if there is someone else we can contact if {0} is not available
-addSecondaryContact.checkYourAnswersLabel = Do you have a secondary contact?
+addSecondaryContact.checkYourAnswersLabel = Do you have a second contact?
 
 secondaryContactName.title = What is the name of the alternative person or team we should contact about compliance for Pillar 2 top-up taxes?
 secondaryContactName.heading = What is the name of the alternative person or team we should contact about compliance for Pillar 2 top-up taxes?
@@ -1049,11 +1049,11 @@ rfm.secondaryContactEmail.change.hidden = the secondary contact email address
 rfm.secondaryTelephonePreference.change.hidden = can we contact the secondary contact by telephone
 rfm.secondaryTelephone.change.hidden = the telephone number for the secondary contact
 
-rfm.addSecondaryContact.title = Is there someone else we can contact?
-rfm.addSecondaryContact.heading = Is there someone else we can contact if {0} is not available?
-rfm.addSecondaryContact.hint = This can be a team mailbox or another contact who is able to deal with enquiries about the group’s management of Pillar 2 top-up taxes.
+rfm.addSecondaryContact.title = Add a secondary contact
+rfm.addSecondaryContact.p1 = We use the secondary contact if we do not get a response from the primary contact. We encourage you to provide a secondary contact, if possible.
+rfm.addSecondaryContact.p2 = This can be a team mailbox or another contact who is able to deal with enquiries about the group’s management of Pillar 2 top-up taxes.
 rfm.addSecondaryContact.error.required = Select yes if there is someone else we can contact if {0} is not available
-rfm.addSecondaryContact.checkYourAnswersLabel = Do you have a secondary contact?
+rfm.addSecondaryContact.checkYourAnswersLabel = Do you have a second contact?
 
 rfm.secondaryContactName.title = What is the name of the alternative person or team we should contact about compliance for Pillar 2 top-up taxes?
 rfm.secondaryContactName.heading = What is the name of the alternative person or team we should contact about compliance for Pillar 2 top-up taxes?

--- a/test/views/subscriptionview/AddSecondaryContactViewSpec.scala
+++ b/test/views/subscriptionview/AddSecondaryContactViewSpec.scala
@@ -14,30 +14,30 @@
  * limitations under the License.
  */
 
-package views.rfm
+package views.subscriptionview
 
 import base.ViewSpecBase
-import forms.RfmAddSecondaryContactFormProvider
+import forms.AddSecondaryContactFormProvider
 import models.NormalMode
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import views.html.rfm.RfmAddSecondaryContactView
+import views.html.subscriptionview.AddSecondaryContactView
 
-class RfmAddSecondaryContactViewSpec extends ViewSpecBase {
+class AddSecondaryContactViewSpec extends ViewSpecBase {
 
-  val formProvider = new RfmAddSecondaryContactFormProvider
-  val page: RfmAddSecondaryContactView = inject[RfmAddSecondaryContactView]
+  val formProvider = new AddSecondaryContactFormProvider
+  val page: AddSecondaryContactView = inject[AddSecondaryContactView]
 
   val view: Document = Jsoup.parse(page(formProvider("John Doe"), "John Doe", NormalMode)(request, appConfig, messages).toString())
 
-  "Rfm Add Secondary Contact View" should {
+  "AddSecondaryContactView" should {
 
-    "have a title" in {
+    "have a title and a heading" in {
       view.getElementsByTag("title").text must include("Add a secondary contact")
     }
 
     "have a caption" in {
-      view.getElementsByClass("govuk-caption-l").text must include("Contact details")
+      view.getElementsByClass("govuk-caption-l").text must equal("Contact details")
     }
 
     "have a heading" in {

--- a/test/views/subscriptionview/manageAccount/AddSecondaryContactViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/AddSecondaryContactViewSpec.scala
@@ -14,30 +14,29 @@
  * limitations under the License.
  */
 
-package views.rfm
+package views.subscriptionview.manageAccount
 
 import base.ViewSpecBase
-import forms.RfmAddSecondaryContactFormProvider
-import models.NormalMode
+import forms.AddSecondaryContactFormProvider
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import views.html.rfm.RfmAddSecondaryContactView
+import views.html.subscriptionview.manageAccount.AddSecondaryContactView
 
-class RfmAddSecondaryContactViewSpec extends ViewSpecBase {
+class AddSecondaryContactViewSpec extends ViewSpecBase {
 
-  val formProvider = new RfmAddSecondaryContactFormProvider
-  val page: RfmAddSecondaryContactView = inject[RfmAddSecondaryContactView]
+  val formProvider = new AddSecondaryContactFormProvider
+  val page: AddSecondaryContactView = inject[AddSecondaryContactView]
 
-  val view: Document = Jsoup.parse(page(formProvider("John Doe"), "John Doe", NormalMode)(request, appConfig, messages).toString())
+  val view: Document = Jsoup.parse(page(formProvider("John Doe"), "John Doe")(request, appConfig, messages).toString())
 
-  "Rfm Add Secondary Contact View" should {
+  "AddSecondaryContactView" should {
 
     "have a title" in {
       view.getElementsByTag("title").text must include("Add a secondary contact")
     }
 
     "have a caption" in {
-      view.getElementsByClass("govuk-caption-l").text must include("Contact details")
+      view.getElementsByClass("govuk-caption-l").text must equal("Contact details")
     }
 
     "have a heading" in {
@@ -58,7 +57,7 @@ class RfmAddSecondaryContactViewSpec extends ViewSpecBase {
     }
 
     "have a button" in {
-      view.getElementsByClass("govuk-button").text must equal("Save and continue")
+      view.getElementsByClass("govuk-button").text must equal("Continue")
     }
   }
 }

--- a/test/views/subscriptionview/manageAccount/ManageContactCheckYourAnswersViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/ManageContactCheckYourAnswersViewSpec.scala
@@ -129,7 +129,7 @@ class ManageContactCheckYourAnswersViewSpec extends ViewSpecBase with Subscripti
     }
 
     "have a second contact summary list" in {
-      val isSecondContact      = "Do you have a secondary contact?"
+      val isSecondContact      = "Do you have a second contact?"
       val isSecondContactValue = "Yes"
       view.getElementsByClass("govuk-summary-list__key").get(4).text() mustBe isSecondContact
       view.getElementsByClass("govuk-summary-list__value").get(4).text() mustBe isSecondContactValue


### PR DESCRIPTION
- Content added to help make the page more user-friendly
- Form error localised to only radio box and legend
- Added unit tests for two views and implemented stricter matching assertion (_equal_ instead of _include_) where useful