### PR TITLE
PIL-1427 Allow AMPERSAND in ContactAddress in RfmContactAddressFormPr…

### DIFF
--- a/app/forms/RfmContactAddressFormProvider.scala
+++ b/app/forms/RfmContactAddressFormProvider.scala
@@ -16,7 +16,7 @@
 
 package forms
 
-import forms.Validation.XSS_REGEX
+import forms.Validation.{XSS_REGEX, XSS_REGEX_ALLOW_AMPERSAND}
 import forms.mappings.AddressMappings.maxAddressLineLength
 import forms.mappings.{AddressMappings, Mappings}
 import models.NonUKAddress
@@ -33,7 +33,7 @@ class RfmContactAddressFormProvider @Inject() extends Mappings with AddressMappi
           .verifying(
             firstError(
               maxLength(maxAddressLineLength, "rfmContactAddress.error.addressLine1.length"),
-              regexp(XSS_REGEX, "addressLine1.error.xss")
+              regexp(XSS_REGEX_ALLOW_AMPERSAND, "addressLine1.error.xss")
             )
           ),
       "addressLine2" -> optional(

--- a/test-utils/generators/Generators.scala
+++ b/test-utils/generators/Generators.scala
@@ -17,7 +17,7 @@
 package generators
 
 import models.{FinancialHistory, TransactionHistory}
-import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Arbitrary._
 import org.scalacheck.Gen._
 import org.scalacheck.{Arbitrary, Gen, Shrink}
 import wolfendale.scalacheck.regexp.RegexpGen
@@ -28,7 +28,6 @@ import scala.math.BigDecimal.RoundingMode
 trait Generators extends UserAnswersGenerator with PageGenerators with ModelGenerators with UserAnswersEntryGenerators {
 
   implicit val dontShrink: Shrink[String] = Shrink.shrinkAny
-  implicit val arbNonWhitespace: Arbitrary[Char] = Arbitrary(arbitrary[Char](Arbitrary.arbChar).suchThat(_ > ' '))
 
   def genIntersperseString(gen: Gen[String], value: String, frequencyV: Int = 1, frequencyN: Int = 10): Gen[String] = {
 

--- a/test-utils/generators/Generators.scala
+++ b/test-utils/generators/Generators.scala
@@ -17,7 +17,7 @@
 package generators
 
 import models.{FinancialHistory, TransactionHistory}
-import org.scalacheck.Arbitrary._
+import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen._
 import org.scalacheck.{Arbitrary, Gen, Shrink}
 import wolfendale.scalacheck.regexp.RegexpGen
@@ -28,6 +28,7 @@ import scala.math.BigDecimal.RoundingMode
 trait Generators extends UserAnswersGenerator with PageGenerators with ModelGenerators with UserAnswersEntryGenerators {
 
   implicit val dontShrink: Shrink[String] = Shrink.shrinkAny
+  implicit val arbNonWhitespace: Arbitrary[Char] = Arbitrary(arbitrary[Char](Arbitrary.arbChar).suchThat(_ > ' '))
 
   def genIntersperseString(gen: Gen[String], value: String, frequencyV: Int = 1, frequencyN: Int = 10): Gen[String] = {
 
@@ -118,7 +119,7 @@ trait Generators extends UserAnswersGenerator with PageGenerators with ModelGene
 
   def invalidSortCodes: Gen[String] = {
     val digits    = Gen.numChar
-    val nonDigits = arbitrary[Char] suchThat (!_.isDigit)
+    val nonDigits = arbitrary[Char] suchThat (c => !c.isDigit && c != '-')
     for {
       n            <- Gen.choose(1, 5)
       digitPart    <- Gen.listOfN(n, digits)


### PR DESCRIPTION
PIL-1427 Allow AMPERSAND in ContactAddress in RfmContactAddressFormProvider. This aligns the validation for ContactAddress in RfmContactAddressFormProvider with the other pillar2-frontend validations for the address-line1 field, which all allow the use of ampersand. 