### PR TITLE
PIL-2174 - Remove reserach link from dashboard and registration view

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -99,7 +99,6 @@ class FrontendAppConfig @Inject() (configuration: Configuration, servicesConfig:
   val opsBaseUrl:             String  = servicesConfig.baseUrl("ops")
   val opsStartUrl:            String  = configuration.get[String]("microservice.services.ops.startUrl")
   val enablePayByBankAccount: Boolean = configuration.get[Boolean]("features.enablePayByBankAccount")
-  val pillar2ResearchUrl:     String  = configuration.get[String]("urls.pillar2Research")
 
   def transactionHistoryEndDate: LocalDate = {
     val date = configuration.get[String]("features.transactionHistoryEndDate")

--- a/app/views/DashboardView.scala.html
+++ b/app/views/DashboardView.scala.html
@@ -90,13 +90,4 @@
     @paragraphMessageWithLink(linkMessage = messages("dashboard.link"), linkUrl = "https://www.gov.uk/government/consultations/draft-guidance-multinational-top-up-tax-and-domestic-top-up-tax", linkClass = "govuk-link", linkRel = "noopener noreferrer", target = "_blank", message2 = Some(messages("dashboard.p2")))
   }
 
-  @h2(messages("research.heading"), size = "m", extraClasses = Seq("pillar2-research-heading"))
-  @paragraphBody(message = messages("research.body"), classes = "govuk-body pillar2-research-body")
-  @paragraphBodyLink(
-    message = messages("research.link"),
-    linkUrl = appConfig.pillar2ResearchUrl,
-    linkClass = "govuk-link pillar2-research-link",
-    target = Some("_blank")
-  )
-
 }

--- a/app/views/registrationview/RegistrationConfirmationView.scala.html
+++ b/app/views/registrationview/RegistrationConfirmationView.scala.html
@@ -66,13 +66,4 @@
     fullStop = true
   )))
 
-  @heading(messages("research.heading"), "govuk-heading-m govuk-!-margin-top-5 pillar2-research-heading", "h2")
-  @paragraphBody(message = messages("research.body"), classes = "govuk-body pillar2-research-body")
-  @paragraphBodyLink(
-    message = messages("research.link"),
-    linkUrl = appConfig.pillar2ResearchUrl,
-    linkClass = "govuk-link pillar2-research-link",
-    target = Some("_blank")
-  )
-
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -143,7 +143,6 @@ urls {
   eacdHomePage = "/report-pillar2-top-up-taxes/bta/eacd"
   startPagePillar2 = "https://www.gov.uk/guidance/report-pillar-2-top-up-taxes"
   asaHomePage = "/report-pillar2-top-up-taxes/asa/home"
-  pillar2Research = "https://docs.google.com/forms/d/e/1FAIpQLSfFWEj9sG3kD23gj-yKU51vpp5m6BR1Gql9VkMaYgSpzKRWNQ/viewform?usp=dialog"
 }
 
 enrolment {

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1543,12 +1543,3 @@ manageContactDetails.title = Submitting your contact details
 manageContactDetails.heading = Submitting your contact details
 manageContactDetails.h1 = Submitting your contact details
 manageContactDetails.h2 = Do not press back in your browser or leave this page. It may take up to a minute to process this change.
-
-###############################################
-#
-# Pillar 2 Research
-#
-###############################################
-research.heading = Take part in Pillar 2 research
-research.body = Help us improve this online service by taking part in user research.
-research.link = Register for Pillar 2 user research (opens in a new tab)

--- a/test/views/DashboardViewSpec.scala
+++ b/test/views/DashboardViewSpec.scala
@@ -149,22 +149,6 @@ class DashboardViewSpec extends ViewSpecBase {
         "HMRC are currently delivering this service on a phased approach. We’ll release the tools that you need to submit your returns before the due date for reporting."
       )
     }
-
-    "have a Pillar 2 Research heading" in {
-      organisationDashboardView.getElementsByClass("pillar2-research-heading").text must be("Take part in Pillar 2 research")
-    }
-
-    "have a Pillar 2 Research paragraph" in {
-      organisationDashboardView.getElementsByClass("pillar2-research-body").last.text must be(
-        "Help us improve this online service by taking part in user research."
-      )
-    }
-
-    "have a link to the Pillar 2 Research page that opens in a new tab" in {
-      organisationDashboardView.getElementsByClass("pillar2-research-link").text must be("Register for Pillar 2 user research (opens in a new tab)")
-      organisationDashboardView.getElementsByClass("pillar2-research-link").attr("target") must be("_blank")
-      organisationDashboardView.getElementsByClass("pillar2-research-link").attr("href")   must be(appConfig.pillar2ResearchUrl)
-    }
   }
 
   "Dashboard View for Agent" should {
@@ -271,22 +255,6 @@ class DashboardViewSpec extends ViewSpecBase {
         "HMRC are currently delivering this service on a phased approach. We’ll release the tools that you need to submit your returns before the due date for reporting."
       )
 
-    }
-
-    "have a Pillar 2 Research heading" in {
-      agentDashboardView.getElementsByClass("pillar2-research-heading").text must be("Take part in Pillar 2 research")
-    }
-
-    "have a Pillar 2 Research paragraph" in {
-      agentDashboardView.getElementsByClass("pillar2-research-body").last.text must be(
-        "Help us improve this online service by taking part in user research."
-      )
-    }
-
-    "have a link to the Pillar 2 Research page that opens in a new tab" in {
-      agentDashboardView.getElementsByClass("pillar2-research-link").text must be("Register for Pillar 2 user research (opens in a new tab)")
-      agentDashboardView.getElementsByClass("pillar2-research-link").attr("target") must be("_blank")
-      agentDashboardView.getElementsByClass("pillar2-research-link").attr("href")   must be(appConfig.pillar2ResearchUrl)
     }
   }
 }

--- a/test/views/registration/RegistrationConfirmationViewSpec.scala
+++ b/test/views/registration/RegistrationConfirmationViewSpec.scala
@@ -87,20 +87,5 @@ class RegistrationConfirmationViewSpec extends ViewSpecBase {
       )
     }
 
-    "have a Pillar 2 Research heading" in {
-      viewDomestic.getElementsByClass("pillar2-research-heading").text must be("Take part in Pillar 2 research")
-    }
-
-    "have a Pillar 2 Research paragraph" in {
-      viewDomestic.getElementsByClass("pillar2-research-body").last.text must be(
-        "Help us improve this online service by taking part in user research."
-      )
-    }
-
-    "have a link to the Pillar 2 Research page that opens in a new tab" in {
-      viewDomestic.getElementsByClass("pillar2-research-link").text           must be("Register for Pillar 2 user research (opens in a new tab)")
-      viewDomestic.getElementsByClass("pillar2-research-link").attr("target") must be("_blank")
-      viewDomestic.getElementsByClass("pillar2-research-link").attr("href")   must be(appConfig.pillar2ResearchUrl)
-    }
   }
 }


### PR DESCRIPTION
This PR removes the section for the Pillar 2 user research survey from the dashboard and registration confirmation pages.

This change is intended to be temporary. This PR can be reverted to re-introduce the section in the future with an updated link.