### PR TITLE
PIL-1976 Minor fix to GA4 tracking code

### DIFF
--- a/app/views/templates/Layout.scala.html
+++ b/app/views/templates/Layout.scala.html
@@ -63,7 +63,7 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', @{appConfig.googleAnalyticsTrackingId});
+      gtag('config', '@{appConfig.googleAnalyticsTrackingId}');
     </script>
   }
   @hmrcHead(


### PR DESCRIPTION
- Added missing `'` around the Google tracking ID.