### PR TITLE
[PIL-1654-ops-integration] Add OPS integration

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -81,9 +81,7 @@ class FrontendAppConfig @Inject() (configuration: Configuration, servicesConfig:
   val partnershipBvEnabled:        Boolean = configuration.get[Boolean]("features.partnershipBvEnabled")
 
   //Enable Disable
-  val privateBetaEnabled: Boolean = configuration.get[Boolean]("features.privateBetaEnabled")
-  val grsStubEnabled:     Boolean = configuration.get[Boolean]("features.grsStubEnabled")
-  val pillar2mailbox:     String  = configuration.get[String]("features.pillar2mailbox")
+  val grsStubEnabled: Boolean = configuration.get[Boolean]("features.grsStubEnabled")
 
   lazy val locationCanonicalList: String = loadConfig("location.canonical.list.all")
 
@@ -95,8 +93,9 @@ class FrontendAppConfig @Inject() (configuration: Configuration, servicesConfig:
   val eacdHomePageUrl:              String  = configuration.get[String]("urls.eacdHomePage")
   val howToRegisterPlr2GuidanceUrl: String  = configuration.get[String]("urls.howToRegisterPlr2Guidance")
 
-  val opsBaseUrl:  String = servicesConfig.baseUrl("ops")
-  val opsStartUrl: String = configuration.get[String]("microservice.services.ops.startUrl")
+  val opsBaseUrl:             String  = servicesConfig.baseUrl("ops")
+  val opsStartUrl:            String  = configuration.get[String]("microservice.services.ops.startUrl")
+  val enablePayByBankAccount: Boolean = configuration.get[Boolean]("features.enablePayByBankAccount")
 
   def transactionHistoryEndDate: LocalDate = {
     val date = configuration.get[String]("features.transactionHistoryEndDate")

--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -87,17 +87,16 @@ class FrontendAppConfig @Inject() (configuration: Configuration, servicesConfig:
 
   lazy val locationCanonicalList: String = loadConfig("location.canonical.list.all")
 
-  val registrationControllerMne:      String = "Domestic Top-up Tax and Multinational Top-up Tax"
-  val registrationControllerDomestic: String = "Domestic Top-up Tax"
-  val serviceStartLink:               String = servicesConfig.getString("urls.serviceStartLink")
+  val serviceStartLink: String = servicesConfig.getString("urls.serviceStartLink")
 
-  val showErrorScreens:             Boolean = configuration.get[Boolean]("features.showErrorScreens")
-  val showDoYouHaveP2TopUpTaxId:    Boolean = configuration.get[Boolean]("features.showDoYouHaveP2TopUpTaxId")
   val btaAccessEnabled:             Boolean = configuration.get[Boolean]("features.btaAccessEnabled")
   val btaHomePageUrl:               String  = configuration.get[String]("urls.btaHomePage")
   val asaHomePageUrl:               String  = configuration.get[String]("urls.asaHomePage")
   val eacdHomePageUrl:              String  = configuration.get[String]("urls.eacdHomePage")
   val howToRegisterPlr2GuidanceUrl: String  = configuration.get[String]("urls.howToRegisterPlr2Guidance")
+
+  val opsBaseUrl:  String = servicesConfig.baseUrl("ops")
+  val opsStartUrl: String = configuration.get[String]("microservice.services.ops.startUrl")
 
   def transactionHistoryEndDate: LocalDate = {
     val date = configuration.get[String]("features.transactionHistoryEndDate")

--- a/app/connectors/OPSConnector.scala
+++ b/app/connectors/OPSConnector.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import config.FrontendAppConfig
+import controllers.payments.{routes => paymentRoutes}
+import controllers.routes
+import models.{OPSRedirectRequest, OPSRedirectResponse}
+import play.api.Logging
+import play.api.libs.json._
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.client.HttpClientV2
+
+import java.net.URI
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class OPSConnector @Inject() (val config: FrontendAppConfig, val http: HttpClientV2)(implicit ec: ExecutionContext) extends Logging {
+
+  lazy private val startUrl = config.opsStartUrl
+  lazy private val opsUrl   = s"${config.opsBaseUrl}$startUrl"
+
+  def getRedirectLocation(pillar2Id: String)(implicit hc: HeaderCarrier): Future[String] = {
+    val request =
+      OPSRedirectRequest(
+        reference = pillar2Id,
+        amountInPence = 0,
+        returnUrl = s"${config.host}${routes.TransactionHistoryController.onPageLoadTransactionHistory(None).url}",
+        backUrl = s"${config.host}${paymentRoutes.MakeAPaymentDashboardController.onPageLoad.url}"
+      )
+    http
+      .post(URI.create(opsUrl).toURL)
+      .withBody(Json.toJson(request))
+      .execute[OPSRedirectResponse]
+      .map(_.nextUrl)
+  }
+
+}

--- a/app/models/OPSRedirectRequest.scala
+++ b/app/models/OPSRedirectRequest.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json.{Json, OFormat}
+
+case class OPSRedirectRequest(reference: String, amountInPence: BigDecimal, returnUrl: String, backUrl: String)
+
+object OPSRedirectRequest {
+  implicit val format: OFormat[OPSRedirectRequest] = Json.format[OPSRedirectRequest]
+}

--- a/app/models/OPSRedirectResponse.scala
+++ b/app/models/OPSRedirectResponse.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json.{Json, OFormat}
+
+case class OPSRedirectResponse(journeyId: String, nextUrl: String)
+
+object OPSRedirectResponse {
+  implicit val format: OFormat[OPSRedirectResponse] = Json.format[OPSRedirectResponse]
+}

--- a/app/views/DashboardView.scala.html
+++ b/app/views/DashboardView.scala.html
@@ -53,7 +53,7 @@
         <!--PAY YOUR TUT SECTION-->
         @h2(messages("dashboard.payments"), size = "m")
         @p(if(agentView) messages("dashboard.agent.noPayment") else messages("dashboard.noPayment"))
-        @paragraphMessageWithLink(linkMessage = messages("dashboard.voluntaryPayment"), linkUrl = controllers.routes.MakeAPaymentDashboardController.onPageLoad.url)
+        @paragraphMessageWithLink(linkMessage = messages("dashboard.voluntaryPayment"), linkUrl = controllers.payments.routes.MakeAPaymentDashboardController.onPageLoad.url)
 
         @paragraphMessageWithLink(linkMessage = if(agentView) messages("dashboard.agent.paymentHistory") else messages("dashboard.paymentHistory"), linkUrl = controllers.routes.TransactionHistoryController.onPageLoadTransactionHistory(None).url)
 

--- a/app/views/LegacyMakeAPaymentDashboardView.scala.html
+++ b/app/views/LegacyMakeAPaymentDashboardView.scala.html
@@ -1,0 +1,37 @@
+@*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.FrontendAppConfig
+@import views.html.components.gds._
+
+@this(
+        layout: templates.Layout,
+        govukButton: GovukButton,
+        paragraphMessageWithLink: ParagraphMessageWithLink,
+        p: paragraphBody,
+        heading: heading,
+        govukSummaryList: GovukSummaryList,
+)
+
+@(plrID: String)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@layout(
+    pageTitle = titleNoForm(messages("payment.legacy.dashboard.title"))) {
+    @heading(messages("payment.legacy.dashboard.header"), classes = "govuk-heading-l")
+    @p(messages("payment.legacy.dashboard.message1", plrID))
+    @p(messages("payment.legacy.dashboard.message2"))
+    @paragraphMessageWithLink(Some(messages("payment.legacy.dashboard.message3")), linkMessage = messages("payment.legacy.dashboard.message4"), linkUrl = "https://www.gov.uk/guidance/pay-pillar-2-top-up-taxes-domestic-top-up-tax-and-multinational-top-up-tax")
+
+}

--- a/app/views/MakeAPaymentDashboardView.scala.html
+++ b/app/views/MakeAPaymentDashboardView.scala.html
@@ -33,7 +33,10 @@
 ) {
     @heading(messages("payment.dashboard.header"), classes = "govuk-heading-l")
     @p(messages("payment.dashboard.message1", plrID))
-    @p(messages("payment.dashboard.message2"))
-    @paragraphMessageWithLink(Some(messages("payment.dashboard.message3")), linkMessage = messages("payment.dashboard.message4"), linkUrl = "https://www.gov.uk/guidance/pay-pillar-2-top-up-taxes-domestic-top-up-tax-and-multinational-top-up-tax")
+    @paragraphMessageWithLink(Some(messages("payment.dashboard.message2")), linkMessage = messages("payment.dashboard.linkText"),
+        linkUrl = "https://www.gov.uk/guidance/pay-pillar-2-top-up-taxes-domestic-top-up-tax-and-multinational-top-up-tax")
+    @govukButton(
+        ButtonViewModel(messages("payment.dashboard.buttonText")).asLink(controllers.payments.routes.MakeAPaymentDashboardController.onRedirect.url)
+    )
 
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -403,7 +403,8 @@ GET         /replace-filing-member/error/incomplete-task                        
 
 GET         /replace-filing-member/error/restart-error                              controllers.rfm.RfmJourneyRecoveryController.onPageLoad
 
-GET         /payment/pay                                                                             controllers.MakeAPaymentDashboardController.onPageLoad
+GET         /payment/pay                                                                             controllers.payments.MakeAPaymentDashboardController.onPageLoad
+GET         /payment/redirect                                                                        controllers.payments.MakeAPaymentDashboardController.onRedirect
 GET         /replace-filing-member/security/check-answers                                            controllers.rfm.SecurityQuestionsCheckYourAnswersController.onPageLoad(mode: Mode = NormalMode)
 POST        /replace-filing-member/security/check-answers                                            controllers.rfm.SecurityQuestionsCheckYourAnswersController.onSubmit
 GET         /replace-filing-member/security/change-check-answers                                     controllers.rfm.SecurityQuestionsCheckYourAnswersController.onPageLoad(mode: Mode = CheckMode)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -164,6 +164,7 @@ features {
   showDoYouHaveP2TopUpTaxId = true
   showErrorScreens = true
   btaAccessEnabled = true
+  enablePayByBankAccount = true
 
   incorporatedEntityBvEnabled = false
   partnershipBvEnabled = false

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -62,6 +62,13 @@ microservice {
       startUrl = "/enrolment-store-proxy"
     }
 
+    ops {
+      host = localhost
+      port = 9057
+      protocol = http
+      startUrl = "/pay-api/pillar-2/journey/start"
+    }
+
     tax-enrolments {
       host = localhost
       port = 9995

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -191,9 +191,9 @@ grs.registration.error.b33 = and try again using different details if you think 
 payment.dashboard.title = Make a payment
 payment.dashboard.header = Make a payment
 payment.dashboard.message1 = Your unique payment reference is <b>{0}</b>. You must use this when making Pillar 2 top-up tax payments.
-payment.dashboard.message2 = Submit your return before making a payment. Your payment is due on the same date as your return.
-payment.dashboard.message3 = You can
-payment.dashboard.message4 = read the guidance to find the methods you can use to make a payment.
+payment.dashboard.message2 = You can use the ''Pay Now'' button to pay online, or
+payment.dashboard.linkText = read more about other payment methods. (opens in a new tab)
+payment.dashboard.buttonText = Pay Now
 
 repayment.requestRefundBeforeStart.title = Request a refund
 repayment.requestRefundBeforeStart.header = Request a refund

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -195,6 +195,13 @@ payment.dashboard.message2 = You can use the ''Pay Now'' button to pay online, o
 payment.dashboard.linkText = read more about other payment methods. (opens in a new tab)
 payment.dashboard.buttonText = Pay Now
 
+payment.legacy.dashboard.title = Make a payment
+payment.legacy.dashboard.header = Make a payment
+payment.legacy.dashboard.message1 = Your unique payment reference is <b>{0}</b>. You must use this when making Pillar 2 top-up tax payments.
+payment.legacy.dashboard.message2 = Submit your return before making a payment. Your payment is due on the same date as your return.
+payment.legacy.dashboard.message3 = You can
+payment.legacy.dashboard.message4 = read the guidance to find the methods you can use to make a payment.
+
 repayment.requestRefundBeforeStart.title = Request a refund
 repayment.requestRefundBeforeStart.header = Request a refund
 repayment.requestRefundBeforeStart.p1 = You can use this service to request a refund if you have funds in your Pillar 2 account available for repayment.

--- a/test/base/WireMockServerHandler.scala
+++ b/test/base/WireMockServerHandler.scala
@@ -21,7 +21,7 @@ import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
-import play.api.libs.json.JsValue
+import play.api.libs.json.{Format, JsValue, Json}
 
 trait WireMockServerHandler extends BeforeAndAfterAll with BeforeAndAfterEach {
   this: SpecBase =>
@@ -43,13 +43,24 @@ trait WireMockServerHandler extends BeforeAndAfterAll with BeforeAndAfterEach {
     server.stop()
   }
 
-  protected def stubResponse(expectedEndpoint: String, expectedStatus: Int, expectedBody: String): StubMapping =
+  protected def stubResponse(expectedEndpoint: String, returnStatus: Int, returnBody: String): StubMapping =
     server.stubFor(
       post(urlEqualTo(s"$expectedEndpoint"))
         .willReturn(
           aResponse()
-            .withStatus(expectedStatus)
-            .withBody(expectedBody)
+            .withStatus(returnStatus)
+            .withBody(returnBody)
+        )
+    )
+
+  protected def stubResponse[T: Format](expectedEndpoint: String, expectedBody: T)(returnStatus: Int, returnBody: String): StubMapping =
+    server.stubFor(
+      post(urlEqualTo(s"$expectedEndpoint"))
+        .withRequestBody(equalToJson(Json.toJson(expectedBody).toString()))
+        .willReturn(
+          aResponse()
+            .withStatus(returnStatus)
+            .withBody(returnBody)
         )
     )
 

--- a/test/connectors/BarsConnectorSpec.scala
+++ b/test/connectors/BarsConnectorSpec.scala
@@ -37,7 +37,7 @@ class BarsConnectorSpec extends SpecBase with WireMockServerHandler {
 
   "BarsConnector" must {
     "verify business back account details and return response" in {
-      stubResponse(barsUrl, expectedStatus = 200, barsResponse)
+      stubResponse(barsUrl, returnStatus = 200, barsResponse)
 
       val value = connector.verify(business, account, UUID.randomUUID())
 
@@ -45,7 +45,7 @@ class BarsConnectorSpec extends SpecBase with WireMockServerHandler {
     }
 
     "return failed future with InternalIssueError for any bad response" in {
-      stubResponse(barsUrl, expectedStatus = 400, errorResponse)
+      stubResponse(barsUrl, returnStatus = 400, errorResponse)
 
       val value = connector.verify(business, account, UUID.randomUUID())
 

--- a/test/connectors/OPSConnectorTest.scala
+++ b/test/connectors/OPSConnectorTest.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import base.{SpecBase, WireMockServerHandler}
+import config.FrontendAppConfig
+import controllers.payments.{routes => paymentRoutes}
+import controllers.routes
+import models.{OPSRedirectRequest, OPSRedirectResponse}
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.Json
+
+class OPSConnectorTest extends SpecBase with WireMockServerHandler {
+
+  override lazy val app: Application = new GuiceApplicationBuilder()
+    .configure(
+      conf = "microservice.services.ops.port" -> server.port()
+    )
+    .build()
+
+  lazy val classUnderTest: OPSConnector = app.injector.instanceOf[OPSConnector]
+  lazy val opsEndpoint:    String       = app.injector.instanceOf[FrontendAppConfig].opsStartUrl
+
+  "OPS Connector" should {
+    "connect to OPS for a redirect journey" in {
+      val response = OPSRedirectResponse("journeyId", "nextUrl")
+      val expectedRequest = OPSRedirectRequest(
+        reference = "pillar2Id",
+        amountInPence = 0,
+        returnUrl = s"http://localhost:10050${routes.TransactionHistoryController.onPageLoadTransactionHistory(None)}",
+        backUrl = s"http://localhost:10050${paymentRoutes.MakeAPaymentDashboardController.onPageLoad.url}"
+      )
+      stubResponse(opsEndpoint, expectedRequest)(CREATED, Json.toJson(response).toString())
+      val result = classUnderTest.getRedirectLocation("pillar2Id").futureValue
+      result mustEqual response.nextUrl
+    }
+  }
+
+}

--- a/test/views/DashboardViewSpec.scala
+++ b/test/views/DashboardViewSpec.scala
@@ -90,7 +90,7 @@ class DashboardViewSpec extends ViewSpecBase {
 
       elements.get(5).text                               must include("You have no payments due")
       elements.get(6).getElementsByTag("a").text()       must include("Make a payment")
-      elements.get(6).getElementsByTag("a").attr("href") must include(controllers.routes.MakeAPaymentDashboardController.onPageLoad.url)
+      elements.get(6).getElementsByTag("a").attr("href") must include(controllers.payments.routes.MakeAPaymentDashboardController.onPageLoad.url)
       elements.get(7).getElementsByTag("a").text()       must include("View your transaction history")
       elements.get(7).getElementsByTag("a").attr("href") must include(
         controllers.routes.TransactionHistoryController.onPageLoadTransactionHistory(None).url
@@ -234,7 +234,7 @@ class DashboardViewSpec extends ViewSpecBase {
 
       elements.get(7).text                               must include("Your client has no payments due.")
       elements.get(8).getElementsByTag("a").text()       must include("Make a payment")
-      elements.get(8).getElementsByTag("a").attr("href") must include(controllers.routes.MakeAPaymentDashboardController.onPageLoad.url)
+      elements.get(8).getElementsByTag("a").attr("href") must include(controllers.payments.routes.MakeAPaymentDashboardController.onPageLoad.url)
       elements.get(9).getElementsByTag("a").text()       must include("View your client’s transaction history")
       elements.get(9).getElementsByTag("a").attr("href") must include(
         controllers.routes.TransactionHistoryController.onPageLoadTransactionHistory(None).url

--- a/test/views/MakeAPaymentDashboardViewSpec.scala
+++ b/test/views/MakeAPaymentDashboardViewSpec.scala
@@ -21,6 +21,8 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import views.html.MakeAPaymentDashboardView
 
+import scala.jdk.CollectionConverters._
+
 class MakeAPaymentDashboardViewSpec extends ViewSpecBase {
   private val page: MakeAPaymentDashboardView = inject[MakeAPaymentDashboardView]
   val testPlr2Id = "12345678"
@@ -35,26 +37,42 @@ class MakeAPaymentDashboardViewSpec extends ViewSpecBase {
 
     "have a heading" in {
       val h1 = makePaymentDashboardView.getElementsByTag("h1")
-      h1.text must equal("Make a payment")
+      h1.listIterator().asScala.toList must have size 1
+      h1.text                          must equal("Make a payment")
       h1.hasClass("govuk-heading-l") mustBe true
     }
 
     "have the correct paragraphs" in {
-      val element = makePaymentDashboardView.getElementsByTag("p")
-      element.get(1).text() must equal(
+      val paragraphs = makePaymentDashboardView.getElementsByTag("p").listIterator().asScala.toList.filter(_.hasClass("govuk-body"))
+      paragraphs must have size 2
+      paragraphs.head.text() must equal(
         s"""Your unique payment reference is $testPlr2Id. You must use this when making Pillar 2 top-up tax payments."""
       )
-      element.get(2).text() must equal(
-        "Submit your return before making a payment. Your payment is due on the same date as your return."
-      )
-      element.get(3).text() must equal(
-        "You can read the guidance to find the methods you can use to make a payment."
+      paragraphs.tail.head.text() must equal(
+        "You can use the 'Pay Now' button to pay online, or read more about other payment methods. (opens in a new tab)"
       )
     }
 
-    "have the correct link" in {
-      val element = makePaymentDashboardView.getElementsByClass("govuk-link")
-      element.get(2).attr("href") must equal(
+    "have the correct Pay Now button" in {
+      val elements = makePaymentDashboardView.getElementsByTag("a").listIterator().asScala.toList.filter(_.hasClass("govuk-button"))
+      elements must have size 1
+      val button = elements.head
+      button.attr("href") must equal(
+        "/report-pillar2-top-up-taxes/payment/redirect"
+      )
+      button.text() mustEqual "Pay Now"
+    }
+
+    "have the correct link to payment guidance" in {
+      val elements = makePaymentDashboardView
+        .getElementsByTag("a")
+        .listIterator()
+        .asScala
+        .toList
+        .filter(_.text == "read more about other payment methods. (opens in a new tab)")
+      elements must have size 1
+      val guidancePageLink = elements.head
+      guidancePageLink.attr("href") must equal(
         "https://www.gov.uk/guidance/pay-pillar-2-top-up-taxes-domestic-top-up-tax-and-multinational-top-up-tax"
       )
     }


### PR DESCRIPTION
Add OPS integration. Once the user clicks on 'Pay Now', they will be redirected to OPS (Open Payment Services) who will handle payment and redirect back to the transaction history screen

![Screenshot 2025-03-06 at 17 18 54](https://github.com/user-attachments/assets/b08e9248-c2c2-43d1-b431-4036c8cfe3d4)
