### PR TITLE
[PIL-1666-fix-groupid] Fix groupId check on RFM

### DIFF
--- a/app/controllers/actions/SessionDataRetrievalAction.scala
+++ b/app/controllers/actions/SessionDataRetrievalAction.scala
@@ -32,7 +32,7 @@ class SessionDataRetrievalActionImpl @Inject() (
 
   override protected def transform[A](request: IdentifierRequest[A]): Future[SessionOptionalDataRequest[A]] =
     sessionRepository.get(request.userId).map { maybeUserAnswers =>
-      SessionOptionalDataRequest(request.request, request.userId, maybeUserAnswers)
+      SessionOptionalDataRequest(request, request.userId, maybeUserAnswers)
     }
 
 }

--- a/app/models/requests/DataRequest.scala
+++ b/app/models/requests/DataRequest.scala
@@ -55,13 +55,13 @@ final case class SubscriptionDataRequest[A](
 ) extends WrappedRequest[A](request)
 
 final case class SessionDataRequest[A](
-  request:     Request[A],
+  request:     IdentifierRequest[A],
   userId:      String,
   userAnswers: UserAnswers
 ) extends WrappedRequest[A](request)
 
 final case class SessionOptionalDataRequest[A](
-  request:     Request[A],
+  request:     IdentifierRequest[A],
   userId:      String,
   userAnswers: Option[UserAnswers]
 ) extends WrappedRequest[A](request)

--- a/test/controllers/actions/FakeDataRetrievalAction.scala
+++ b/test/controllers/actions/FakeDataRetrievalAction.scala
@@ -45,6 +45,6 @@ class FakeSessionDataRetrievalAction(dataToReturn: Option[UserAnswers]) extends 
     scala.concurrent.ExecutionContext.Implicits.global
 
   override protected def transform[A](request: IdentifierRequest[A]): Future[SessionOptionalDataRequest[A]] =
-    Future(SessionOptionalDataRequest(request.request, request.userId, dataToReturn))
+    Future(SessionOptionalDataRequest(request, request.userId, dataToReturn))
 
 }


### PR DESCRIPTION
**Why are we comparing groupId?**
Two users can have the same group, without the same pillar2 enrolment, if they also manage tax on a different HMRC platform. 
This check ensures that two users with the same group but without a similar pillar2 enrolment cannot perform RFM. This KB page redirects them to BTA to add a user to pillar2 enrolment, which is probably what they are trying to do anyway.

**How does this fix work?**
The original change didn't work because it only allowed users through if the groupId was identical, which is the opposite of the intended check. Now, this check will continue with RFM if the user's groupId does not match the groupId's returned for the pillar2 enrolment. 