### PR TITLE
PIL-2001 - Make BIC and IBAN fields optional when either one is provided

### DIFF
--- a/app/forms/NonUKBankFormProvider.scala
+++ b/app/forms/NonUKBankFormProvider.scala
@@ -38,7 +38,7 @@ class NonUKBankFormProvider @Inject() extends Mappings {
           maxLength(Constants.MAX_LENGTH_60, "repayments.nonUKBank.error.nameOnBankAccount.length"),
           regexp(XSS_REGEX_ALLOW_AMPERSAND, "repayments.nonUKBank.error.nameOnBankAccount.xss")
         ),
-      "bic" -> bankAccount("repayments.nonUKBank.error.bic.required")
+      "bic" -> bic("repayments.nonUKBank.error.bic.required")
         .verifying(
           firstError(
             minLength(Constants.MIN_LENGTH_8, "repayments.nonUKBank.error.bic.length"),
@@ -46,7 +46,7 @@ class NonUKBankFormProvider @Inject() extends Mappings {
             regexp(Validation.BIC_SWIFT_REGEX, "repayments.nonUKBank.error.bic.format")
           )
         ),
-      "iban" -> bankAccount("repayments.nonUKBank.error.iban.required")
+      "iban" -> iban("repayments.nonUKBank.error.iban.required")
         .verifying(
           firstError(
             maxLength(Constants.MAX_LENGTH_34, "repayments.nonUKBank.error.iban.length"),

--- a/app/forms/mappings/Formatters.scala
+++ b/app/forms/mappings/Formatters.scala
@@ -81,31 +81,43 @@ trait Formatters extends Transforms with Constraints {
 
   /** Creates a formatter for a field that is optional if another field has a value. If both fields are empty, returns an error for the current field.
     *
+    * The formatter will:
+    *   - Use the provided formatter to handle the field's value
+    *   - Return None if the field is empty but the dependent field has a value
+    *   - Return an error if both fields are empty
+    *
     * @param dependentFieldName
     *   The name of the field that this field depends on
     * @param errorKey
     *   The error message key to use when validation fails
+    * @param formatter
+    *   The formatter to use for the field's value
     * @param args
     *   Optional arguments for the error message
     */
-  protected def dependentFieldFormatter(
+  protected def dependentFieldFormatter[A](
     dependentFieldName: String,
     errorKey:           String,
+    formatter:          Formatter[A],
     args:               Seq[String] = Seq.empty
-  ): Formatter[Option[String]] = new Formatter[Option[String]] {
-    override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], Option[String]] = {
+  ): Formatter[Option[A]] = new Formatter[Option[A]] {
+    override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], Option[A]] = {
       val fieldValue     = data.get(key).map(_.trim).filter(_.nonEmpty)
       val dependentValue = data.get(dependentFieldName).map(_.trim).filter(_.nonEmpty)
 
       if (fieldValue.isDefined || dependentValue.isDefined) {
-        Right(fieldValue)
+        if (fieldValue.isDefined) {
+          formatter.bind(key, data).map(Some(_))
+        } else {
+          Right(None)
+        }
       } else {
         Left(Seq(FormError(key, errorKey, args)))
       }
     }
 
-    override def unbind(key: String, value: Option[String]): Map[String, String] =
-      Map(key -> value.getOrElse(""))
+    override def unbind(key: String, value: Option[A]): Map[String, String] =
+      value.map(v => formatter.unbind(key, v)).getOrElse(Map(key -> ""))
   }
 
   private[mappings] def booleanFormatter(requiredKey: String, invalidKey: String, args: Seq[String] = Seq.empty): Formatter[Boolean] =

--- a/app/forms/mappings/Mappings.scala
+++ b/app/forms/mappings/Mappings.scala
@@ -33,10 +33,10 @@ trait Mappings extends Formatters with Constraints {
     of(bankAccountFormatter(errorKey, args))
 
   protected def bic(errorKey: String = "error.required", args: Seq[String] = Seq.empty): FieldMapping[Option[String]] =
-    of(dependentFieldFormatter(dependentFieldName = "iban", errorKey, args))
+    of(dependentFieldFormatter[String]("iban", errorKey, bankAccountFormatter(errorKey, args), args))
 
   protected def iban(errorKey: String = "error.required", args: Seq[String] = Seq.empty): FieldMapping[Option[String]] =
-    of(dependentFieldFormatter(dependentFieldName = "bic", errorKey, args))
+    of(dependentFieldFormatter[String]("bic", errorKey, bankAccountFormatter(errorKey, args), args))
 
   protected def sortCode(errorKey: String = "error.required", args: Seq[String] = Seq.empty): FieldMapping[String] =
     of(sortCodeFormatter(errorKey, args))

--- a/app/forms/mappings/Mappings.scala
+++ b/app/forms/mappings/Mappings.scala
@@ -32,6 +32,12 @@ trait Mappings extends Formatters with Constraints {
   protected def bankAccount(errorKey: String = "error.required", args: Seq[String] = Seq.empty): FieldMapping[String] =
     of(bankAccountFormatter(errorKey, args))
 
+  protected def bic(errorKey: String = "error.required", args: Seq[String] = Seq.empty): FieldMapping[Option[String]] =
+    of(dependentFieldFormatter(dependentFieldName = "iban", errorKey, args))
+
+  protected def iban(errorKey: String = "error.required", args: Seq[String] = Seq.empty): FieldMapping[Option[String]] =
+    of(dependentFieldFormatter(dependentFieldName = "bic", errorKey, args))
+
   protected def sortCode(errorKey: String = "error.required", args: Seq[String] = Seq.empty): FieldMapping[String] =
     of(sortCodeFormatter(errorKey, args))
 

--- a/app/models/repayments/NonUKBank.scala
+++ b/app/models/repayments/NonUKBank.scala
@@ -18,7 +18,7 @@ package models.repayments
 
 import play.api.libs.json._
 
-case class NonUKBank(bankName: String, nameOnBankAccount: String, bic: String, iban: String)
+case class NonUKBank(bankName: String, nameOnBankAccount: String, bic: Option[String], iban: Option[String])
 object NonUKBank {
   implicit val format: OFormat[NonUKBank] = Json.format[NonUKBank]
 }

--- a/app/services/RepaymentService.scala
+++ b/app/services/RepaymentService.scala
@@ -75,8 +75,8 @@ class RepaymentService @Inject() (
               bankName = bankDetails.bankName,
               sortCode = None,
               accountNumber = None,
-              iban = Some(bankDetails.iban),
-              bic = Some(bankDetails.bic),
+              iban = bankDetails.iban,
+              bic = bankDetails.bic,
               countryCode = None
             )
           )

--- a/app/viewmodels/checkAnswers/repayments/NonUKBankBicOrSwiftCodeSummary.scala
+++ b/app/viewmodels/checkAnswers/repayments/NonUKBankBicOrSwiftCodeSummary.scala
@@ -29,11 +29,13 @@ object NonUKBankBicOrSwiftCodeSummary {
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
     answers
       .get(NonUKBankPage)
-      .map { answer =>
-        SummaryListRowViewModel(
-          key = "repayments.nonUKBank.summary.bicOrSwiftCode.checkYourAnswersLabel",
-          value = ValueViewModel(HtmlContent(answer.bic))
-        )
+      .flatMap { answer =>
+        answer.bic.map { bic =>
+          SummaryListRowViewModel(
+            key = "repayments.nonUKBank.summary.bicOrSwiftCode.checkYourAnswersLabel",
+            value = ValueViewModel(HtmlContent(bic))
+          )
+        }
       }
 
 }

--- a/app/viewmodels/checkAnswers/repayments/NonUKBankIbanSummary.scala
+++ b/app/viewmodels/checkAnswers/repayments/NonUKBankIbanSummary.scala
@@ -29,11 +29,13 @@ object NonUKBankIbanSummary {
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
     answers
       .get(NonUKBankPage)
-      .map { answer =>
-        SummaryListRowViewModel(
-          key = "repayments.nonUKBank.summary.iban.checkYourAnswersLabel",
-          value = ValueViewModel(HtmlContent(answer.iban))
-        )
+      .flatMap { answer =>
+        answer.iban.map { iban =>
+          SummaryListRowViewModel(
+            key = "repayments.nonUKBank.summary.iban.checkYourAnswersLabel",
+            value = ValueViewModel(HtmlContent(iban))
+          )
+        }
       }
 
 }

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -3,6 +3,6 @@
 
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.8")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.10")
 
 // format: on

--- a/test/controllers/repayments/NonUKBankControllerSpec.scala
+++ b/test/controllers/repayments/NonUKBankControllerSpec.scala
@@ -49,7 +49,7 @@ class NonUKBankControllerSpec extends SpecBase {
     }
 
     "must populate the view correctly on a GET when the question has previously been answered" in {
-      val ua = emptyUserAnswers.setOrException(NonUKBankPage, NonUKBank("BankName", "Name", "HBUKGB4B", "GB29NWBK60161331926819"))
+      val ua = emptyUserAnswers.setOrException(NonUKBankPage, NonUKBank("BankName", "Name", Some("HBUKGB4B"), Some("GB29NWBK60161331926819")))
       val application = applicationBuilder(userAnswers = Some(ua))
         .overrides(inject.bind[SessionRepository].toInstance(mockSessionRepository))
         .build()
@@ -60,7 +60,7 @@ class NonUKBankControllerSpec extends SpecBase {
         val result  = route(application, request).value
         status(result) mustEqual OK
         contentAsString(result) mustEqual
-          view(formProvider().fill(NonUKBank("BankName", "Name", "HBUKGB4B", "GB29NWBK60161331926819")), NormalMode)(
+          view(formProvider().fill(NonUKBank("BankName", "Name", Some("HBUKGB4B"), Some("GB29NWBK60161331926819"))), NormalMode)(
             request,
             applicationConfig,
             messages(application)

--- a/test/forms/NonUKBankFormProviderSpec.scala
+++ b/test/forms/NonUKBankFormProviderSpec.scala
@@ -117,11 +117,41 @@ class NonUKBankFormProviderSpec extends StringFieldBehaviours {
       generator = Some(longStringsConformingToRegex(regex, maxLength))
     )
 
-    behave like mandatoryField(
-      form,
-      fieldName,
-      requiredError = FormError(fieldName, requiredKey)
-    )
+    "bind successfully when IBAN is provided" in {
+      val result = form.bind(
+        Map(
+          "bankName"          -> "Test Bank",
+          "nameOnBankAccount" -> "Test Account",
+          "bic"               -> "",
+          "iban"              -> "GB82WEST12345698765432"
+        )
+      )
+      result.errors mustBe empty
+    }
+
+    "bind successfully when BIC is provided" in {
+      val result = form.bind(
+        Map(
+          "bankName"          -> "Test Bank",
+          "nameOnBankAccount" -> "Test Account",
+          "bic"               -> "ABCDEF12",
+          "iban"              -> ""
+        )
+      )
+      result.errors mustBe empty
+    }
+
+    "fail to bind when both BIC and IBAN are empty" in {
+      val result = form.bind(
+        Map(
+          "bankName"          -> "Test Bank",
+          "nameOnBankAccount" -> "Test Account",
+          "bic"               -> "",
+          "iban"              -> ""
+        )
+      )
+      result.errors must contain(FormError(fieldName, requiredKey))
+    }
   }
 
   ".iban" - {
@@ -146,10 +176,40 @@ class NonUKBankFormProviderSpec extends StringFieldBehaviours {
       generator = Some(longStringsConformingToRegex(regex, maxLength))
     )
 
-    behave like mandatoryField(
-      form,
-      fieldName,
-      requiredError = FormError(fieldName, requiredKey)
-    )
+    "bind successfully when BIC is provided" in {
+      val result = form.bind(
+        Map(
+          "bankName"          -> "Test Bank",
+          "nameOnBankAccount" -> "Test Account",
+          "bic"               -> "ABCDEF12",
+          "iban"              -> ""
+        )
+      )
+      result.errors mustBe empty
+    }
+
+    "bind successfully when IBAN is provided" in {
+      val result = form.bind(
+        Map(
+          "bankName"          -> "Test Bank",
+          "nameOnBankAccount" -> "Test Account",
+          "bic"               -> "",
+          "iban"              -> "GB82WEST12345698765432"
+        )
+      )
+      result.errors mustBe empty
+    }
+
+    "fail to bind when both BIC and IBAN are empty" in {
+      val result = form.bind(
+        Map(
+          "bankName"          -> "Test Bank",
+          "nameOnBankAccount" -> "Test Account",
+          "bic"               -> "",
+          "iban"              -> ""
+        )
+      )
+      result.errors must contain(FormError(fieldName, requiredKey))
+    }
   }
 }

--- a/test/forms/mappings/FormattersSpec.scala
+++ b/test/forms/mappings/FormattersSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.mappings
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import play.api.data.FormError
+
+class FormattersSpec extends AnyFreeSpec with Matchers with Formatters {
+
+  "dependentFieldFormatter" - {
+    val formatter = dependentFieldFormatter(
+      dependentFieldName = "otherField",
+      errorKey = "error.required"
+    )
+
+    "bind successfully when the field has a value" in {
+      val data = Map(
+        "field" -> "value",
+        "otherField" -> ""
+      )
+      formatter.bind("field", data) mustBe Right(Some("value"))
+    }
+
+    "bind successfully when the dependent field has a value" in {
+      val data = Map(
+        "field" -> "",
+        "otherField" -> "value"
+      )
+      formatter.bind("field", data) mustBe Right(None)
+    }
+
+    "bind successfully when both fields have values" in {
+      val data = Map(
+        "field" -> "value1",
+        "otherField" -> "value2"
+      )
+      formatter.bind("field", data) mustBe Right(Some("value1"))
+    }
+
+    "fail to bind when both fields are empty" in {
+      val data = Map(
+        "field" -> "",
+        "otherField" -> ""
+      )
+      formatter.bind("field", data) mustBe Left(Seq(FormError("field", "error.required")))
+    }
+
+    "unbind returns empty string for None" in {
+      formatter.unbind("field", None) mustBe Map("field" -> "")
+    }
+
+    "unbind returns the value for Some" in {
+      formatter.unbind("field", Some("value")) mustBe Map("field" -> "value")
+    }
+  }
+} 

--- a/test/forms/mappings/FormattersSpec.scala
+++ b/test/forms/mappings/FormattersSpec.scala
@@ -30,7 +30,7 @@ class FormattersSpec extends AnyFreeSpec with Matchers with Formatters {
 
     "bind successfully when the field has a value" in {
       val data = Map(
-        "field" -> "value",
+        "field"      -> "value",
         "otherField" -> ""
       )
       formatter.bind("field", data) mustBe Right(Some("value"))
@@ -38,7 +38,7 @@ class FormattersSpec extends AnyFreeSpec with Matchers with Formatters {
 
     "bind successfully when the dependent field has a value" in {
       val data = Map(
-        "field" -> "",
+        "field"      -> "",
         "otherField" -> "value"
       )
       formatter.bind("field", data) mustBe Right(None)
@@ -46,7 +46,7 @@ class FormattersSpec extends AnyFreeSpec with Matchers with Formatters {
 
     "bind successfully when both fields have values" in {
       val data = Map(
-        "field" -> "value1",
+        "field"      -> "value1",
         "otherField" -> "value2"
       )
       formatter.bind("field", data) mustBe Right(Some("value1"))
@@ -54,7 +54,7 @@ class FormattersSpec extends AnyFreeSpec with Matchers with Formatters {
 
     "fail to bind when both fields are empty" in {
       val data = Map(
-        "field" -> "",
+        "field"      -> "",
         "otherField" -> ""
       )
       formatter.bind("field", data) mustBe Left(Seq(FormError("field", "error.required")))
@@ -68,4 +68,4 @@ class FormattersSpec extends AnyFreeSpec with Matchers with Formatters {
       formatter.unbind("field", Some("value")) mustBe Map("field" -> "value")
     }
   }
-} 
+}

--- a/test/helpers/RepaymentsHelpersSpec.scala
+++ b/test/helpers/RepaymentsHelpersSpec.scala
@@ -233,8 +233,8 @@ class RepaymentsHelpersSpec extends SpecBase {
     val nonUkBankAccountDetails: NonUKBank = NonUKBank(
       bankName = "BankName",
       nameOnBankAccount = "Name",
-      bic = "HBUKGB4B",
-      iban = "GB29NWBK60161331926819"
+      bic = Some("HBUKGB4B"),
+      iban = Some("GB29NWBK60161331926819")
     )
     val refundAmount: BigDecimal = 10000.1
 

--- a/test/helpers/UserAnswersFixture.scala
+++ b/test/helpers/UserAnswersFixture.scala
@@ -660,8 +660,8 @@ trait UserAnswersFixture extends TryValues {
   private val nonUkBankAccount = NonUKBank(
     nameOnBankAccount = "Paddington",
     bankName = "Bank of Bears",
-    iban = "123132",
-    bic = "11111111"
+    iban = Some("123132"),
+    bic = Some("11111111")
   )
   private val refundAmount: BigDecimal = 10000.1
   val completeRepaymentDataUkBankAccount: UserAnswers = emptyUserAnswers

--- a/test/models/repayments/RepaymentJourneyModelSpec.scala
+++ b/test/models/repayments/RepaymentJourneyModelSpec.scala
@@ -36,8 +36,8 @@ class RepaymentJourneyModelSpec extends AnyFreeSpec with Matchers with OptionVal
     val nonUkBankAccountDetails = NonUKBank(
       nameOnBankAccount = "Paddington",
       bankName = "Bank of Bears",
-      iban = "123132",
-      bic = "11111111"
+      iban = Some("123132"),
+      bic = Some("11111111")
     )
 
     "UkBankAccount" - {
@@ -168,7 +168,7 @@ class RepaymentJourneyModelSpec extends AnyFreeSpec with Matchers with OptionVal
           reasonForRequestingRefund = "The reason for refund",
           ukOrAbroadBankAccount = ForeignBankAccount,
           bankAccountDetails = None,
-          nonUKBank = Some(NonUKBank("Bank of Bears", "Paddington", "11111111", "123132")),
+          nonUKBank = Some(NonUKBank("Bank of Bears", "Paddington", Some("11111111"), Some("123132"))),
           repaymentsContactName = "contact name",
           repaymentsContactEmail = "contact@test.com",
           repaymentsContactByPhone = true,
@@ -205,7 +205,7 @@ class RepaymentJourneyModelSpec extends AnyFreeSpec with Matchers with OptionVal
           reasonForRequestingRefund = "The reason for refund",
           ukOrAbroadBankAccount = ForeignBankAccount,
           bankAccountDetails = None,
-          nonUKBank = Some(NonUKBank("Bank of Bears", "Paddington", "11111111", "123132")),
+          nonUKBank = Some(NonUKBank("Bank of Bears", "Paddington", Some("11111111"), Some("123132"))),
           repaymentsContactName = "contact name",
           repaymentsContactEmail = "contact@test.com",
           repaymentsContactByPhone = false,

--- a/test/navigation/RepaymentNavigatorSpec.scala
+++ b/test/navigation/RepaymentNavigatorSpec.scala
@@ -253,7 +253,7 @@ class RepaymentNavigatorSpec extends SpecBase {
       "go to Repayments CYA page from Bank Account type page if Non-UK bank account page is previously answered" in {
         val ua = emptyUserAnswers
           .setOrException(UkOrAbroadBankAccountPage, UkOrAbroadBankAccount.ForeignBankAccount)
-          .setOrException(NonUKBankPage, NonUKBank("BankName", "Name", "HBUKGB4B", "GB29NWBK60161331926819"))
+          .setOrException(NonUKBankPage, NonUKBank("BankName", "Name", Some("HBUKGB4B"), Some("GB29NWBK60161331926819")))
         navigator.nextPage(UkOrAbroadBankAccountPage, CheckMode, ua) mustBe
           repaymentsQuestionsCYA
       }
@@ -262,7 +262,7 @@ class RepaymentNavigatorSpec extends SpecBase {
         navigator.nextPage(
           NonUKBankPage,
           CheckMode,
-          emptyUserAnswers.setOrException(NonUKBankPage, NonUKBank("BankName", "Name", "HBUKGB4B", "GB29NWBK60161331926819"))
+          emptyUserAnswers.setOrException(NonUKBankPage, NonUKBank("BankName", "Name", Some("HBUKGB4B"), Some("GB29NWBK60161331926819")))
         ) mustBe
           repaymentsQuestionsCYA
       }

--- a/test/pages/UkOrAbroadBankAccountPageSpec.scala
+++ b/test/pages/UkOrAbroadBankAccountPageSpec.scala
@@ -35,7 +35,7 @@ class UkOrAbroadBankAccountPageSpec extends PageBehaviours {
   "must remove NonUKBankPage when UkBankAccount is selected" in {
     forAll { userAnswers: UserAnswers =>
       val result = userAnswers
-        .set(NonUKBankPage, NonUKBank("BankName", "Name", "HBUKGB4B", "GB29NWBK60161331926819"))
+        .set(NonUKBankPage, NonUKBank("BankName", "Name", Some("HBUKGB4B"), Some("GB29NWBK60161331926819")))
         .success
         .value
         .set(UkOrAbroadBankAccountPage, UkOrAbroadBankAccount.UkBankAccount)

--- a/test/views/repayments/RepaymentsCheckYourAnswersViewSpec.scala
+++ b/test/views/repayments/RepaymentsCheckYourAnswersViewSpec.scala
@@ -33,7 +33,7 @@ class RepaymentsCheckYourAnswersViewSpec extends ViewSpecBase {
     .setOrException(RepaymentsRefundAmountPage, amount)
     .setOrException(ReasonForRequestingRefundPage, "answer for reason")
     .setOrException(UkOrAbroadBankAccountPage, UkOrAbroadBankAccount.ForeignBankAccount)
-    .setOrException(NonUKBankPage, NonUKBank("BankName", "Name", "HBUKGB4B", "GB29NWBK60161331926819"))
+    .setOrException(NonUKBankPage, NonUKBank("BankName", "Name", Some("HBUKGB4B"), Some("GB29NWBK60161331926819")))
     .setOrException(RepaymentsContactNamePage, "contact name")
     .setOrException(RepaymentsContactEmailPage, "test@test.com")
     .setOrException(RepaymentsContactByTelephonePage, true)


### PR DESCRIPTION
This change allows users to provide either a BIC/SWIFT or IBAN, rather than requiring both.

- Added a new `dependentFieldFormatter` that validates fields based on their dependencies:
  - Returns the formatted value if the field has a value given a formatter
  - Returns None if the field is empty but the dependent field has a value
  - Returns an error if both fields are empty
- Updated BIC and IBAN fields to be optional in the `NonUKBank` model
- Modified form validation to require at least one of BIC or IBAN
- Updated bloop version