### PR TITLE
PIL-2007 - Refactor Manage Contact Details for background processing

### DIFF
--- a/app/controllers/subscription/manageAccount/ManageContactCheckYourAnswersController.scala
+++ b/app/controllers/subscription/manageAccount/ManageContactCheckYourAnswersController.scala
@@ -19,7 +19,7 @@ package controllers.subscription.manageAccount
 import cats.data.OptionT
 import config.FrontendAppConfig
 import controllers.actions.{IdentifierAction, SubscriptionDataRequiredAction, SubscriptionDataRetrievalAction}
-import models.subscription.ManageContactDetailsStatus
+import models.subscription.{ManageContactDetailsStatus, SubscriptionLocalData}
 import models.{InternalIssueError, UnexpectedResponse, UserAnswers}
 import pages.{AgentClientPillar2ReferencePage, ManageContactDetailsStatusPage}
 import play.api.Logging
@@ -27,6 +27,8 @@ import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
 import services.{ReferenceNumberService, SubscriptionService}
+import uk.gov.hmrc.auth.core.Enrolment
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.countryOptions.CountryOptions
 import viewmodels.checkAnswers.manageAccount._
@@ -91,38 +93,52 @@ class ManageContactCheckYourAnswersController @Inject() (
 
   def onSubmit(): Action[AnyContent] = (identify andThen getData andThen requireData).async { implicit request =>
     logger.info(s"[ManageContactCheckYourAnswers] Submission started for user ${request.userId}")
-    val result = for {
-      userAnswers <- OptionT.liftF(sessionRepository.get(request.userId))
-      referenceNumber <- OptionT
-                           .fromOption[Future](userAnswers.flatMap(_.get(AgentClientPillar2ReferencePage)))
-                           .orElse(OptionT.fromOption[Future](referenceNumberService.get(None, enrolments = Some(request.enrolments))))
-      _ <- OptionT.liftF(subscriptionService.amendContactOrGroupDetails(request.userId, referenceNumber, request.subscriptionLocalData))
+
+    for {
+      userAnswers <- sessionRepository.get(request.userId)
       updatedAnswers = userAnswers match {
                          case Some(answers) => answers.setOrException(ManageContactDetailsStatusPage, ManageContactDetailsStatus.InProgress)
                          case None =>
                            UserAnswers(request.userId).setOrException(ManageContactDetailsStatusPage, ManageContactDetailsStatus.InProgress)
                        }
-      _ <- OptionT.liftF(sessionRepository.set(updatedAnswers))
+      _ <- sessionRepository.set(updatedAnswers)
     } yield {
-      logger.info(s"[ManageContactCheckYourAnswers] Redirecting to waiting room for ${request.userId}")
+      updateSubscriptionInBackground(request.userId, request.subscriptionLocalData, request.enrolments)
       Redirect(controllers.subscription.manageAccount.routes.ManageContactDetailsWaitingRoomController.onPageLoad)
     }
+  }
+
+  private def updateSubscriptionInBackground(userId: String, subscriptionData: SubscriptionLocalData, enrolments: Set[Enrolment])(implicit
+    hc:                                              HeaderCarrier,
+    ec:                                              ExecutionContext
+  ): Future[Unit] = {
+    val result = for {
+      userAnswers <- OptionT.liftF(sessionRepository.get(userId))
+      referenceNumber <- OptionT
+                           .fromOption[Future](userAnswers.flatMap(_.get(AgentClientPillar2ReferencePage)))
+                           .orElse(OptionT.fromOption[Future](referenceNumberService.get(None, enrolments = Some(enrolments))))
+      _ <- OptionT.liftF(subscriptionService.amendContactOrGroupDetails(userId, referenceNumber, subscriptionData))
+      updatedAnswers = userAnswers match {
+                         case Some(answers) =>
+                           answers.setOrException(ManageContactDetailsStatusPage, ManageContactDetailsStatus.SuccessfullyCompleted)
+                         case None =>
+                           UserAnswers(userId).setOrException(ManageContactDetailsStatusPage, ManageContactDetailsStatus.SuccessfullyCompleted)
+                       }
+      _ <- OptionT.liftF(sessionRepository.set(updatedAnswers))
+    } yield ()
 
     result.value
       .recover {
         case InternalIssueError =>
-          logger.error(s"[ManageContactCheckYourAnswers] Submission failed for ${request.userId} due to InternalIssueError")
-          Some(Redirect(controllers.routes.ViewAmendSubscriptionFailedController.onPageLoad))
+          logger.error(s"[ManageContactCheckYourAnswers] Subscription update failed for $userId due to InternalIssueError")
+          None
         case UnexpectedResponse =>
-          logger.error(s"[ManageContactCheckYourAnswers] Submission failed for ${request.userId} due to UnexpectedResponse")
-          Some(Redirect(controllers.routes.ViewAmendSubscriptionFailedController.onPageLoad))
+          logger.error(s"[ManageContactCheckYourAnswers] Subscription update failed for $userId due to UnexpectedResponse")
+          None
         case e: Exception =>
-          logger.error(s"[ManageContactCheckYourAnswers] Submission failed for ${request.userId}: ${e.getMessage}")
-          Some(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad()))
+          logger.error(s"[ManageContactCheckYourAnswers] Subscription update failed for $userId: ${e.getMessage}")
+          None
       }
-      .map(_.getOrElse {
-        logger.error(s"[ManageContactCheckYourAnswers] Submission failed for ${request.userId}")
-        Redirect(controllers.routes.JourneyRecoveryController.onPageLoad())
-      })
+      .map(_ => ())
   }
 }

--- a/app/controllers/subscription/manageAccount/ManageContactDetailsWaitingRoomController.scala
+++ b/app/controllers/subscription/manageAccount/ManageContactDetailsWaitingRoomController.scala
@@ -59,10 +59,6 @@ class ManageContactDetailsWaitingRoomController @Inject() (
             logger.info(s"[ManageContactDetailsWaitingRoom] InProgress status for ${request.userId}, re-rendering spinner")
             Future.successful(Ok(view(Some(ManageContactDetailsStatus.InProgress))))
 
-          case Some(ManageContactDetailsStatus.Failed) =>
-            logger.warn(s"[ManageContactDetailsWaitingRoom] Failed status detected for ${request.userId}, redirecting to error page")
-            Future.successful(Redirect(controllers.routes.ViewAmendSubscriptionFailedController.onPageLoad))
-
           case Some(ManageContactDetailsStatus.FailException) =>
             logger.warn(s"[ManageContactDetailsWaitingRoom] FailException status detected for ${request.userId}, redirecting to error page")
             Future.successful(Redirect(controllers.routes.ViewAmendSubscriptionFailedController.onPageLoad))

--- a/app/controllers/subscription/manageAccount/ManageContactDetailsWaitingRoomController.scala
+++ b/app/controllers/subscription/manageAccount/ManageContactDetailsWaitingRoomController.scala
@@ -57,10 +57,21 @@ class ManageContactDetailsWaitingRoomController @Inject() (
 
           case Some(ManageContactDetailsStatus.InProgress) =>
             logger.info(s"[ManageContactDetailsWaitingRoom] InProgress status for ${request.userId}, re-rendering spinner")
-            sessionRepository.set(
-              refreshedAnswers.get.setOrException(ManageContactDetailsStatusPage, ManageContactDetailsStatus.SuccessfullyCompleted)
-            )
             Future.successful(Ok(view(Some(ManageContactDetailsStatus.InProgress))))
+
+          case Some(ManageContactDetailsStatus.Failed) =>
+            logger.warn(s"[ManageContactDetailsWaitingRoom] Failed status detected for ${request.userId}, redirecting to error page")
+            Future.successful(Redirect(controllers.routes.ViewAmendSubscriptionFailedController.onPageLoad))
+
+          case Some(ManageContactDetailsStatus.FailException) =>
+            logger.warn(s"[ManageContactDetailsWaitingRoom] FailException status detected for ${request.userId}, redirecting to error page")
+            Future.successful(Redirect(controllers.routes.ViewAmendSubscriptionFailedController.onPageLoad))
+
+          case Some(ManageContactDetailsStatus.FailedInternalIssueError) =>
+            logger.warn(
+              s"[ManageContactDetailsWaitingRoom] FailedInternalIssueError status detected for ${request.userId}, redirecting to error page"
+            )
+            Future.successful(Redirect(controllers.routes.ViewAmendSubscriptionFailedController.onPageLoad))
 
           case _ =>
             logger.warn(s"[ManageContactDetailsWaitingRoom] Missing or unexpected status for ${request.userId}, redirecting to error page")

--- a/app/models/subscription/ManageContactDetailsStatus.scala
+++ b/app/models/subscription/ManageContactDetailsStatus.scala
@@ -30,9 +30,6 @@ object ManageContactDetailsStatus extends Enum[ManageContactDetailsStatus] with 
   case object SuccessfullyCompleted extends ManageContactDetailsStatus {
     override def entryName = "successfullyCompleted"
   }
-  case object Failed extends ManageContactDetailsStatus {
-    override def entryName = "failed"
-  }
   case object FailedInternalIssueError extends ManageContactDetailsStatus {
     override def entryName = "failedInternalIssueError"
   }

--- a/app/models/subscription/ManageContactDetailsStatus.scala
+++ b/app/models/subscription/ManageContactDetailsStatus.scala
@@ -30,6 +30,9 @@ object ManageContactDetailsStatus extends Enum[ManageContactDetailsStatus] with 
   case object SuccessfullyCompleted extends ManageContactDetailsStatus {
     override def entryName = "successfullyCompleted"
   }
+  case object Failed extends ManageContactDetailsStatus {
+    override def entryName = "failed"
+  }
   case object FailedInternalIssueError extends ManageContactDetailsStatus {
     override def entryName = "failedInternalIssueError"
   }

--- a/test/controllers/subscription/manageAccount/ManageContactCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/subscription/manageAccount/ManageContactCheckYourAnswersControllerSpec.scala
@@ -263,11 +263,7 @@ class ManageContactCheckYourAnswersControllerSpec extends SpecBase with SummaryL
             result
           ).value mustEqual controllers.subscription.manageAccount.routes.ManageContactDetailsWaitingRoomController.onPageLoad.url
 
-          // Verify initial status update
           verify(mockSessionRepository).set(org.mockito.ArgumentMatchers.eq(expectedInitialAnswers))
-
-          // Wait for background task and verify final status update
-          Thread.sleep(100) // Give background task time to complete
           verify(mockSessionRepository).set(org.mockito.ArgumentMatchers.eq(expectedFinalAnswers))
         }
       }
@@ -342,7 +338,7 @@ class ManageContactCheckYourAnswersControllerSpec extends SpecBase with SummaryL
         }
       }
 
-      "handle unexpected exception during submission (background processing)" in {
+      "handle unexpected exception during submission" in {
         val mockSessionRepository            = mock[SessionRepository]
         val userAnswers                      = UserAnswers("id")
         val initialUserAnswersWithInProgress = userAnswers.setOrException(ManageContactDetailsStatusPage, ManageContactDetailsStatus.InProgress)
@@ -377,12 +373,11 @@ class ManageContactCheckYourAnswersControllerSpec extends SpecBase with SummaryL
           redirectLocation(result).value mustEqual routes.ManageContactDetailsWaitingRoomController.onPageLoad.url
 
           verify(mockSessionRepository).set(org.mockito.ArgumentMatchers.eq(initialUserAnswersWithInProgress))
-          Thread.sleep(200) // Allow time for background processing
           verify(mockSessionRepository).set(org.mockito.ArgumentMatchers.eq(finalUserAnswersWithFailed))
         }
       }
 
-      "handle InternalIssueError during submission (background processing)" in {
+      "handle InternalIssueError during submission" in {
         val mockSessionRepository            = mock[SessionRepository]
         val userAnswers                      = UserAnswers("id")
         val initialUserAnswersWithInProgress = userAnswers.setOrException(ManageContactDetailsStatusPage, ManageContactDetailsStatus.InProgress)
@@ -422,7 +417,7 @@ class ManageContactCheckYourAnswersControllerSpec extends SpecBase with SummaryL
         }
       }
 
-      "handle other subscription service errors during submission (background processing)" in {
+      "handle other subscription service errors during submission" in {
         val mockSessionRepository            = mock[SessionRepository]
         val userAnswers                      = UserAnswers("id")
         val initialUserAnswersWithInProgress = userAnswers.setOrException(ManageContactDetailsStatusPage, ManageContactDetailsStatus.InProgress)

--- a/test/controllers/subscription/manageAccount/ManageContactCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/subscription/manageAccount/ManageContactCheckYourAnswersControllerSpec.scala
@@ -31,7 +31,7 @@ import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import repositories.SessionRepository
-import services.{ReferenceNumberService, SubscriptionService}
+import services.SubscriptionService
 import uk.gov.hmrc.auth.core.AffinityGroup.Agent
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.Credentials
@@ -201,7 +201,7 @@ class ManageContactCheckYourAnswersControllerSpec extends SpecBase with SummaryL
 
     "onSubmit" should {
 
-      "trigger amend subscription API if all data is available for contact detail" in {
+      "set status to InProgress and redirect to waiting room immediately" in {
         val mockSessionRepository  = mock[SessionRepository]
         val userAnswers            = UserAnswers("id")
         val expectedUpdatedAnswers = userAnswers.setOrException(ManageContactDetailsStatusPage, ManageContactDetailsStatus.InProgress)
@@ -210,23 +210,21 @@ class ManageContactCheckYourAnswersControllerSpec extends SpecBase with SummaryL
         when(mockSessionRepository.set(any())).thenReturn(Future.successful(true))
 
         val application = applicationBuilder(
+          userAnswers = Some(userAnswers),
           subscriptionLocalData = Some(amendSubscription),
           enrolments = enrolments
         )
           .overrides(
-            bind[SubscriptionService].toInstance(mockSubscriptionService),
-            bind[SessionRepository].toInstance(mockSessionRepository)
+            bind[SessionRepository].toInstance(mockSessionRepository),
+            bind[SubscriptionService].toInstance(mockSubscriptionService)
           )
           .build()
 
         running(application) {
-          when(mockSubscriptionService.amendContactOrGroupDetails(any(), any(), any[SubscriptionLocalData])(any()))
-            .thenReturn(Future.successful(Done))
-
           val request = FakeRequest(POST, controllers.subscription.manageAccount.routes.ManageContactCheckYourAnswersController.onSubmit.url)
           val result  = route(application, request).value
 
-          status(result) mustBe SEE_OTHER
+          status(result) mustEqual SEE_OTHER
           redirectLocation(
             result
           ).value mustEqual controllers.subscription.manageAccount.routes.ManageContactDetailsWaitingRoomController.onPageLoad.url
@@ -234,86 +232,11 @@ class ManageContactCheckYourAnswersControllerSpec extends SpecBase with SummaryL
         }
       }
 
-      "trigger amend subscription API for Agent if all data is available for contact detail" in {
-        val mockSessionRepository = mock[SessionRepository]
-        val userAnswers           = UserAnswers("id")
-
-        when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(userAnswers)))
-        when(mockSessionRepository.set(any())).thenReturn(Future.successful(true))
-
-        val application = applicationBuilder(
-          subscriptionLocalData = Some(amendSubscription),
-          enrolments = enrolments
-        )
-          .overrides(
-            bind[SubscriptionService].toInstance(mockSubscriptionService),
-            bind[SessionRepository].toInstance(mockSessionRepository),
-            bind[AuthConnector].toInstance(mockAuthConnector)
-          )
-          .build()
-        when(mockAuthConnector.authorise[AgentRetrievalsType](any(), any())(any(), any()))
-          .thenReturn(
-            Future.successful(
-              Some(id) ~ pillar2AgentEnrolment ~ Some(Agent) ~ Some(User) ~ Some(Credentials(providerId, providerType))
-            )
-          )
-
-        running(application) {
-          when(mockSubscriptionService.amendContactOrGroupDetails(any(), any(), any[SubscriptionLocalData])(any()))
-            .thenReturn(Future.successful(Done))
-          val request = FakeRequest(POST, controllers.subscription.manageAccount.routes.ManageContactCheckYourAnswersController.onSubmit.url)
-          val result  = route(application, request).value
-          status(result) mustBe SEE_OTHER
-          redirectLocation(
-            result
-          ).value mustEqual controllers.subscription.manageAccount.routes.ManageContactDetailsWaitingRoomController.onPageLoad.url
-        }
-      }
-
-      "redirect to error page if POST of amend object fails" in {
-        val mockSessionRepository = mock[SessionRepository]
-        val userAnswers           = UserAnswers("id")
-
-        when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(userAnswers)))
-        when(mockSubscriptionService.amendContactOrGroupDetails(any(), any(), any[SubscriptionLocalData])(any()))
-          .thenReturn(Future.failed(new Exception("Unexpected error")))
-
-        val application = applicationBuilder(
-          subscriptionLocalData = Some(amendSubscription),
-          enrolments = enrolments
-        )
-          .overrides(
-            bind[SubscriptionService].toInstance(mockSubscriptionService),
-            bind[SessionRepository].toInstance(mockSessionRepository)
-          )
-          .build()
-
-        running(application) {
-          val request = FakeRequest(POST, controllers.subscription.manageAccount.routes.ManageContactCheckYourAnswersController.onSubmit.url)
-          val result  = route(application, request).value
-
-          status(result) mustEqual SEE_OTHER
-          redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
-        }
-      }
-
-      "redirect to the journey recovery if no pillar2 reference is found" in {
-        val application = applicationBuilder(subscriptionLocalData = Some(emptySubscriptionLocalData))
-          .build()
-
-        running(application) {
-          val request = FakeRequest(POST, controllers.subscription.manageAccount.routes.ManageContactCheckYourAnswersController.onSubmit.url)
-          val result  = route(application, request).value
-
-          status(result) mustBe SEE_OTHER
-          redirectLocation(result).value mustBe controllers.routes.JourneyRecoveryController.onPageLoad().url
-        }
-
-      }
-
-      "set status to InProgress and redirect to waiting room on successful submission" in {
-        val mockSessionRepository = mock[SessionRepository]
-        val userAnswers           = UserAnswers("id")
+      "update status to SuccessfullyCompleted when background subscription update succeeds" in {
+        val mockSessionRepository  = mock[SessionRepository]
+        val userAnswers            = UserAnswers("id")
+        val expectedInitialAnswers = userAnswers.setOrException(ManageContactDetailsStatusPage, ManageContactDetailsStatus.InProgress)
+        val expectedFinalAnswers   = userAnswers.setOrException(ManageContactDetailsStatusPage, ManageContactDetailsStatus.SuccessfullyCompleted)
 
         when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(userAnswers)))
         when(mockSessionRepository.set(any())).thenReturn(Future.successful(true))
@@ -340,179 +263,23 @@ class ManageContactCheckYourAnswersControllerSpec extends SpecBase with SummaryL
             result
           ).value mustEqual controllers.subscription.manageAccount.routes.ManageContactDetailsWaitingRoomController.onPageLoad.url
 
-          verify(mockSessionRepository).set(any())
-        }
-      }
+          // Verify initial status update
+          verify(mockSessionRepository).set(org.mockito.ArgumentMatchers.eq(expectedInitialAnswers))
 
-      "handle failed status update but successful submission" in {
-        val mockSessionRepository = mock[SessionRepository]
-        val userAnswers           = UserAnswers("id")
-
-        when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(userAnswers)))
-        when(mockSessionRepository.set(any())).thenReturn(Future.successful(false))
-        when(mockSubscriptionService.amendContactOrGroupDetails(any(), any(), any[SubscriptionLocalData])(any()))
-          .thenReturn(Future.successful(Done))
-
-        val application = applicationBuilder(
-          userAnswers = Some(userAnswers),
-          subscriptionLocalData = Some(amendSubscription),
-          enrolments = enrolments
-        )
-          .overrides(
-            bind[SessionRepository].toInstance(mockSessionRepository),
-            bind[SubscriptionService].toInstance(mockSubscriptionService)
-          )
-          .build()
-
-        running(application) {
-          val request = FakeRequest(POST, controllers.subscription.manageAccount.routes.ManageContactCheckYourAnswersController.onSubmit.url)
-          val result  = route(application, request).value
-
-          status(result) mustEqual SEE_OTHER
-          redirectLocation(
-            result
-          ).value mustEqual controllers.subscription.manageAccount.routes.ManageContactDetailsWaitingRoomController.onPageLoad.url
-        }
-      }
-
-      "handle session repository get failure during submission" in {
-        val mockSessionRepository = mock[SessionRepository]
-        when(mockSessionRepository.get(any())).thenReturn(Future.failed(new Exception("Database error")))
-
-        val application = applicationBuilder(
-          subscriptionLocalData = Some(amendSubscription),
-          enrolments = enrolments
-        )
-          .overrides(bind[SessionRepository].toInstance(mockSessionRepository))
-          .build()
-
-        running(application) {
-          val request = FakeRequest(POST, controllers.subscription.manageAccount.routes.ManageContactCheckYourAnswersController.onSubmit.url)
-          val result  = route(application, request).value
-
-          status(result) mustEqual SEE_OTHER
-          redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
-        }
-      }
-
-      "handle missing userAnswers during submission" in {
-        val mockSessionRepository      = mock[SessionRepository]
-        val mockReferenceNumberService = mock[ReferenceNumberService]
-
-        when(mockSessionRepository.get(any())).thenReturn(Future.successful(None))
-        when(mockReferenceNumberService.get(any(), any())).thenReturn(None)
-
-        val application = applicationBuilder(
-          subscriptionLocalData = Some(amendSubscription),
-          enrolments = enrolments
-        )
-          .overrides(
-            bind[SessionRepository].toInstance(mockSessionRepository),
-            bind[ReferenceNumberService].toInstance(mockReferenceNumberService)
-          )
-          .build()
-
-        running(application) {
-          val request = FakeRequest(POST, controllers.subscription.manageAccount.routes.ManageContactCheckYourAnswersController.onSubmit.url)
-          val result  = route(application, request).value
-
-          status(result) mustEqual SEE_OTHER
-          redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+          // Wait for background task and verify final status update
+          Thread.sleep(100) // Give background task time to complete
+          verify(mockSessionRepository).set(org.mockito.ArgumentMatchers.eq(expectedFinalAnswers))
         }
       }
 
       "handle subscription service failure with InternalIssueError" in {
-        val mockSessionRepository = mock[SessionRepository]
-        val userAnswers           = UserAnswers("id")
-
-        when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(userAnswers)))
-        when(mockSubscriptionService.amendContactOrGroupDetails(any(), any(), any[SubscriptionLocalData])(any()))
-          .thenReturn(Future.failed(InternalIssueError))
-
-        val application = applicationBuilder(
-          userAnswers = Some(userAnswers),
-          subscriptionLocalData = Some(amendSubscription),
-          enrolments = enrolments
-        )
-          .overrides(
-            bind[SessionRepository].toInstance(mockSessionRepository),
-            bind[SubscriptionService].toInstance(mockSubscriptionService)
-          )
-          .build()
-
-        running(application) {
-          val request = FakeRequest(POST, controllers.subscription.manageAccount.routes.ManageContactCheckYourAnswersController.onSubmit.url)
-          val result  = route(application, request).value
-
-          status(result) mustEqual SEE_OTHER
-          redirectLocation(result).value mustEqual controllers.routes.ViewAmendSubscriptionFailedController.onPageLoad.url
-        }
-      }
-
-      "handle unexpected exception during submission" in {
-        val mockSessionRepository = mock[SessionRepository]
-        val userAnswers           = UserAnswers("id")
-
-        when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(userAnswers)))
-        when(mockSubscriptionService.amendContactOrGroupDetails(any(), any(), any[SubscriptionLocalData])(any()))
-          .thenReturn(Future.failed(new RuntimeException("Unexpected error")))
-
-        val application = applicationBuilder(
-          userAnswers = Some(userAnswers),
-          subscriptionLocalData = Some(amendSubscription),
-          enrolments = enrolments
-        )
-          .overrides(
-            bind[SessionRepository].toInstance(mockSessionRepository),
-            bind[SubscriptionService].toInstance(mockSubscriptionService)
-          )
-          .build()
-
-        running(application) {
-          val request = FakeRequest(POST, controllers.subscription.manageAccount.routes.ManageContactCheckYourAnswersController.onSubmit.url)
-          val result  = route(application, request).value
-
-          status(result) mustEqual SEE_OTHER
-          redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
-        }
-      }
-
-      "handle missing status in user answers" in {
-        val mockSessionRepository = mock[SessionRepository]
-        val userAnswers           = UserAnswers("id") // No status set
+        val mockSessionRepository  = mock[SessionRepository]
+        val userAnswers            = UserAnswers("id")
+        val expectedInitialAnswers = userAnswers.setOrException(ManageContactDetailsStatusPage, ManageContactDetailsStatus.InProgress)
 
         when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(userAnswers)))
         when(mockSessionRepository.set(any())).thenReturn(Future.successful(true))
         when(mockSubscriptionService.amendContactOrGroupDetails(any(), any(), any[SubscriptionLocalData])(any()))
-          .thenReturn(Future.successful(Done))
-
-        val application = applicationBuilder(
-          userAnswers = Some(userAnswers),
-          subscriptionLocalData = Some(amendSubscription),
-          enrolments = enrolments
-        )
-          .overrides(
-            bind[SessionRepository].toInstance(mockSessionRepository),
-            bind[SubscriptionService].toInstance(mockSubscriptionService)
-          )
-          .build()
-
-        running(application) {
-          val request = FakeRequest(POST, controllers.subscription.manageAccount.routes.ManageContactCheckYourAnswersController.onSubmit.url)
-          val result  = route(application, request).value
-
-          status(result) mustEqual SEE_OTHER
-          redirectLocation(result).value mustEqual
-            controllers.subscription.manageAccount.routes.ManageContactDetailsWaitingRoomController.onPageLoad.url
-        }
-      }
-
-      "handle InternalIssueError during submission" in {
-        val mockSessionRepository = mock[SessionRepository]
-        val userAnswers           = UserAnswers("id")
-
-        when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(userAnswers)))
-        when(mockSubscriptionService.amendContactOrGroupDetails(any(), any(), any[SubscriptionLocalData])(any()))
           .thenReturn(Future.failed(InternalIssueError))
 
         val application = applicationBuilder(
@@ -531,15 +298,22 @@ class ManageContactCheckYourAnswersControllerSpec extends SpecBase with SummaryL
           val result  = route(application, request).value
 
           status(result) mustEqual SEE_OTHER
-          redirectLocation(result).value mustEqual controllers.routes.ViewAmendSubscriptionFailedController.onPageLoad.url
+          redirectLocation(
+            result
+          ).value mustEqual controllers.subscription.manageAccount.routes.ManageContactDetailsWaitingRoomController.onPageLoad.url
+
+          // Verify initial status update
+          verify(mockSessionRepository).set(org.mockito.ArgumentMatchers.eq(expectedInitialAnswers))
         }
       }
 
-      "must redirect to ViewAmendSubscriptionFailed when subscription service returns UnexpectedResponse" in {
-        val mockSessionRepository = mock[SessionRepository]
-        val userAnswers           = UserAnswers("id")
+      "handle subscription service failure with UnexpectedResponse" in {
+        val mockSessionRepository  = mock[SessionRepository]
+        val userAnswers            = UserAnswers("id")
+        val expectedInitialAnswers = userAnswers.setOrException(ManageContactDetailsStatusPage, ManageContactDetailsStatus.InProgress)
 
         when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(userAnswers)))
+        when(mockSessionRepository.set(any())).thenReturn(Future.successful(true))
         when(mockSubscriptionService.amendContactOrGroupDetails(any(), any(), any[SubscriptionLocalData])(any()))
           .thenReturn(Future.failed(UnexpectedResponse))
 
@@ -559,15 +333,68 @@ class ManageContactCheckYourAnswersControllerSpec extends SpecBase with SummaryL
           val result  = route(application, request).value
 
           status(result) mustEqual SEE_OTHER
-          redirectLocation(result).value mustEqual controllers.routes.ViewAmendSubscriptionFailedController.onPageLoad.url
+          redirectLocation(
+            result
+          ).value mustEqual controllers.subscription.manageAccount.routes.ManageContactDetailsWaitingRoomController.onPageLoad.url
+
+          // Verify initial status update
+          verify(mockSessionRepository).set(org.mockito.ArgumentMatchers.eq(expectedInitialAnswers))
         }
       }
 
-      "must redirect to ViewAmendSubscriptionFailed when subscription service returns InternalIssueError" in {
-        val mockSessionRepository = mock[SessionRepository]
-        val userAnswers           = UserAnswers("id")
+      "handle unexpected exception during submission (background processing)" in {
+        val mockSessionRepository            = mock[SessionRepository]
+        val userAnswers                      = UserAnswers("id")
+        val initialUserAnswersWithInProgress = userAnswers.setOrException(ManageContactDetailsStatusPage, ManageContactDetailsStatus.InProgress)
+        val finalUserAnswersWithFailed       = userAnswers.setOrException(ManageContactDetailsStatusPage, ManageContactDetailsStatus.Failed)
 
-        when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(userAnswers)))
+        when(mockSessionRepository.get(userAnswers.id))
+          .thenReturn(Future.successful(Some(userAnswers))) // For onSubmit's initial get
+          .thenReturn(Future.successful(Some(initialUserAnswersWithInProgress))) // For the get inside the background recover block
+
+        when(mockSessionRepository.set(initialUserAnswersWithInProgress)).thenReturn(Future.successful(true))
+        when(mockSessionRepository.set(finalUserAnswersWithFailed)).thenReturn(Future.successful(true))
+
+        when(mockSubscriptionService.amendContactOrGroupDetails(any(), any(), any[SubscriptionLocalData])(any()))
+          .thenReturn(Future.failed(new RuntimeException("Unexpected error")))
+
+        val application = applicationBuilder(
+          userAnswers = Some(userAnswers),
+          subscriptionLocalData = Some(amendSubscription),
+          enrolments = enrolments
+        )
+          .overrides(
+            bind[SessionRepository].toInstance(mockSessionRepository),
+            bind[SubscriptionService].toInstance(mockSubscriptionService)
+          )
+          .build()
+
+        running(application) {
+          val request = FakeRequest(POST, routes.ManageContactCheckYourAnswersController.onSubmit.url)
+          val result  = route(application, request).value
+
+          status(result) mustEqual SEE_OTHER
+          redirectLocation(result).value mustEqual routes.ManageContactDetailsWaitingRoomController.onPageLoad.url
+
+          verify(mockSessionRepository).set(org.mockito.ArgumentMatchers.eq(initialUserAnswersWithInProgress))
+          Thread.sleep(200) // Allow time for background processing
+          verify(mockSessionRepository).set(org.mockito.ArgumentMatchers.eq(finalUserAnswersWithFailed))
+        }
+      }
+
+      "handle InternalIssueError during submission (background processing)" in {
+        val mockSessionRepository            = mock[SessionRepository]
+        val userAnswers                      = UserAnswers("id")
+        val initialUserAnswersWithInProgress = userAnswers.setOrException(ManageContactDetailsStatusPage, ManageContactDetailsStatus.InProgress)
+        val finalUserAnswersWithFailed       = userAnswers.setOrException(ManageContactDetailsStatusPage, ManageContactDetailsStatus.Failed)
+
+        when(mockSessionRepository.get(userAnswers.id))
+          .thenReturn(Future.successful(Some(userAnswers))) // For onSubmit's initial get
+          .thenReturn(Future.successful(Some(initialUserAnswersWithInProgress))) // For the get inside the background recover block
+
+        when(mockSessionRepository.set(initialUserAnswersWithInProgress)).thenReturn(Future.successful(true))
+        when(mockSessionRepository.set(finalUserAnswersWithFailed)).thenReturn(Future.successful(true))
+
         when(mockSubscriptionService.amendContactOrGroupDetails(any(), any(), any[SubscriptionLocalData])(any()))
           .thenReturn(Future.failed(InternalIssueError))
 
@@ -583,21 +410,33 @@ class ManageContactCheckYourAnswersControllerSpec extends SpecBase with SummaryL
           .build()
 
         running(application) {
-          val request = FakeRequest(POST, controllers.subscription.manageAccount.routes.ManageContactCheckYourAnswersController.onSubmit.url)
+          val request = FakeRequest(POST, routes.ManageContactCheckYourAnswersController.onSubmit.url)
           val result  = route(application, request).value
 
           status(result) mustEqual SEE_OTHER
-          redirectLocation(result).value mustEqual controllers.routes.ViewAmendSubscriptionFailedController.onPageLoad.url
+          redirectLocation(result).value mustEqual routes.ManageContactDetailsWaitingRoomController.onPageLoad.url
+
+          verify(mockSessionRepository).set(org.mockito.ArgumentMatchers.eq(initialUserAnswersWithInProgress))
+          Thread.sleep(200) // Allow time for background processing
+          verify(mockSessionRepository).set(org.mockito.ArgumentMatchers.eq(finalUserAnswersWithFailed))
         }
       }
 
-      "must redirect to JourneyRecovery when subscription service returns any other error" in {
-        val mockSessionRepository = mock[SessionRepository]
-        val userAnswers           = UserAnswers("id")
+      "handle other subscription service errors during submission (background processing)" in {
+        val mockSessionRepository            = mock[SessionRepository]
+        val userAnswers                      = UserAnswers("id")
+        val initialUserAnswersWithInProgress = userAnswers.setOrException(ManageContactDetailsStatusPage, ManageContactDetailsStatus.InProgress)
+        val finalUserAnswersWithFailed       = userAnswers.setOrException(ManageContactDetailsStatusPage, ManageContactDetailsStatus.Failed)
 
-        when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(userAnswers)))
+        when(mockSessionRepository.get(userAnswers.id))
+          .thenReturn(Future.successful(Some(userAnswers))) // For onSubmit's initial get
+          .thenReturn(Future.successful(Some(initialUserAnswersWithInProgress))) // For the get inside the background recover block
+
+        when(mockSessionRepository.set(initialUserAnswersWithInProgress)).thenReturn(Future.successful(true))
+        when(mockSessionRepository.set(finalUserAnswersWithFailed)).thenReturn(Future.successful(true))
+
         when(mockSubscriptionService.amendContactOrGroupDetails(any(), any(), any[SubscriptionLocalData])(any()))
-          .thenReturn(Future.failed(new RuntimeException("Other error")))
+          .thenReturn(Future.failed(UnexpectedResponse)) // Example of another error
 
         val application = applicationBuilder(
           userAnswers = Some(userAnswers),
@@ -611,11 +450,15 @@ class ManageContactCheckYourAnswersControllerSpec extends SpecBase with SummaryL
           .build()
 
         running(application) {
-          val request = FakeRequest(POST, controllers.subscription.manageAccount.routes.ManageContactCheckYourAnswersController.onSubmit.url)
+          val request = FakeRequest(POST, routes.ManageContactCheckYourAnswersController.onSubmit.url)
           val result  = route(application, request).value
 
           status(result) mustEqual SEE_OTHER
-          redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+          redirectLocation(result).value mustEqual routes.ManageContactDetailsWaitingRoomController.onPageLoad.url
+
+          verify(mockSessionRepository).set(org.mockito.ArgumentMatchers.eq(initialUserAnswersWithInProgress))
+          Thread.sleep(200) // Allow time for background processing
+          verify(mockSessionRepository).set(org.mockito.ArgumentMatchers.eq(finalUserAnswersWithFailed))
         }
       }
     }

--- a/test/controllers/subscription/manageAccount/ManageContactDetailsWaitingRoomControllerSpec.scala
+++ b/test/controllers/subscription/manageAccount/ManageContactDetailsWaitingRoomControllerSpec.scala
@@ -96,9 +96,9 @@ class ManageContactDetailsWaitingRoomControllerSpec extends SpecBase with Before
         }
       }
 
-      "redirect to error page when status is Failed" in {
+      "redirect to error page when status is FailException" in {
         val userAnswers = UserAnswers("id")
-          .setOrException(ManageContactDetailsStatusPage, Failed)
+          .setOrException(ManageContactDetailsStatusPage, FailException)
 
         when(mockSessionRepository.get(any()))
           .thenReturn(Future.successful(Some(userAnswers)))
@@ -118,9 +118,9 @@ class ManageContactDetailsWaitingRoomControllerSpec extends SpecBase with Before
         }
       }
 
-      "redirect to error page when status is unexpected" in {
+      "redirect to error page when status is FailedInternalIssueError" in {
         val userAnswers = UserAnswers("id")
-          .setOrException(ManageContactDetailsStatusPage, FailException)
+          .setOrException(ManageContactDetailsStatusPage, FailedInternalIssueError)
 
         when(mockSessionRepository.get(any()))
           .thenReturn(Future.successful(Some(userAnswers)))


### PR DESCRIPTION
Updates "Manage Contact Details" to process subscription amendments in the background.

*   Users are now immediately sent to a waiting room after submitting contact changes.
*   The subscription update happens in the background.
    *   Success: Session status becomes `SuccessfullyCompleted`.
    *   Failure: Session status becomes  one of the Failed statuses.
*   The waiting room polls this session status:
    *   `SuccessfullyCompleted` -> Dashboard.
    *   `InProgress` -> Spinner.
    *   `FailException` (or other specific errors) -> Error page.
*   Tests for `ManageContactCheckYourAnswersController` and `ManageContactDetailsWaitingRoomController` updated to reflect this new flow and status handling.