### PR TITLE
PIL-1715 - Updated telephone validation to catch preceding "++"

### DIFF
--- a/app/forms/CaptureTelephoneDetailsFormProvider.scala
+++ b/app/forms/CaptureTelephoneDetailsFormProvider.scala
@@ -16,6 +16,7 @@
 
 package forms
 
+import forms.Validation.TELEPHONE_REGEX
 import forms.mappings.Mappings
 import play.api.data.Form
 
@@ -23,11 +24,10 @@ import javax.inject.Inject
 
 class CaptureTelephoneDetailsFormProvider @Inject() extends Mappings {
   private val phoneNumberLength = 24
-  private val phoneRegex        = """^[A-Z0-9 )/(\-*#+]*$"""
   def apply(userName: String): Form[String] = Form(
     "telephoneNumber" ->
       text("captureTelephoneDetails.error.required", Seq(userName))
         .verifying(maxLength(phoneNumberLength, "captureTelephoneDetails.messages.error.length"))
-        .verifying(regexp(phoneRegex, "captureTelephoneDetails.messages.error.format", Seq(userName)))
+        .verifying(regexp(TELEPHONE_REGEX, "captureTelephoneDetails.messages.error.format", Seq(userName)))
   )
 }

--- a/app/forms/ContactCaptureTelephoneDetailsFormProvider.scala
+++ b/app/forms/ContactCaptureTelephoneDetailsFormProvider.scala
@@ -16,6 +16,7 @@
 
 package forms
 
+import forms.Validation.TELEPHONE_REGEX
 import forms.mappings.Mappings
 import play.api.data.Form
 
@@ -23,11 +24,10 @@ import javax.inject.Inject
 
 class ContactCaptureTelephoneDetailsFormProvider @Inject() extends Mappings {
   private val phoneNumberLength = 24
-  val phoneRegex                = """^[A-Z0-9 )/(\-*#+]*$"""
   def apply(userName: String): Form[String] = Form(
     "value" ->
       text("contactCaptureTelephoneDetails.error.required", Seq(userName))
         .verifying(maxLength(phoneNumberLength, "contactCaptureTelephoneDetails.error.length"))
-        .verifying(regexp(phoneRegex, "contactCaptureTelephoneDetails.error.format", userName))
+        .verifying(regexp(TELEPHONE_REGEX, "contactCaptureTelephoneDetails.error.format", userName))
   )
 }

--- a/app/forms/NfmCaptureTelephoneDetailsFormProvider.scala
+++ b/app/forms/NfmCaptureTelephoneDetailsFormProvider.scala
@@ -16,6 +16,7 @@
 
 package forms
 
+import forms.Validation.TELEPHONE_REGEX
 import forms.mappings.Mappings
 import play.api.data.Form
 
@@ -23,11 +24,10 @@ import javax.inject.Inject
 
 class NfmCaptureTelephoneDetailsFormProvider @Inject() extends Mappings {
   private val phoneNumberLength = 24
-  val phoneRegex                = """^[A-Z0-9 )/(\-*#+]*$"""
   def apply(userName: String): Form[String] = Form(
     "value" ->
       text("nfmCaptureTelephoneDetails.error.required", Seq(userName))
         .verifying(maxLength(phoneNumberLength, "nfmCaptureTelephoneDetails.error.length"))
-        .verifying(regexp(phoneRegex, "nfmCaptureTelephoneDetails.error.format", Seq(userName)))
+        .verifying(regexp(TELEPHONE_REGEX, "nfmCaptureTelephoneDetails.error.format", Seq(userName)))
   )
 }

--- a/app/forms/RepaymentsTelephoneDetailsFormProvider.scala
+++ b/app/forms/RepaymentsTelephoneDetailsFormProvider.scala
@@ -31,7 +31,7 @@ class RepaymentsTelephoneDetailsFormProvider @Inject() extends Mappings {
           firstError(
             maxLength(Constants.MAX_LENGTH_24, "repayments.telephoneDetails.error.length"),
             regexp(
-              Validation.REPAYMENTS_TELEPHONE_REGEX,
+              Validation.TELEPHONE_REGEX,
               "repayments.telephoneDetails.error.format",
               contactName
             )

--- a/app/forms/RfmSecondaryTelephoneFormProvider.scala
+++ b/app/forms/RfmSecondaryTelephoneFormProvider.scala
@@ -16,6 +16,7 @@
 
 package forms
 
+import forms.Validation.TELEPHONE_REGEX
 import forms.mappings.Mappings
 import play.api.data.Form
 
@@ -23,12 +24,14 @@ import javax.inject.Inject
 
 class RfmSecondaryTelephoneFormProvider @Inject() extends Mappings {
   private val phoneNumberLength = 24
-  val phoneRegex                = """^[A-Z0-9 )/(\-*#+]*$"""
   def apply(userName: String): Form[String] =
     Form(
       "value" -> text("rfm.secondaryTelephone.error.required", Seq(userName))
         .verifying(
-          firstError(maxLength(phoneNumberLength, "rfm.secondaryTelephone.error.length"), regexp(phoneRegex, "rfm.secondaryTelephone.error.format"))
+          firstError(
+            maxLength(phoneNumberLength, "rfm.secondaryTelephone.error.length"),
+            regexp(TELEPHONE_REGEX, "rfm.secondaryTelephone.error.format")
+          )
         )
     )
 }

--- a/app/forms/SecondaryTelephoneFormProvider.scala
+++ b/app/forms/SecondaryTelephoneFormProvider.scala
@@ -16,6 +16,7 @@
 
 package forms
 
+import forms.Validation.TELEPHONE_REGEX
 import forms.mappings.Mappings
 import play.api.data.Form
 
@@ -23,11 +24,10 @@ import javax.inject.Inject
 
 class SecondaryTelephoneFormProvider @Inject() extends Mappings {
   private val phoneNumberLength = 24
-  val phoneRegex                = """^[A-Z0-9 )/(\-*#+]*$"""
   def apply(userName: String): Form[String] =
     Form(
       "value" -> text("secondaryTelephone.error.required", Seq(userName))
         .verifying(maxLength(phoneNumberLength, "secondaryTelephone.error.length"))
-        .verifying(regexp(phoneRegex, "secondaryTelephone.error.format", Seq(userName)))
+        .verifying(regexp(TELEPHONE_REGEX, "secondaryTelephone.error.format", Seq(userName)))
     )
 }

--- a/app/forms/Validation.scala
+++ b/app/forms/Validation.scala
@@ -19,14 +19,14 @@ package forms
 object Validation {
   final val EMAIL_REGEX =
     """^(?!\.)("([^"\r\\]|\\["\r\\])*"|([-a-zA-Z0-9!#$%&'*+/=?^_`{|}~]|(?<!\.)\.)*)(?<!\.)@[a-zA-Z0-9][\w\.-]*[a-zA-Z0-9]\.[a-zA-Z][a-zA-Z\.]*[a-zA-Z]$"""
-  final val GROUPID_REGEX              = "^X[A-Z]PLR[0-9]{10}$"
-  final val TELEPHONE_REGEX            = "^[0-9 +()]{0,25}$"
-  final val REPAYMENTS_TELEPHONE_REGEX = "^[0-9 +()]{0,50}$"
-  final val BIC_SWIFT_REGEX            = "^[A-Z]{6}[A-Z0-9]{2}([A-Z0-9]{3})?$"
-  final val IBAN_REGEX                 = "^[A-Z]{2}[0-9]{2}[0-9A-Z]{10,30}$"
-  final val MONETARY_REGEX             = """^-?(\d*(\.\d{1,2})?)$"""
-  final val SORT_CODE_REGEX            = """^[0-9]{6}$"""
-  final val ACCOUNT_NUMBER_REGEX       = """^[0-9]{8}$"""
-  final val XSS_REGEX                  = """^[^<>"&]*$"""
-  final val XSS_REGEX_ALLOW_AMPERSAND  = """^[^<>"]*$"""
+  final val GROUPID_REGEX = "^X[A-Z]PLR[0-9]{10}$"
+  final val TELEPHONE_REGEX =
+    "^(?:(?:\\(?(?:00|\\+)([1-4]\\d\\d|[1-9]\\d?)\\)?)?[-. /]?)?((?:\\(?\\d{1,}\\)?[-. /]?){0,})(?:[-. /]?(?:#|ext\\.?|extension|x)[-. /]?(\\d+))?$"
+  final val BIC_SWIFT_REGEX           = "^[A-Z]{6}[A-Z0-9]{2}([A-Z0-9]{3})?$"
+  final val IBAN_REGEX                = "^[A-Z]{2}[0-9]{2}[0-9A-Z]{10,30}$"
+  final val MONETARY_REGEX            = """^-?(\d*(\.\d{1,2})?)$"""
+  final val SORT_CODE_REGEX           = """^[0-9]{6}$"""
+  final val ACCOUNT_NUMBER_REGEX      = """^[0-9]{8}$"""
+  final val XSS_REGEX                 = """^[^<>"&]*$"""
+  final val XSS_REGEX_ALLOW_AMPERSAND = """^[^<>"]*$"""
 }

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -299,7 +299,7 @@ rfmCaptureTelephoneDetails.heading = What is the telephone number for {0}?
 rfmCaptureTelephoneDetails.hint = For international numbers include the country code.
 rfmCaptureTelephoneDetails.error.required = Enter the telephone number for {0}
 rfmCaptureTelephoneDetails.messages.error.length = Telephone number must be 24 characters or less
-rfmCaptureTelephoneDetails.messages.error.format = Enter a telephone number in the correct format, like 01632 960 001 or +44 808 157 0192
+rfmCaptureTelephoneDetails.messages.error.format = Enter a telephone number in the correct format, for example 01632 960 001 or +44 808 157 0192
 rfmCaptureTelephoneDetails.change.hidden = the telephone number for the primary contact
 rfmCaptureTelephoneDetails.checkYourAnswersLabel = Telephone number
 
@@ -414,7 +414,7 @@ captureTelephoneDetails.heading = What is the telephone number for {0}?
 captureTelephoneDetails.hint = For international numbers include the country code.
 captureTelephoneDetails.error.required = Enter the telephone number for {0}
 captureTelephoneDetails.messages.error.length = Telephone number should be 24 characters or less
-captureTelephoneDetails.messages.error.format = Enter the telephone number for {0} in the correct format, like 01632 960 001 or +44 808 157 0192
+captureTelephoneDetails.messages.error.format = Enter the telephone number for {0} in the correct format, for example 01632 960 001 or +44 808 157 0192
 captureTelephoneDetails.change.hidden = the telephone number for the Ultimate Parent Entity contact
 captureTelephoneDetails.checkYourAnswersLabel = Telephone number
 
@@ -636,7 +636,7 @@ nfmCaptureTelephoneDetails.heading = What is the telephone number for {0}?
 nfmCaptureTelephoneDetails.hint = For international numbers include the country code
 nfmCaptureTelephoneDetails.error.required = Enter the telephone number for {0}
 nfmCaptureTelephoneDetails.error.length = The telephone number must be 24 characters or less
-nfmCaptureTelephoneDetails.error.format = Enter the telephone number for {0} in the correct format, like 01632 960 001 or +44 808 157 0192
+nfmCaptureTelephoneDetails.error.format = Enter the telephone number for {0} in the correct format, for example 01632 960 001 or +44 808 157 0192
 
 nfmCaptureTelephoneDetails.checkYourAnswersLabel.hidden = the telephone number for the nominated filing member
 contactNfmByTelephone.checkYourAnswersLabel.hidden = can we contact the nominated filing member by telephone
@@ -716,7 +716,7 @@ contactCaptureTelephoneDetails.heading = What is the telephone number for {0}?
 contactCaptureTelephoneDetails.hint = For international numbers include the country code.
 contactCaptureTelephoneDetails.error.required = Enter telephone number for {0}
 contactCaptureTelephoneDetails.error.length = Telephone number must be 24 characters or less
-contactCaptureTelephoneDetails.error.format = Enter the telephone number for {0} in the correct format, like 01632 960 001 or +44 808 157 0192
+contactCaptureTelephoneDetails.error.format = Enter the telephone number for {0} in the correct format, for example 01632 960 001 or +44 808 157 0192
 contactCaptureTelephoneDetails.checkYourAnswersLabel.hidden = the contact telephone number
 
 contactNameCompliance.checkYourAnswersLabel = Contact name
@@ -801,7 +801,7 @@ secondaryTelephone.hint = For international numbers include the country code.
 secondaryTelephone.checkYourAnswersLabel = Second contact telephone number
 secondaryTelephone.error.required = Enter the telephone number for {0}
 secondaryTelephone.error.length = Telephone number must be 24 characters or less
-secondaryTelephone.error.format = Enter the telephone number for {0} in the correct format, like 01632 960 001 or +44 808 157 0192
+secondaryTelephone.error.format = Enter the telephone number for {0} in the correct format, for example 01632 960 001 or +44 808 157 0192
 
 checkYourAnswers.furtherRegistrationDetail = Further group details
 checkYourAnswers.submit.registration = Now submit your registration to report Pillar 2 Top-up Taxes
@@ -1396,7 +1396,7 @@ repayments.telephoneDetails.heading = What is the telephone number for {0}?
 repayments.telephoneDetails.hint = For international numbers include the country code.
 repayments.telephoneDetails.error.required = Enter a telephone number for {0}
 repayments.telephoneDetails.error.length = Telephone number must be 24 characters or less
-repayments.telephoneDetails.error.format = Enter a telephone number for {0} in the correct format, like 01632 960 001 or +44 808 157 0192
+repayments.telephoneDetails.error.format = Enter a telephone number for {0} in the correct format, for example 01632 960 001 or +44 808 157 0192
 
 repayments.incompleteDataView.title = Refund request has missing information
 repayments.incompleteDataView.heading = Refund request has missing information

--- a/test/forms/CaptureTelephoneDetailsFormProviderSpec.scala
+++ b/test/forms/CaptureTelephoneDetailsFormProviderSpec.scala
@@ -17,10 +17,11 @@
 package forms
 
 import forms.behaviours.StringFieldBehaviours
-import play.api.data.FormError
 import org.scalacheck.Gen
-import scala.collection.immutable.Seq
 import play.api.data.Form
+import play.api.data.FormError
+
+import scala.collection.immutable.Seq
 class CaptureTelephoneDetailsFormProviderSpec extends StringFieldBehaviours {
 
   val requiredKey = "captureTelephoneDetails.error.required"
@@ -28,10 +29,10 @@ class CaptureTelephoneDetailsFormProviderSpec extends StringFieldBehaviours {
   val formatKey   = "captureTelephoneDetails.messages.error.format"
   val formatReg   = Validation.TELEPHONE_REGEX
 
-  val invalidPhoneNumberGen = Gen.oneOf(
-    Gen.const("++44 1234 567890"), 
-    Gen.const("123$!abc"), 
-    Gen.const("abc123") 
+  val invalidPhoneNumberGen: Gen[String] = Gen.oneOf(
+    Gen.const("++44 1234 567890"),
+    Gen.const("123$!abc"),
+    Gen.const("abc123")
   )
 
   val formProvider = new CaptureTelephoneDetailsFormProvider()

--- a/test/forms/CaptureTelephoneDetailsFormProviderSpec.scala
+++ b/test/forms/CaptureTelephoneDetailsFormProviderSpec.scala
@@ -31,6 +31,7 @@ class CaptureTelephoneDetailsFormProviderSpec extends StringFieldBehaviours {
 
   val invalidPhoneNumberGen: Gen[String] = Gen.oneOf(
     Gen.const("++44 1234 567890"),
+    Gen.const("+44 1234 567890  "),
     Gen.const("123$!abc"),
     Gen.const("abc123")
   )

--- a/test/forms/CaptureTelephoneDetailsFormProviderSpec.scala
+++ b/test/forms/CaptureTelephoneDetailsFormProviderSpec.scala
@@ -20,25 +20,26 @@ import forms.behaviours.StringFieldBehaviours
 import play.api.data.FormError
 import org.scalacheck.Gen
 import scala.collection.immutable.Seq
+import play.api.data.Form
+class CaptureTelephoneDetailsFormProviderSpec extends StringFieldBehaviours {
 
-class SecondaryTelephoneFormProviderSpec extends StringFieldBehaviours {
-
-  val requiredKey = "secondaryTelephone.error.required"
-  val lengthKey   = "secondaryTelephone.error.length"
-  val formatKey   = "secondaryTelephone.error.format"
+  val requiredKey = "captureTelephoneDetails.error.required"
+  val lengthKey   = "captureTelephoneDetails.messages.error.length"
+  val formatKey   = "captureTelephoneDetails.messages.error.format"
   val formatReg   = Validation.TELEPHONE_REGEX
 
   val invalidPhoneNumberGen = Gen.oneOf(
-    Gen.const("++44 1234 567890"),
-    Gen.const("123$!abc"),
-    Gen.const("abc123")
+    Gen.const("++44 1234 567890"), 
+    Gen.const("123$!abc"), 
+    Gen.const("abc123") 
   )
 
-  val form = new SecondaryTelephoneFormProvider()("test")
+  val formProvider = new CaptureTelephoneDetailsFormProvider()
+  val form: Form[String] = formProvider("test")
 
   ".value" - {
 
-    val fieldName = "value"
+    val fieldName = "telephoneNumber"
 
     behave like mandatoryField(
       form,

--- a/test/forms/ContactCaptureTelephoneDetailsFormProviderSpec.scala
+++ b/test/forms/ContactCaptureTelephoneDetailsFormProviderSpec.scala
@@ -31,6 +31,7 @@ class ContactCaptureTelephoneDetailsFormProviderSpec extends StringFieldBehaviou
 
   val invalidPhoneNumberGen: Gen[String] = Gen.oneOf(
     Gen.const("++44 1234 567890"),
+    Gen.const("+44 1234 567890  "),
     Gen.const("123$!abc"),
     Gen.const("abc123")
   )

--- a/test/forms/ContactCaptureTelephoneDetailsFormProviderSpec.scala
+++ b/test/forms/ContactCaptureTelephoneDetailsFormProviderSpec.scala
@@ -17,10 +17,11 @@
 package forms
 
 import forms.behaviours.StringFieldBehaviours
-import play.api.data.FormError
 import org.scalacheck.Gen
-import scala.collection.immutable.Seq
 import play.api.data.Form
+import play.api.data.FormError
+
+import scala.collection.immutable.Seq
 class ContactCaptureTelephoneDetailsFormProviderSpec extends StringFieldBehaviours {
 
   val requiredKey = "contactCaptureTelephoneDetails.error.required"
@@ -28,10 +29,10 @@ class ContactCaptureTelephoneDetailsFormProviderSpec extends StringFieldBehaviou
   val formatKey   = "contactCaptureTelephoneDetails.error.format"
   val formatReg   = Validation.TELEPHONE_REGEX
 
-  val invalidPhoneNumberGen = Gen.oneOf(
-    Gen.const("++44 1234 567890"), 
-    Gen.const("123$!abc"), 
-    Gen.const("abc123") 
+  val invalidPhoneNumberGen: Gen[String] = Gen.oneOf(
+    Gen.const("++44 1234 567890"),
+    Gen.const("123$!abc"),
+    Gen.const("abc123")
   )
 
   val formProvider = new ContactCaptureTelephoneDetailsFormProvider()

--- a/test/forms/ContactCaptureTelephoneDetailsFormProviderSpec.scala
+++ b/test/forms/ContactCaptureTelephoneDetailsFormProviderSpec.scala
@@ -20,21 +20,22 @@ import forms.behaviours.StringFieldBehaviours
 import play.api.data.FormError
 import org.scalacheck.Gen
 import scala.collection.immutable.Seq
+import play.api.data.Form
+class ContactCaptureTelephoneDetailsFormProviderSpec extends StringFieldBehaviours {
 
-class SecondaryTelephoneFormProviderSpec extends StringFieldBehaviours {
-
-  val requiredKey = "secondaryTelephone.error.required"
-  val lengthKey   = "secondaryTelephone.error.length"
-  val formatKey   = "secondaryTelephone.error.format"
+  val requiredKey = "contactCaptureTelephoneDetails.error.required"
+  val lengthKey   = "contactCaptureTelephoneDetails.error.length"
+  val formatKey   = "contactCaptureTelephoneDetails.error.format"
   val formatReg   = Validation.TELEPHONE_REGEX
 
   val invalidPhoneNumberGen = Gen.oneOf(
-    Gen.const("++44 1234 567890"),
-    Gen.const("123$!abc"),
-    Gen.const("abc123")
+    Gen.const("++44 1234 567890"), 
+    Gen.const("123$!abc"), 
+    Gen.const("abc123") 
   )
 
-  val form = new SecondaryTelephoneFormProvider()("test")
+  val formProvider = new ContactCaptureTelephoneDetailsFormProvider()
+  val form: Form[String] = formProvider("test")
 
   ".value" - {
 

--- a/test/forms/NfmCaptureTelephoneDetailsFormProviderSpec.scala
+++ b/test/forms/NfmCaptureTelephoneDetailsFormProviderSpec.scala
@@ -32,6 +32,7 @@ class NfmCaptureTelephoneDetailsFormProviderSpec extends StringFieldBehaviours {
 
   val invalidPhoneNumberGen: Gen[String] = Gen.oneOf(
     Gen.const("++44 1234 567890"),
+    Gen.const("+44 1234 567890  "),
     Gen.const("123$!abc"),
     Gen.const("abc123")
   )

--- a/test/forms/NfmCaptureTelephoneDetailsFormProviderSpec.scala
+++ b/test/forms/NfmCaptureTelephoneDetailsFormProviderSpec.scala
@@ -17,10 +17,11 @@
 package forms
 
 import forms.behaviours.StringFieldBehaviours
-import play.api.data.FormError
 import org.scalacheck.Gen
-import scala.collection.immutable.Seq
 import play.api.data.Form
+import play.api.data.FormError
+
+import scala.collection.immutable.Seq
 
 class NfmCaptureTelephoneDetailsFormProviderSpec extends StringFieldBehaviours {
 
@@ -29,10 +30,10 @@ class NfmCaptureTelephoneDetailsFormProviderSpec extends StringFieldBehaviours {
   val formatKey   = "nfmCaptureTelephoneDetails.error.format"
   val formatReg   = Validation.TELEPHONE_REGEX
 
-  val invalidPhoneNumberGen = Gen.oneOf(
-    Gen.const("++44 1234 567890"), 
-    Gen.const("123$!abc"), 
-    Gen.const("abc123") 
+  val invalidPhoneNumberGen: Gen[String] = Gen.oneOf(
+    Gen.const("++44 1234 567890"),
+    Gen.const("123$!abc"),
+    Gen.const("abc123")
   )
 
   val formProvider = new NfmCaptureTelephoneDetailsFormProvider()

--- a/test/forms/NfmCaptureTelephoneDetailsFormProviderSpec.scala
+++ b/test/forms/NfmCaptureTelephoneDetailsFormProviderSpec.scala
@@ -20,21 +20,23 @@ import forms.behaviours.StringFieldBehaviours
 import play.api.data.FormError
 import org.scalacheck.Gen
 import scala.collection.immutable.Seq
+import play.api.data.Form
 
-class SecondaryTelephoneFormProviderSpec extends StringFieldBehaviours {
+class NfmCaptureTelephoneDetailsFormProviderSpec extends StringFieldBehaviours {
 
-  val requiredKey = "secondaryTelephone.error.required"
-  val lengthKey   = "secondaryTelephone.error.length"
-  val formatKey   = "secondaryTelephone.error.format"
+  val requiredKey = "nfmCaptureTelephoneDetails.error.required"
+  val lengthKey   = "nfmCaptureTelephoneDetails.error.length"
+  val formatKey   = "nfmCaptureTelephoneDetails.error.format"
   val formatReg   = Validation.TELEPHONE_REGEX
 
   val invalidPhoneNumberGen = Gen.oneOf(
-    Gen.const("++44 1234 567890"),
-    Gen.const("123$!abc"),
-    Gen.const("abc123")
+    Gen.const("++44 1234 567890"), 
+    Gen.const("123$!abc"), 
+    Gen.const("abc123") 
   )
 
-  val form = new SecondaryTelephoneFormProvider()("test")
+  val formProvider = new NfmCaptureTelephoneDetailsFormProvider()
+  val form: Form[String] = formProvider("test")
 
   ".value" - {
 

--- a/test/forms/RepaymentsTelephoneDetailsFormProviderSpec.scala
+++ b/test/forms/RepaymentsTelephoneDetailsFormProviderSpec.scala
@@ -18,14 +18,19 @@ package forms
 
 import forms.behaviours.StringFieldBehaviours
 import play.api.data.{Form, FormError}
-
+import org.scalacheck.Gen
 class RepaymentsTelephoneDetailsFormProviderSpec extends StringFieldBehaviours {
 
   val requiredKey = "repayments.telephoneDetails.error.required"
   val lengthKey   = "repayments.telephoneDetails.error.length"
   val formatKey   = "repayments.telephoneDetails.error.format"
   val maxLength   = 50
-  val formatReg   = """^[A-Z0-9 )/(\-*#+]*$"""
+  val formatReg   = Validation.TELEPHONE_REGEX
+  val invalidPhoneNumberGen = Gen.oneOf(
+    Gen.const("++44 1234 567890"),
+    Gen.const("123$!abc"),
+    Gen.const("abc123")
+  )
 
   val formProvider = new RepaymentsTelephoneDetailsFormProvider()
   val form: Form[String] = formProvider("test")
@@ -38,6 +43,14 @@ class RepaymentsTelephoneDetailsFormProviderSpec extends StringFieldBehaviours {
       form,
       fieldName,
       requiredError = FormError(fieldName, requiredKey, Seq("test"))
+    )
+
+    behave like fieldWithRegex(
+      form,
+      fieldName,
+      regex = formatReg,
+      regexViolationGen = invalidPhoneNumberGen,
+      regexError = FormError(fieldName, formatKey, Seq("test"))
     )
   }
 }

--- a/test/forms/RepaymentsTelephoneDetailsFormProviderSpec.scala
+++ b/test/forms/RepaymentsTelephoneDetailsFormProviderSpec.scala
@@ -28,6 +28,7 @@ class RepaymentsTelephoneDetailsFormProviderSpec extends StringFieldBehaviours {
   val formatReg   = Validation.TELEPHONE_REGEX
   val invalidPhoneNumberGen: Gen[String] = Gen.oneOf(
     Gen.const("++44 1234 567890"),
+    Gen.const("+44 1234 567890  "),
     Gen.const("123$!abc"),
     Gen.const("abc123")
   )

--- a/test/forms/RepaymentsTelephoneDetailsFormProviderSpec.scala
+++ b/test/forms/RepaymentsTelephoneDetailsFormProviderSpec.scala
@@ -17,8 +17,8 @@
 package forms
 
 import forms.behaviours.StringFieldBehaviours
-import play.api.data.{Form, FormError}
 import org.scalacheck.Gen
+import play.api.data.{Form, FormError}
 class RepaymentsTelephoneDetailsFormProviderSpec extends StringFieldBehaviours {
 
   val requiredKey = "repayments.telephoneDetails.error.required"
@@ -26,7 +26,7 @@ class RepaymentsTelephoneDetailsFormProviderSpec extends StringFieldBehaviours {
   val formatKey   = "repayments.telephoneDetails.error.format"
   val maxLength   = 50
   val formatReg   = Validation.TELEPHONE_REGEX
-  val invalidPhoneNumberGen = Gen.oneOf(
+  val invalidPhoneNumberGen: Gen[String] = Gen.oneOf(
     Gen.const("++44 1234 567890"),
     Gen.const("123$!abc"),
     Gen.const("abc123")

--- a/test/forms/RfmCaptureTelephoneDetailsFormProviderSpec.scala
+++ b/test/forms/RfmCaptureTelephoneDetailsFormProviderSpec.scala
@@ -19,14 +19,19 @@ package forms
 import forms.behaviours.StringFieldBehaviours
 import play.api.data.Form
 import play.api.data.FormError
-
+import org.scalacheck.Gen
 class RfmCaptureTelephoneDetailsFormProviderSpec extends StringFieldBehaviours {
 
   val requiredKey = "rfmCaptureTelephoneDetails.error.required"
   val lengthKey   = "rfmCaptureTelephoneDetails.error.length"
-  val formatKey   = "rfmCaptureTelephoneDetails.error.format"
-  val maxLength   = 24
-  val formatReg   = """^[A-Z0-9 )/(\-*#+]*$"""
+  val formatKey   = "rfmCaptureTelephoneDetails.messages.error.format"
+  val formatReg   = Validation.TELEPHONE_REGEX
+
+  val invalidPhoneNumberGen = Gen.oneOf(
+    Gen.const("++44 1234 567890"),
+    Gen.const("123$!abc"),
+    Gen.const("abc123")
+  )
 
   val formProvider = new RfmCaptureTelephoneDetailsFormProvider()
   val form: Form[String] = formProvider("test")
@@ -39,6 +44,14 @@ class RfmCaptureTelephoneDetailsFormProviderSpec extends StringFieldBehaviours {
       form,
       fieldName,
       requiredError = FormError(fieldName, requiredKey, Seq("test"))
+    )
+
+    behave like fieldWithRegex(
+      form,
+      fieldName,
+      regex = formatReg,
+      regexViolationGen = invalidPhoneNumberGen,
+      regexError = FormError(fieldName, formatKey)
     )
   }
 }

--- a/test/forms/RfmCaptureTelephoneDetailsFormProviderSpec.scala
+++ b/test/forms/RfmCaptureTelephoneDetailsFormProviderSpec.scala
@@ -29,6 +29,7 @@ class RfmCaptureTelephoneDetailsFormProviderSpec extends StringFieldBehaviours {
 
   val invalidPhoneNumberGen: Gen[String] = Gen.oneOf(
     Gen.const("++44 1234 567890"),
+    Gen.const("+44 1234 567890  "),
     Gen.const("123$!abc"),
     Gen.const("abc123")
   )

--- a/test/forms/RfmCaptureTelephoneDetailsFormProviderSpec.scala
+++ b/test/forms/RfmCaptureTelephoneDetailsFormProviderSpec.scala
@@ -17,9 +17,9 @@
 package forms
 
 import forms.behaviours.StringFieldBehaviours
+import org.scalacheck.Gen
 import play.api.data.Form
 import play.api.data.FormError
-import org.scalacheck.Gen
 class RfmCaptureTelephoneDetailsFormProviderSpec extends StringFieldBehaviours {
 
   val requiredKey = "rfmCaptureTelephoneDetails.error.required"
@@ -27,7 +27,7 @@ class RfmCaptureTelephoneDetailsFormProviderSpec extends StringFieldBehaviours {
   val formatKey   = "rfmCaptureTelephoneDetails.messages.error.format"
   val formatReg   = Validation.TELEPHONE_REGEX
 
-  val invalidPhoneNumberGen = Gen.oneOf(
+  val invalidPhoneNumberGen: Gen[String] = Gen.oneOf(
     Gen.const("++44 1234 567890"),
     Gen.const("123$!abc"),
     Gen.const("abc123")

--- a/test/forms/RfmSecondaryTelephoneFormProviderSpec.scala
+++ b/test/forms/RfmSecondaryTelephoneFormProviderSpec.scala
@@ -17,9 +17,10 @@
 package forms
 
 import forms.behaviours.StringFieldBehaviours
-import play.api.data.FormError
 import org.scalacheck.Gen
 import play.api.data.Form
+import play.api.data.FormError
+
 import scala.collection.immutable.Seq
 
 class RfmSecondaryTelephoneFormProviderSpec extends StringFieldBehaviours {
@@ -29,10 +30,10 @@ class RfmSecondaryTelephoneFormProviderSpec extends StringFieldBehaviours {
   val formatKey   = "rfm.secondaryTelephone.error.format"
   val formatReg   = Validation.TELEPHONE_REGEX
 
-  val invalidPhoneNumberGen = Gen.oneOf(
-    Gen.const("++44 1234 567890"), 
-    Gen.const("123$!abc"), 
-    Gen.const("abc123") 
+  val invalidPhoneNumberGen: Gen[String] = Gen.oneOf(
+    Gen.const("++44 1234 567890"),
+    Gen.const("123$!abc"),
+    Gen.const("abc123")
   )
 
   val formProvider = new RfmSecondaryTelephoneFormProvider()

--- a/test/forms/RfmSecondaryTelephoneFormProviderSpec.scala
+++ b/test/forms/RfmSecondaryTelephoneFormProviderSpec.scala
@@ -32,6 +32,7 @@ class RfmSecondaryTelephoneFormProviderSpec extends StringFieldBehaviours {
 
   val invalidPhoneNumberGen: Gen[String] = Gen.oneOf(
     Gen.const("++44 1234 567890"),
+    Gen.const("+44 1234 567890  "),
     Gen.const("123$!abc"),
     Gen.const("abc123")
   )

--- a/test/forms/RfmSecondaryTelephoneFormProviderSpec.scala
+++ b/test/forms/RfmSecondaryTelephoneFormProviderSpec.scala
@@ -19,22 +19,24 @@ package forms
 import forms.behaviours.StringFieldBehaviours
 import play.api.data.FormError
 import org.scalacheck.Gen
+import play.api.data.Form
 import scala.collection.immutable.Seq
 
-class SecondaryTelephoneFormProviderSpec extends StringFieldBehaviours {
+class RfmSecondaryTelephoneFormProviderSpec extends StringFieldBehaviours {
 
-  val requiredKey = "secondaryTelephone.error.required"
-  val lengthKey   = "secondaryTelephone.error.length"
-  val formatKey   = "secondaryTelephone.error.format"
+  val requiredKey = "rfm.secondaryTelephone.error.required"
+  val lengthKey   = "rfm.secondaryTelephone.error.length"
+  val formatKey   = "rfm.secondaryTelephone.error.format"
   val formatReg   = Validation.TELEPHONE_REGEX
 
   val invalidPhoneNumberGen = Gen.oneOf(
-    Gen.const("++44 1234 567890"),
-    Gen.const("123$!abc"),
-    Gen.const("abc123")
+    Gen.const("++44 1234 567890"), 
+    Gen.const("123$!abc"), 
+    Gen.const("abc123") 
   )
 
-  val form = new SecondaryTelephoneFormProvider()("test")
+  val formProvider = new RfmSecondaryTelephoneFormProvider()
+  val form: Form[String] = formProvider("test")
 
   ".value" - {
 
@@ -51,7 +53,7 @@ class SecondaryTelephoneFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       regex = formatReg,
       regexViolationGen = invalidPhoneNumberGen,
-      regexError = FormError(fieldName, formatKey, Seq("test"))
+      regexError = FormError(fieldName, formatKey)
     )
   }
 }

--- a/test/forms/SecondaryTelephoneFormProviderSpec.scala
+++ b/test/forms/SecondaryTelephoneFormProviderSpec.scala
@@ -31,6 +31,7 @@ class SecondaryTelephoneFormProviderSpec extends StringFieldBehaviours {
 
   val invalidPhoneNumberGen: Gen[String] = Gen.oneOf(
     Gen.const("++44 1234 567890"),
+    Gen.const("+44 1234 567890  "),
     Gen.const("123$!abc"),
     Gen.const("abc123")
   )

--- a/test/forms/SecondaryTelephoneFormProviderSpec.scala
+++ b/test/forms/SecondaryTelephoneFormProviderSpec.scala
@@ -17,8 +17,9 @@
 package forms
 
 import forms.behaviours.StringFieldBehaviours
-import play.api.data.FormError
 import org.scalacheck.Gen
+import play.api.data.FormError
+
 import scala.collection.immutable.Seq
 
 class SecondaryTelephoneFormProviderSpec extends StringFieldBehaviours {
@@ -28,7 +29,7 @@ class SecondaryTelephoneFormProviderSpec extends StringFieldBehaviours {
   val formatKey   = "secondaryTelephone.error.format"
   val formatReg   = Validation.TELEPHONE_REGEX
 
-  val invalidPhoneNumberGen = Gen.oneOf(
+  val invalidPhoneNumberGen: Gen[String] = Gen.oneOf(
     Gen.const("++44 1234 567890"),
     Gen.const("123$!abc"),
     Gen.const("abc123")

--- a/test/views/repayments/RepaymentsTelephoneDetailsViewSpec.scala
+++ b/test/views/repayments/RepaymentsTelephoneDetailsViewSpec.scala
@@ -117,13 +117,13 @@ class RepaymentsTelephoneDetailsViewSpec extends ViewSpecBase {
     "have an error summary" in {
       view.getElementsByClass("govuk-error-summary__title").text must include("There is a problem")
       view.getElementsByClass("govuk-list govuk-error-summary__list").text must include(
-        "Enter a telephone number for ABC Limited in the correct format, like 01632 960 001 or +44 808 157 0192"
+        "Enter a telephone number for ABC Limited in the correct format, for example 01632 960 001 or +44 808 157 0192"
       )
     }
 
     "have an input error" in {
       view.getElementsByClass("govuk-error-message").text must include(
-        "Enter a telephone number for ABC Limited in the correct format, like 01632 960 001 or +44 808 157 0192"
+        "Enter a telephone number for ABC Limited in the correct format, for example 01632 960 001 or +44 808 157 0192"
       )
     }
 


### PR DESCRIPTION
An issue was found where a user was able to input a telephone number preceding with "++".

I've since improved the regex across all of pillar2 and unified the telephone regex used where it's possible to input a telephone number. Some DetailFormProvider's didn't have matching unit tests so these have been added in too.

