### PR TITLE
PIL-1715 - Error message fix

### DIFF
--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1091,7 +1091,7 @@ rfm.secondaryTelephone.hint = For international numbers include the country code
 rfm.secondaryTelephone.checkYourAnswersLabel = Second contact telephone number
 rfm.secondaryTelephone.error.required = You need to enter the telephone for {0}
 rfm.secondaryTelephone.error.length = The telephone number should be 24 characters or less
-rfm.secondaryTelephone.error.format = Enter a telephone number, for example 01632 960 001 or +44 808 157 0192
+rfm.secondaryTelephone.error.format = Enter a telephone number in the correct format, for example 01632 960 001 or +44 808 157 0192
 
 rfm.journeyRecoveryView.title = There has been an error
 rfm.journeyRecoveryView.heading = There has been an error

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1091,7 +1091,7 @@ rfm.secondaryTelephone.hint = For international numbers include the country code
 rfm.secondaryTelephone.checkYourAnswersLabel = Second contact telephone number
 rfm.secondaryTelephone.error.required = You need to enter the telephone for {0}
 rfm.secondaryTelephone.error.length = The telephone number should be 24 characters or less
-rfm.secondaryTelephone.error.format = Enter a telephone number, like 01632 960 001 or +44 808 157 0192
+rfm.secondaryTelephone.error.format = Enter a telephone number, for example 01632 960 001 or +44 808 157 0192
 
 rfm.journeyRecoveryView.title = There has been an error
 rfm.journeyRecoveryView.heading = There has been an error


### PR DESCRIPTION
Please see https://github.com/hmrc/pillar2-frontend/pull/443 & https://github.com/hmrc/pillar2-frontend/pull/445. This is to correct the error message for an incorrectly inputted contact number in the rfm journeys second contact number. 

This should match the error in [the ticket](https://jira.tools.tax.service.gov.uk/browse/PIL-1715).
<img width="1473" alt="image" src="https://github.com/user-attachments/assets/2d2f18a0-f0a4-4554-a56b-862363dc168c" />
