### PR TITLE
PIL-1854  - Fix ampersand display in NFM Name Registration summary

### DIFF
--- a/.g8/stringPage/app/viewmodels/checkAnswers/$className$Summary.scala
+++ b/.g8/stringPage/app/viewmodels/checkAnswers/$className$Summary.scala
@@ -8,7 +8,7 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist._
 import viewmodels.implicits._
 import play.twirl.api.HtmlFormat
-
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
 object $className$Summary  {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
@@ -17,7 +17,7 @@ object $className$Summary  {
 
         SummaryListRowViewModel(
           key     = "$className;format="decap"$.checkYourAnswersLabel",
-          value   = ValueViewModel(HtmlFormat.escape(answer).toString),
+          value   = ValueViewModel(HtmlContent(HtmlFormat.escape(answer))),
           actions = Seq(
             ActionItemViewModel("site.change", routes.$className$Controller.onPageLoad(CheckMode).url)
               .withVisuallyHiddenText(messages("$className;format="decap"$.change.hidden"))

--- a/app/viewmodels/checkAnswers/RfmNameRegistrationSummary.scala
+++ b/app/viewmodels/checkAnswers/RfmNameRegistrationSummary.scala
@@ -23,6 +23,7 @@ import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist._
 import viewmodels.implicits._
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
 
 object RfmNameRegistrationSummary {
 
@@ -30,7 +31,7 @@ object RfmNameRegistrationSummary {
     answers.get(RfmNameRegistrationPage).map { answer =>
       SummaryListRowViewModel(
         key = "rfm.nameRegistration.checkYourAnswersLabel",
-        value = ValueViewModel(HtmlFormat.escape(answer).toString),
+        value = ValueViewModel(HtmlContent(HtmlFormat.escape(answer))),
         actions = Seq(
           ActionItemViewModel("site.change", controllers.rfm.routes.RfmNameRegistrationController.onPageLoad(CheckMode).url)
             .withVisuallyHiddenText(messages("rfm.nameRegistration.change.hidden"))

--- a/app/viewmodels/checkAnswers/RfmNameRegistrationSummary.scala
+++ b/app/viewmodels/checkAnswers/RfmNameRegistrationSummary.scala
@@ -20,10 +20,10 @@ import models.{CheckMode, UserAnswers}
 import pages.RfmNameRegistrationPage
 import play.api.i18n.Messages
 import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist._
 import viewmodels.implicits._
-import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
 
 object RfmNameRegistrationSummary {
 


### PR DESCRIPTION
## Problem
The ampersand character "&" is displayed as "&amp;" on the NFM Name Registration check your answers page, while it appears correctly as "&" on the UPE check your answers page.

## Solution
- Fixed the NFM name registration summary to match UPE implementation by removing `.toString()` call that was causing double HTML escaping
- Updated g8 template for name fields to use the correct HTML escaping pattern, preventing this issue in future implementations