### PR TITLE
PIL-1857: Corrected date formatter for the transaction history page table to show full month names

### DIFF
--- a/app/controllers/TransactionHistoryController.scala
+++ b/app/controllers/TransactionHistoryController.scala
@@ -203,7 +203,7 @@ object TransactionHistoryController {
 
     Seq(
       TableRow(
-        content = Text(history.date.format(DateTimeFormatter.ofPattern("dd MMM yyyy")))
+        content = Text(history.date.format(DateTimeFormatter.ofPattern("d MMMM yyyy")))
       ),
       TableRow(
         content = Text(history.paymentType)

--- a/test/views/paymenthistory/TransactionHistoryViewSpec.scala
+++ b/test/views/paymenthistory/TransactionHistoryViewSpec.scala
@@ -27,9 +27,9 @@ class TransactionHistoryViewSpec extends ViewSpecBase {
 
   val table: Table = Table(
     List(
-      List(TableRow(Text("01 Jul 2024")), TableRow(Text("Payment")), TableRow(Text("£-5000.00")), TableRow(Text("£0.00"))),
-      List(TableRow(Text("01 Jul 2024")), TableRow(Text("Payment")), TableRow(Text("£-5000.00")), TableRow(Text("£0.00"))),
-      List(TableRow(Text("01 Jul 2024")), TableRow(Text("Payment")), TableRow(Text("£-5000.00")), TableRow(Text("£0.00")))
+      List(TableRow(Text("1 July 2024")), TableRow(Text("Payment")), TableRow(Text("£-5000.00")), TableRow(Text("£0.00"))),
+      List(TableRow(Text("1 July 2024")), TableRow(Text("Payment")), TableRow(Text("£-5000.00")), TableRow(Text("£0.00"))),
+      List(TableRow(Text("1 July 2024")), TableRow(Text("Payment")), TableRow(Text("£-5000.00")), TableRow(Text("£0.00")))
     ),
     head = Some(
       Seq(
@@ -103,7 +103,7 @@ class TransactionHistoryViewSpec extends ViewSpecBase {
 
       (1 to 3).foreach { int =>
         val tableRow = groupView.getElementsByClass("govuk-table__row").get(int).getElementsByClass("govuk-table__cell")
-        tableRow.first().text must include("01 Jul 2024")
+        tableRow.first().text must include("1 July 2024")
         tableRow.get(1).text  must include("Payment")
         tableRow.get(2).text  must include("£-5000.00")
         tableRow.get(3).text  must include("£0.00")


### PR DESCRIPTION
All transaction dates display the month spelt out in full
Account period tables display entries in reverse chronological order.
The format update is applied to all rows on the Transaction History table