### PR TITLE
PIL-872: DEV | New Tab issue in Jenkins for Acceptance tests

### DIFF
--- a/test/views/bta/NoPlrIdGuidanceViewSpec.scala
+++ b/test/views/bta/NoPlrIdGuidanceViewSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.bta
+
+import base.ViewSpecBase
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import views.html.bta.NoPlrIdGuidanceView
+
+class NoPlrIdGuidanceViewSpec extends ViewSpecBase {
+
+  val page: NoPlrIdGuidanceView = inject[NoPlrIdGuidanceView]
+
+  val view: Document = Jsoup.parse(page()(request, appConfig, messages).toString())
+
+  "No Plr Id Guidance View" should {
+
+    "have a title" in {
+      val title = "You need a Pillar 2 top-up taxes ID to access this service - Report Pillar 2 top-up taxes - GOV.UK"
+      view.getElementsByTag("title").text must include(title)
+    }
+
+    "have a heading" in {
+      view.getElementsByTag("h1").text must include("You need a Pillar 2 top-up taxes ID to access this service")
+    }
+
+    "have a paragraph body" in {
+      view.getElementsByClass("govuk-body").first().text must include("Register to report Pillar 2 top-up taxes to get a Pillar 2 top-up taxes ID.")
+    }
+
+    "have a paragraph link" in {
+      val link = view.getElementsByClass("govuk-body").last().getElementsByTag("a")
+
+      link.text must include("Find out how to register to report Pillar 2 top-up taxes (opens in new tab)")
+      link.attr("href") must include("https://www.gov.uk/guidance/report-pillar-2-top-up-taxes")
+      link.attr("target") mustBe "_blank"
+    }
+
+    "have a button" in {
+      view.getElementsByClass("govuk-button").text must include("Return to your Business Tax Account")
+    }
+
+  }
+}

--- a/test/views/bta/NoPlrIdGuidanceViewSpec.scala
+++ b/test/views/bta/NoPlrIdGuidanceViewSpec.scala
@@ -45,7 +45,7 @@ class NoPlrIdGuidanceViewSpec extends ViewSpecBase {
     "have a paragraph link" in {
       val link = view.getElementsByClass("govuk-body").last().getElementsByTag("a")
 
-      link.text must include("Find out how to register to report Pillar 2 top-up taxes (opens in new tab)")
+      link.text         must include("Find out how to register to report Pillar 2 top-up taxes (opens in new tab)")
       link.attr("href") must include("https://www.gov.uk/guidance/report-pillar-2-top-up-taxes")
       link.attr("target") mustBe "_blank"
     }

--- a/test/views/registrationview/RegistrationFailedNfmViewSpec.scala
+++ b/test/views/registrationview/RegistrationFailedNfmViewSpec.scala
@@ -42,7 +42,7 @@ class RegistrationFailedNfmViewSpec extends ViewSpecBase {
 
     "have a paragraph body" in {
       view.getElementsByClass("govuk-body").first().text must include("We could not match the details you entered with records held by HMRC.")
-      view.getElementsByClass("govuk-body").get(1).text must include("You can confirm your details with the records held by HMRC by:")
+      view.getElementsByClass("govuk-body").get(1).text  must include("You can confirm your details with the records held by HMRC by:")
     }
 
     "have a paragraph links" in {
@@ -50,18 +50,18 @@ class RegistrationFailedNfmViewSpec extends ViewSpecBase {
       val link2 = view.getElementsByTag("ul").first().getElementsByTag("a").get(1)
       val link3 = view.getElementsByClass("govuk-body").get(4)
 
-      link1.text must include("search Companies House for the company registration number and registered office address (opens in a new tab)")
+      link1.text         must include("search Companies House for the company registration number and registered office address (opens in a new tab)")
       link1.attr("href") must include("https://find-and-update.company-information.service.gov.uk/")
       link1.attr("target") mustBe "_blank"
 
-      link2.text must include("ask for a copy of your Corporation Tax Unique Taxpayer Reference (opens in a new tab)")
+      link2.text         must include("ask for a copy of your Corporation Tax Unique Taxpayer Reference (opens in a new tab)")
       link2.attr("href") must include("https://www.tax.service.gov.uk/ask-for-copy-of-your-corporation-tax-utr")
       link2.attr("target") mustBe "_blank"
 
       link3.text must include(
         "You can go back to select the entity type and try again using different details if you think you made an error when entering them."
       )
-      link3.getElementsByTag("a").text() must include("go back to select the entity type")
+      link3.getElementsByTag("a").text()       must include("go back to select the entity type")
       link3.getElementsByTag("a").attr("href") must include("/report-pillar2-top-up-taxes/business-matching/filing-member/uk-based/entity-type")
 
     }

--- a/test/views/registrationview/RegistrationFailedNfmViewSpec.scala
+++ b/test/views/registrationview/RegistrationFailedNfmViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,23 +14,23 @@
  * limitations under the License.
  */
 
-package views
+package views.registrationview
 
 import base.ViewSpecBase
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import views.html.registrationview.RegistrationFailedRfmView
+import views.html.registrationview.RegistrationFailedNfmView
 
-class RegistrationFailedRfmViewSpec extends ViewSpecBase {
+class RegistrationFailedNfmViewSpec extends ViewSpecBase {
 
-  val page: RegistrationFailedRfmView = inject[RegistrationFailedRfmView]
+  val page: RegistrationFailedNfmView = inject[RegistrationFailedNfmView]
 
   val view: Document = Jsoup.parse(page()(request, appConfig, messages).toString())
 
-  "Registration Failed Rfm View" should {
+  "Registration Failed Nfm View" should {
 
     "have a title" in {
-      val title = "The details you entered did not match our records - Report Pillar 2 top-up taxes - GOV.UK"
+      val title = "Register your group - Report Pillar 2 top-up taxes - GOV.UK"
       view.getElementsByTag("title").text must include(title)
     }
 
@@ -42,24 +42,27 @@ class RegistrationFailedRfmViewSpec extends ViewSpecBase {
 
     "have a paragraph body" in {
       view.getElementsByClass("govuk-body").first().text must include("We could not match the details you entered with records held by HMRC.")
-      view.getElementsByClass("govuk-body").get(1).text  must include("You can confirm your details with the records held by HMRC by:")
+      view.getElementsByClass("govuk-body").get(1).text must include("You can confirm your details with the records held by HMRC by:")
     }
 
     "have a paragraph links" in {
       val link1 = view.getElementsByTag("ul").first().getElementsByTag("a").first()
       val link2 = view.getElementsByTag("ul").first().getElementsByTag("a").get(1)
-      val link3 = view.getElementsByClass("govuk-body").get(2)
+      val link3 = view.getElementsByClass("govuk-body").get(4)
 
-      link1.text         must include("search Companies House for the company registration number and registered office address (opens in a new tab)")
+      link1.text must include("search Companies House for the company registration number and registered office address (opens in a new tab)")
       link1.attr("href") must include("https://find-and-update.company-information.service.gov.uk/")
-      link2.text         must include("ask for a copy of your Corporation Tax Unique Taxpayer Reference (opens in a new tab)")
+      link1.attr("target") mustBe "_blank"
+
+      link2.text must include("ask for a copy of your Corporation Tax Unique Taxpayer Reference (opens in a new tab)")
       link2.attr("href") must include("https://www.tax.service.gov.uk/ask-for-copy-of-your-corporation-tax-utr")
+      link2.attr("target") mustBe "_blank"
 
       link3.text must include(
         "You can go back to select the entity type and try again using different details if you think you made an error when entering them."
       )
-      link3.getElementsByTag("a").text()       must include("go back to select the entity type")
-      link3.getElementsByTag("a").attr("href") must include("/replace-filing-member/business-matching/filing-member/uk-based/org-type")
+      link3.getElementsByTag("a").text() must include("go back to select the entity type")
+      link3.getElementsByTag("a").attr("href") must include("/report-pillar2-top-up-taxes/business-matching/filing-member/uk-based/entity-type")
 
     }
 

--- a/test/views/registrationview/RegistrationFailedRfmViewSpec.scala
+++ b/test/views/registrationview/RegistrationFailedRfmViewSpec.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.registrationview
+
+import base.ViewSpecBase
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import views.html.registrationview.RegistrationFailedRfmView
+
+class RegistrationFailedRfmViewSpec extends ViewSpecBase {
+
+  val page: RegistrationFailedRfmView = inject[RegistrationFailedRfmView]
+
+  val view: Document = Jsoup.parse(page()(request, appConfig, messages).toString())
+
+  "Registration Failed Rfm View" should {
+
+    "have a title" in {
+      val title = "The details you entered did not match our records - Report Pillar 2 top-up taxes - GOV.UK"
+      view.getElementsByTag("title").text must include(title)
+    }
+
+    "have a headings" in {
+      view.getElementsByTag("h1").text must include("The details you entered did not match our records")
+      view.getElementsByTag("h2").text must include("How to confirm your details")
+
+    }
+
+    "have a paragraph body" in {
+      view.getElementsByClass("govuk-body").first().text must include("We could not match the details you entered with records held by HMRC.")
+      view.getElementsByClass("govuk-body").get(1).text  must include("You can confirm your details with the records held by HMRC by:")
+    }
+
+    "have a paragraph links" in {
+      val link1 = view.getElementsByTag("ul").first().getElementsByTag("a").first()
+      val link2 = view.getElementsByTag("ul").first().getElementsByTag("a").get(1)
+      val link3 = view.getElementsByClass("govuk-body").get(2)
+
+      link1.text         must include("search Companies House for the company registration number and registered office address (opens in a new tab)")
+      link1.attr("href") must include("https://find-and-update.company-information.service.gov.uk/")
+      link1.attr("target") mustBe "_blank"
+
+      link2.text         must include("ask for a copy of your Corporation Tax Unique Taxpayer Reference (opens in a new tab)")
+      link2.attr("href") must include("https://www.tax.service.gov.uk/ask-for-copy-of-your-corporation-tax-utr")
+      link2.attr("target") mustBe "_blank"
+
+      link3.text must include(
+        "You can go back to select the entity type and try again using different details if you think you made an error when entering them."
+      )
+      link3.getElementsByTag("a").text()       must include("go back to select the entity type")
+      link3.getElementsByTag("a").attr("href") must include("/replace-filing-member/business-matching/filing-member/uk-based/org-type")
+
+    }
+
+  }
+}

--- a/test/views/registrationview/RegistrationFailedUpeViewSpec.scala
+++ b/test/views/registrationview/RegistrationFailedUpeViewSpec.scala
@@ -42,7 +42,7 @@ class RegistrationFailedUpeViewSpec extends ViewSpecBase {
 
     "have a paragraph body" in {
       view.getElementsByClass("govuk-body").first().text must include("We could not match the details you entered with records held by HMRC.")
-      view.getElementsByClass("govuk-body").get(1).text must include("You can confirm your details with the records held by HMRC by:")
+      view.getElementsByClass("govuk-body").get(1).text  must include("You can confirm your details with the records held by HMRC by:")
     }
 
     "have a paragraph links" in {
@@ -50,18 +50,18 @@ class RegistrationFailedUpeViewSpec extends ViewSpecBase {
       val link2 = view.getElementsByTag("ul").first().getElementsByTag("a").get(1)
       val link3 = view.getElementsByClass("govuk-body").get(4)
 
-      link1.text must include("search Companies House for the company registration number and registered office address (opens in a new tab)")
+      link1.text         must include("search Companies House for the company registration number and registered office address (opens in a new tab)")
       link1.attr("href") must include("https://find-and-update.company-information.service.gov.uk/")
       link1.attr("target") mustBe "_blank"
 
-      link2.text must include("ask for a copy of your Corporation Tax Unique Taxpayer Reference (opens in a new tab)")
+      link2.text         must include("ask for a copy of your Corporation Tax Unique Taxpayer Reference (opens in a new tab)")
       link2.attr("href") must include("https://www.tax.service.gov.uk/ask-for-copy-of-your-corporation-tax-utr")
       link2.attr("target") mustBe "_blank"
 
       link3.text must include(
         "You can go back to select the entity type and try again using different details if you think you made an error when entering them."
       )
-      link3.getElementsByTag("a").text() must include("go back to select the entity type")
+      link3.getElementsByTag("a").text()       must include("go back to select the entity type")
       link3.getElementsByTag("a").attr("href") must include("/report-pillar2-top-up-taxes/business-matching/ultimate-parent/uk-based/entity-type")
 
     }

--- a/test/views/registrationview/RegistrationFailedUpeViewSpec.scala
+++ b/test/views/registrationview/RegistrationFailedUpeViewSpec.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.registrationview
+
+import base.ViewSpecBase
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import views.html.registrationview.RegistrationFailedUpeView
+
+class RegistrationFailedUpeViewSpec extends ViewSpecBase {
+
+  val page: RegistrationFailedUpeView = inject[RegistrationFailedUpeView]
+
+  val view: Document = Jsoup.parse(page()(request, appConfig, messages).toString())
+
+  "Registration Failed Upe View" should {
+
+    "have a title" in {
+      val title = "Register your group - Report Pillar 2 top-up taxes - GOV.UK"
+      view.getElementsByTag("title").text must include(title)
+    }
+
+    "have a headings" in {
+      view.getElementsByTag("h1").text must include("The details you entered did not match our records")
+      view.getElementsByTag("h2").text must include("How to confirm your details")
+
+    }
+
+    "have a paragraph body" in {
+      view.getElementsByClass("govuk-body").first().text must include("We could not match the details you entered with records held by HMRC.")
+      view.getElementsByClass("govuk-body").get(1).text must include("You can confirm your details with the records held by HMRC by:")
+    }
+
+    "have a paragraph links" in {
+      val link1 = view.getElementsByTag("ul").first().getElementsByTag("a").first()
+      val link2 = view.getElementsByTag("ul").first().getElementsByTag("a").get(1)
+      val link3 = view.getElementsByClass("govuk-body").get(4)
+
+      link1.text must include("search Companies House for the company registration number and registered office address (opens in a new tab)")
+      link1.attr("href") must include("https://find-and-update.company-information.service.gov.uk/")
+      link1.attr("target") mustBe "_blank"
+
+      link2.text must include("ask for a copy of your Corporation Tax Unique Taxpayer Reference (opens in a new tab)")
+      link2.attr("href") must include("https://www.tax.service.gov.uk/ask-for-copy-of-your-corporation-tax-utr")
+      link2.attr("target") mustBe "_blank"
+
+      link3.text must include(
+        "You can go back to select the entity type and try again using different details if you think you made an error when entering them."
+      )
+      link3.getElementsByTag("a").text() must include("go back to select the entity type")
+      link3.getElementsByTag("a").attr("href") must include("/report-pillar2-top-up-taxes/business-matching/ultimate-parent/uk-based/entity-type")
+
+    }
+
+  }
+}


### PR DESCRIPTION
Acceptance tests scripts are failing in Jenkins because of Links opened in New Tab.

Note: Locally Acceptance test Scripts are working as expected. But in the build server external access is blocked by default. 

Tests are failing in the

UPEAndNFMGRSFlowPages.feature 
@batch2
Scenario: 4 - User registration as UkLimitedCompany failed with party type mismatch error

P2IDValidationPage.feature
@zap_accessibility
Scenario: 1 - Validation page and guidance page for users with NO PLRID and error validation.

AC1: Add the Unit tests for those links are set to open in new tab. 
AC2: Add the Unit tests all the links are set to open in new link, actually opens in new tab.

Outcome
Unit tests added for the links however a config change has also resolved the issue that impacted the P2IDValidationPage.feature - meaning this scenario can remain in the acceptance tests as well.