### PR TITLE
PIL-1420 Fix max field length test bug

### DIFF
--- a/test-utils/generators/Generators.scala
+++ b/test-utils/generators/Generators.scala
@@ -29,7 +29,7 @@ trait Generators extends UserAnswersGenerator with PageGenerators with ModelGene
 
   implicit val dontShrink: Shrink[String] = Shrink.shrinkAny
 
-  implicit val arbNonWhitespace: Arbitrary[Char] = Arbitrary(arbitrary[Char].suchThat(!_.isWhitespace))
+  implicit val arbNonWhitespace: Arbitrary[Char] = Arbitrary(arbitrary[Char](Arbitrary.arbChar).suchThat(!_.isWhitespace))
 
   def genIntersperseString(gen: Gen[String], value: String, frequencyV: Int = 1, frequencyN: Int = 10): Gen[String] = {
 

--- a/test-utils/generators/Generators.scala
+++ b/test-utils/generators/Generators.scala
@@ -29,7 +29,7 @@ trait Generators extends UserAnswersGenerator with PageGenerators with ModelGene
 
   implicit val dontShrink: Shrink[String] = Shrink.shrinkAny
 
-  implicit val arbNonWhitespace: Arbitrary[Char] = Arbitrary(arbitrary[Char](Arbitrary.arbChar).suchThat(!_.isWhitespace))
+  implicit val arbNonWhitespace: Arbitrary[Char] = Arbitrary(arbitrary[Char](Arbitrary.arbChar).suchThat(_ >= ' '))
 
   def genIntersperseString(gen: Gen[String], value: String, frequencyV: Int = 1, frequencyN: Int = 10): Gen[String] = {
 

--- a/test-utils/generators/Generators.scala
+++ b/test-utils/generators/Generators.scala
@@ -101,14 +101,6 @@ trait Generators extends UserAnswersGenerator with PageGenerators with ModelGene
       .map(s => s.take(maxLength))
   }
 
-  def nonWhitespaceRegexConformingStringWithMaxLength(regex: String, maxLength: Int): Gen[String] = {
-    val arbNonWhitespace: Arbitrary[Char] = Arbitrary(arbitrary[Char].suchThat(!_.isWhitespace))
-    val regexGen = RegexpGen.from(regex)(arbNonWhitespace)
-    regexGen
-      .suchThat(_.nonEmpty)
-      .map(s => s.take(maxLength))
-  }
-
   def stringsWithAtLeastOneSpecialChar(specialChars: String, maxLength: Int): Gen[String] = {
     require(specialChars.nonEmpty, "specialChars must not be empty")
     require(maxLength > 0, "maxLength must be positive")
@@ -184,6 +176,15 @@ trait Generators extends UserAnswersGenerator with PageGenerators with ModelGene
     RegexpGen
       .from(regex)
       .map(_.padTo(minLength + 1, 'a'))
+
+  def longNonWhitespaceRegexConformingString(regex: String, minLength: Int): Gen[String] = {
+    val arbNonWhitespace: Arbitrary[Char] = Arbitrary(arbitrary[Char].suchThat(!_.isWhitespace))
+    val regexGen = RegexpGen.from(regex)(arbNonWhitespace)
+    regexGen
+      .map { s =>
+        Stream.continually(s).take((minLength / s.length) + 1).mkString
+      }
+  }
 
   def stringsLongerThan(minLength: Int): Gen[String] = for {
     maxLength <- (minLength * 2).max(100)

--- a/test-utils/generators/Generators.scala
+++ b/test-utils/generators/Generators.scala
@@ -17,7 +17,7 @@
 package generators
 
 import models.{FinancialHistory, TransactionHistory}
-import org.scalacheck.Arbitrary._
+import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen._
 import org.scalacheck.{Arbitrary, Gen, Shrink}
 import wolfendale.scalacheck.regexp.RegexpGen
@@ -28,6 +28,8 @@ import scala.math.BigDecimal.RoundingMode
 trait Generators extends UserAnswersGenerator with PageGenerators with ModelGenerators with UserAnswersEntryGenerators {
 
   implicit val dontShrink: Shrink[String] = Shrink.shrinkAny
+
+  implicit val arbNonWhitespace: Arbitrary[Char] = Arbitrary(arbitrary[Char].suchThat(!_.isWhitespace))
 
   def genIntersperseString(gen: Gen[String], value: String, frequencyV: Int = 1, frequencyN: Int = 10): Gen[String] = {
 
@@ -176,15 +178,6 @@ trait Generators extends UserAnswersGenerator with PageGenerators with ModelGene
     RegexpGen
       .from(regex)
       .map(_.padTo(minLength + 1, 'a'))
-
-  def longNonWhitespaceRegexConformingString(regex: String, minLength: Int): Gen[String] = {
-    val arbNonWhitespace: Arbitrary[Char] = Arbitrary(arbitrary[Char].suchThat(!_.isWhitespace))
-    val regexGen = RegexpGen.from(regex)(arbNonWhitespace)
-    regexGen
-      .map { s =>
-        Stream.continually(s).take((minLength / s.length) + 1).mkString
-      }
-  }
 
   def stringsLongerThan(minLength: Int): Gen[String] = for {
     maxLength <- (minLength * 2).max(100)

--- a/test-utils/generators/Generators.scala
+++ b/test-utils/generators/Generators.scala
@@ -101,6 +101,14 @@ trait Generators extends UserAnswersGenerator with PageGenerators with ModelGene
       .map(s => s.take(maxLength))
   }
 
+  def nonWhitespaceRegexConformingStringWithMaxLength(regex: String, maxLength: Int): Gen[String] = {
+    val arbNonWhitespace: Arbitrary[Char] = Arbitrary(arbitrary[Char].suchThat(!_.isWhitespace))
+    val regexGen = RegexpGen.from(regex)(arbNonWhitespace)
+    regexGen
+      .suchThat(_.nonEmpty)
+      .map(s => s.take(maxLength))
+  }
+
   def stringsWithAtLeastOneSpecialChar(specialChars: String, maxLength: Int): Gen[String] = {
     require(specialChars.nonEmpty, "specialChars must not be empty")
     require(maxLength > 0, "maxLength must be positive")

--- a/test-utils/generators/Generators.scala
+++ b/test-utils/generators/Generators.scala
@@ -29,7 +29,7 @@ trait Generators extends UserAnswersGenerator with PageGenerators with ModelGene
 
   implicit val dontShrink: Shrink[String] = Shrink.shrinkAny
 
-  implicit val arbNonWhitespace: Arbitrary[Char] = Arbitrary(arbitrary[Char](Arbitrary.arbChar).suchThat(_ >= ' '))
+  implicit val arbNonWhitespace: Arbitrary[Char] = Arbitrary(arbitrary[Char](Arbitrary.arbChar).suchThat(_ > ' '))
 
   def genIntersperseString(gen: Gen[String], value: String, frequencyV: Int = 1, frequencyN: Int = 10): Gen[String] = {
 

--- a/test/forms/NonUKBankFormProviderSpec.scala
+++ b/test/forms/NonUKBankFormProviderSpec.scala
@@ -114,7 +114,7 @@ class NonUKBankFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       maxLength = maxLength,
       lengthError = FormError(fieldName, lengthKey, Seq(maxLength)),
-      generator = Some(nonWhitespaceRegexConformingStringWithMaxLength(regex, maxLength))
+      generator = Some(longNonWhitespaceRegexConformingString(regex, maxLength))
     )
 
     behave like mandatoryField(
@@ -143,7 +143,7 @@ class NonUKBankFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       maxLength = maxLength,
       lengthError = FormError(fieldName, lengthKey, Seq(maxLength)),
-      generator = Some(nonWhitespaceRegexConformingStringWithMaxLength(regex, maxLength))
+      generator = Some(longNonWhitespaceRegexConformingString(regex, maxLength))
     )
 
     behave like mandatoryField(

--- a/test/forms/NonUKBankFormProviderSpec.scala
+++ b/test/forms/NonUKBankFormProviderSpec.scala
@@ -114,7 +114,7 @@ class NonUKBankFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       maxLength = maxLength,
       lengthError = FormError(fieldName, lengthKey, Seq(maxLength)),
-      generator = Some(longNonWhitespaceRegexConformingString(regex, maxLength))
+      generator = Some(longStringsConformingToRegex(regex, maxLength))
     )
 
     behave like mandatoryField(
@@ -143,7 +143,7 @@ class NonUKBankFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       maxLength = maxLength,
       lengthError = FormError(fieldName, lengthKey, Seq(maxLength)),
-      generator = Some(longNonWhitespaceRegexConformingString(regex, maxLength))
+      generator = Some(longStringsConformingToRegex(regex, maxLength))
     )
 
     behave like mandatoryField(

--- a/test/forms/NonUKBankFormProviderSpec.scala
+++ b/test/forms/NonUKBankFormProviderSpec.scala
@@ -113,7 +113,8 @@ class NonUKBankFormProviderSpec extends StringFieldBehaviours {
       form,
       fieldName,
       maxLength = maxLength,
-      lengthError = FormError(fieldName, lengthKey, Seq(maxLength))
+      lengthError = FormError(fieldName, lengthKey, Seq(maxLength)),
+      generator = Some(nonWhitespaceRegexConformingStringWithMaxLength(regex, maxLength))
     )
 
     behave like mandatoryField(
@@ -142,7 +143,7 @@ class NonUKBankFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       maxLength = maxLength,
       lengthError = FormError(fieldName, lengthKey, Seq(maxLength)),
-      generator = Some(longStringsConformingToRegex(regex, maxLength))
+      generator = Some(nonWhitespaceRegexConformingStringWithMaxLength(regex, maxLength))
     )
 
     behave like mandatoryField(


### PR DESCRIPTION
## The Issue
Our form field length validation tests weren't properly testing maximum length constraints because:

1. Many form fields trim whitespace before validation (via various formatters)
2. Our test generators were creating strings containing whitespace characters
3. After trimming, test strings would end up shorter than intended, causing tests to pass incorrectly

## The Fix
Added a new arbitrary character generator that excludes in the same manner that the trim method does in the formatter:
```scala
implicit val arbNonWhitespace: Arbitrary[Char] = Arbitrary(arbitrary[Char]
(Arbitrary.arbChar).suchThat(_ > ' '))
```

This generator is now used by default in our string generators, ensuring that:
- Generated test strings don't contain whitespace
- String length remains consistent before and after formatter processing
- Length validation is properly tested

## Testing
- All existing tests pass
- Length validation tests now properly catch maximum length violations