### PR TITLE
PIL-1286 - Added logic to acccessibility Table issue- Horizontal Heading Issue 

### DIFF
--- a/app/controllers/TransactionHistoryController.scala
+++ b/app/controllers/TransactionHistoryController.scala
@@ -85,7 +85,6 @@ class TransactionHistoryController @Inject() (
           case NoResultFound      => Redirect(routes.TransactionHistoryController.onPageLoadNoTransactionHistory())
           case UnexpectedResponse => Redirect(routes.TransactionHistoryController.onPageLoadError())
         }
-
     }
 
   def onPageLoadNoTransactionHistory(): Action[AnyContent] =
@@ -106,7 +105,7 @@ class TransactionHistoryController @Inject() (
     }
 
   def onPageLoadError(): Action[AnyContent] = Action.async { implicit request =>
-    Future successful Ok(errorView())
+    Future.successful(Ok(errorView()))
   }
 }
 
@@ -177,8 +176,8 @@ object TransactionHistoryController {
   ): Option[Table] = {
     val currentPage: Option[Seq[FinancialHistory]] = financialHistory.grouped(ROWS_ON_PAGE).toSeq.lift(paginationIndex - 1)
 
-    currentPage.map { financialHistory =>
-      val rows = financialHistory.map(createTableRows)
+    currentPage.map { historyOnPage =>
+      val rows = historyOnPage.map(createTableRows)
       createTable(rows)
     }
   }
@@ -188,10 +187,10 @@ object TransactionHistoryController {
       rows = rows,
       head = Some(
         Seq(
-          HeadCell(Text(messages("transactionHistory.date"))),
-          HeadCell(Text(messages("transactionHistory.description"))),
-          HeadCell(Text(messages("transactionHistory.amountPaid")), classes = "govuk-table__header--numeric"),
-          HeadCell(Text(messages("transactionHistory.amountRefunded")), classes = "govuk-table__header--numeric")
+          HeadCell(Text(messages("transactionHistory.date")), attributes = Map("scope" -> "col")),
+          HeadCell(Text(messages("transactionHistory.description")), attributes = Map("scope" -> "col")),
+          HeadCell(Text(messages("transactionHistory.amountPaid")), classes = "govuk-table__header--numeric", attributes = Map("scope" -> "col")),
+          HeadCell(Text(messages("transactionHistory.amountRefunded")), classes = "govuk-table__header--numeric", attributes = Map("scope" -> "col"))
         )
       )
     )

--- a/app/views/components/gds/ScrollWrapper.scala.html
+++ b/app/views/components/gds/ScrollWrapper.scala.html
@@ -1,0 +1,21 @@
+@*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(content: Html)
+
+<div class="table-scroll-wrapper">
+    @content
+</div>

--- a/app/views/paymenthistory/TransactionHistoryView.scala.html
+++ b/app/views/paymenthistory/TransactionHistoryView.scala.html
@@ -16,6 +16,10 @@
 
 @import config.FrontendAppConfig
 @import views.html.components.gds._
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.table.Table
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.pagination.Pagination
+@import views.html.paymenthistory.styles.tableScrollStyles
+@import views.html.components.gds.ScrollWrapper
 
 @this(
         layout: templates.Layout,
@@ -28,19 +32,19 @@
 @(table: Table, pagination: Option[Pagination], registrationDate: String)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @pageLayout(contentBlock: Html) = {
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-        @contentBlock
-        </div>
-    </div>
+      @contentBlock
 }
 
 @layout(pageTitle = titleNoForm(messages("transactionHistory.title")), pageLayout = pageLayout) {
 
+    @tableScrollStyles()
+
     @heading(messages("transactionHistory.heading"))
     @p(messages("transactionHistory.p1"))
 
-    @govukTable(table)
+    @ScrollWrapper {
+        @govukTable(table)
+    }
 
     @pagination.map { pag =>
         @govukPagination(pag)

--- a/app/views/paymenthistory/styles/tableScrollStyles.scala.html
+++ b/app/views/paymenthistory/styles/tableScrollStyles.scala.html
@@ -1,0 +1,33 @@
+@*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@()
+
+<style>
+        .table-scroll-wrapper {
+            overflow-x: auto;
+            width: 100%;
+        }
+
+        .govuk-table thead th {
+            position: sticky;
+            top: 0;
+            background: #ffffff;
+            z-index: 2;
+            border-bottom: 2px solid #b1b4b6;
+
+        }
+</style>


### PR DESCRIPTION
Added Horizontal scrolling required to view parts of the table on the “Transaction history” page in the Report Pillar 2 top-up taxes service. This issue can cause users to lose the association between table headers and their corresponding data, especially when using high magnification. 