### PR TITLE
PIL-2232 - Use cached organisationName from SubscriptionLocalData

### DIFF
--- a/app/controllers/actions/SubscriptionDataRequiredAction.scala
+++ b/app/controllers/actions/SubscriptionDataRequiredAction.scala
@@ -29,8 +29,8 @@ class SubscriptionDataRequiredActionImpl @Inject() (implicit val executionContex
     with Logging {
 
   override protected def refine[A](request: OptionalSubscriptionDataRequest[A]): Future[Either[Result, SubscriptionDataRequest[A]]] =
-    (request.maybeSubscriptionLocalData, request.organisationName) match {
-      case (Some(subscriptionData), Some(organisationName)) =>
+    request.maybeSubscriptionLocalData match {
+      case Some(subscriptionData) =>
         Future.successful(
           Right(
             SubscriptionDataRequest(
@@ -38,16 +38,12 @@ class SubscriptionDataRequiredActionImpl @Inject() (implicit val executionContex
               request.userId,
               subscriptionData,
               request.enrolments,
-              request.isAgent,
-              organisationName
+              request.isAgent
             )
           )
         )
-      case (None, _) =>
+      case None =>
         logger.warn(s"subscription data not found")
-        Future.successful(Left(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad())))
-      case (_, None) =>
-        logger.warn(s"organisation name not found")
         Future.successful(Left(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad())))
     }
 

--- a/app/controllers/actions/SubscriptionDataRetrievalAction.scala
+++ b/app/controllers/actions/SubscriptionDataRetrievalAction.scala
@@ -37,16 +37,12 @@ class SubscriptionDataRetrievalActionImpl @Inject() (
 
     for {
       maybeSubscriptionLocalData <- subscriptionConnector.getSubscriptionCache(request.userId)
-      organisationName <- subscriptionConnector
-                            .readSubscription(maybeSubscriptionLocalData.map(_.plrReference).getOrElse(""))
-                            .map(_.map(_.upeDetails.organisationName))
     } yield OptionalSubscriptionDataRequest(
       request.request,
       request.userId,
       maybeSubscriptionLocalData,
       request.enrolments,
-      request.isAgent,
-      organisationName
+      request.isAgent
     )
   }
 }

--- a/app/controllers/subscription/manageAccount/AddSecondaryContactController.scala
+++ b/app/controllers/subscription/manageAccount/AddSecondaryContactController.scala
@@ -53,7 +53,14 @@ class AddSecondaryContactController @Inject() (
         contactName           <- subscriptionLocalData.get(SubPrimaryContactNamePage)
       } yield {
         val form: Form[Boolean] = formProvider(contactName)
-        Ok(view(form.fill(subscriptionLocalData.subAddSecondaryContact), contactName, request.isAgent, request.organisationName))
+        Ok(
+          view(
+            form.fill(subscriptionLocalData.subAddSecondaryContact),
+            contactName,
+            request.isAgent,
+            request.maybeSubscriptionLocalData.flatMap(_.organisationName)
+          )
+        )
       })
         .getOrElse(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad()))
     }
@@ -67,7 +74,8 @@ class AddSecondaryContactController @Inject() (
           form
             .bindFromRequest()
             .fold(
-              formWithErrors => Future.successful(BadRequest(view(formWithErrors, contactName, request.isAgent, Some(request.organisationName)))),
+              formWithErrors =>
+                Future.successful(BadRequest(view(formWithErrors, contactName, request.isAgent, request.subscriptionLocalData.organisationName))),
               {
                 case wantsToNominateSecondaryContact @ true =>
                   for {

--- a/app/controllers/subscription/manageAccount/CaptureSubscriptionAddressController.scala
+++ b/app/controllers/subscription/manageAccount/CaptureSubscriptionAddressController.scala
@@ -52,7 +52,7 @@ class CaptureSubscriptionAddressController @Inject() (
     (identify andThen getData) { implicit request =>
       val preparedForm =
         request.maybeSubscriptionLocalData.flatMap(_.get(SubRegisteredAddressPage).map(address => form.fill(address))).getOrElse(form)
-      Ok(view(preparedForm, countryOptions.options(), request.isAgent, request.organisationName))
+      Ok(view(preparedForm, countryOptions.options(), request.isAgent, request.maybeSubscriptionLocalData.flatMap(_.organisationName)))
     }
 
   def onSubmit(): Action[AnyContent] =
@@ -61,7 +61,9 @@ class CaptureSubscriptionAddressController @Inject() (
         .bindFromRequest()
         .fold(
           formWithErrors =>
-            Future.successful(BadRequest(view(formWithErrors, countryOptions.options(), request.isAgent, Some(request.organisationName)))),
+            Future.successful(
+              BadRequest(view(formWithErrors, countryOptions.options(), request.isAgent, request.subscriptionLocalData.organisationName))
+            ),
           value =>
             for {
               updatedAnswers <-

--- a/app/controllers/subscription/manageAccount/ContactByTelephoneController.scala
+++ b/app/controllers/subscription/manageAccount/ContactByTelephoneController.scala
@@ -54,7 +54,7 @@ class ContactByTelephoneController @Inject() (
             case Some(v) => form.fill(v)
             case None    => form
           }
-          Ok(view(preparedForm, contactName, request.isAgent, request.organisationName))
+          Ok(view(preparedForm, contactName, request.isAgent, request.subscriptionLocalData.organisationName))
 
         }
         .getOrElse(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad()))
@@ -70,7 +70,8 @@ class ContactByTelephoneController @Inject() (
           form
             .bindFromRequest()
             .fold(
-              formWithErrors => Future.successful(BadRequest(view(formWithErrors, contactName, request.isAgent, request.organisationName))),
+              formWithErrors =>
+                Future.successful(BadRequest(view(formWithErrors, contactName, request.isAgent, request.subscriptionLocalData.organisationName))),
               {
                 case nominatePrimaryContactNumber @ true =>
                   for {

--- a/app/controllers/subscription/manageAccount/ContactCaptureTelephoneDetailsController.scala
+++ b/app/controllers/subscription/manageAccount/ContactCaptureTelephoneDetailsController.scala
@@ -56,7 +56,7 @@ class ContactCaptureTelephoneDetailsController @Inject() (
           case Some(v) => form.fill(v)
           case None    => form
         }
-        Ok(view(preparedForm, contactName, request.isAgent, request.organisationName))
+        Ok(view(preparedForm, contactName, request.isAgent, request.maybeSubscriptionLocalData.flatMap(_.organisationName)))
 
       })
         .getOrElse(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad()))
@@ -72,7 +72,8 @@ class ContactCaptureTelephoneDetailsController @Inject() (
           form
             .bindFromRequest()
             .fold(
-              formWithErrors => Future.successful(BadRequest(view(formWithErrors, contactName, request.isAgent, Some(request.organisationName)))),
+              formWithErrors =>
+                Future.successful(BadRequest(view(formWithErrors, contactName, request.isAgent, request.subscriptionLocalData.organisationName))),
               value =>
                 for {
                   updatedAnswers <-

--- a/app/controllers/subscription/manageAccount/ContactEmailAddressController.scala
+++ b/app/controllers/subscription/manageAccount/ContactEmailAddressController.scala
@@ -51,7 +51,14 @@ class ContactEmailAddressController @Inject() (
             .get(SubPrimaryContactNamePage)
             .map { contactName =>
               val form = formProvider(contactName)
-              Ok(view(form.fill(subscriptionLocalData.subPrimaryEmail), contactName, request.isAgent, request.organisationName))
+              Ok(
+                view(
+                  form.fill(subscriptionLocalData.subPrimaryEmail),
+                  contactName,
+                  request.isAgent,
+                  request.maybeSubscriptionLocalData.flatMap(_.organisationName)
+                )
+              )
             }
         }
         .getOrElse(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad()))
@@ -67,7 +74,8 @@ class ContactEmailAddressController @Inject() (
           form
             .bindFromRequest()
             .fold(
-              formWithErrors => Future.successful(BadRequest(view(formWithErrors, contactName, request.isAgent, Some(request.organisationName)))),
+              formWithErrors =>
+                Future.successful(BadRequest(view(formWithErrors, contactName, request.isAgent, request.subscriptionLocalData.organisationName))),
               value =>
                 for {
                   updatedAnswers <-

--- a/app/controllers/subscription/manageAccount/ContactNameComplianceController.scala
+++ b/app/controllers/subscription/manageAccount/ContactNameComplianceController.scala
@@ -52,7 +52,7 @@ class ContactNameComplianceController @Inject() (
         case Some(v) => form.fill(v)
         case None    => form
       }
-      Ok(view(preparedForm, request.isAgent, request.organisationName))
+      Ok(view(preparedForm, request.isAgent, request.maybeSubscriptionLocalData.flatMap(_.organisationName)))
     }
 
   def onSubmit(): Action[AnyContent] =
@@ -60,7 +60,7 @@ class ContactNameComplianceController @Inject() (
       form
         .bindFromRequest()
         .fold(
-          formWithErrors => Future.successful(BadRequest(view(formWithErrors, request.isAgent, Some(request.organisationName)))),
+          formWithErrors => Future.successful(BadRequest(view(formWithErrors, request.isAgent, request.subscriptionLocalData.organisationName))),
           value =>
             for {
               updatedAnswers <-

--- a/app/controllers/subscription/manageAccount/ManageContactCheckYourAnswersController.scala
+++ b/app/controllers/subscription/manageAccount/ManageContactCheckYourAnswersController.scala
@@ -86,7 +86,9 @@ class ManageContactCheckYourAnswersController @Inject() (
               rows = Seq(ContactCorrespondenceAddressSummary.row(countryOptions)).flatten
             )
 
-            Future.successful(Ok(view(primaryContactList, secondaryContactList, address, request.isAgent, request.organisationName)))
+            Future.successful(
+              Ok(view(primaryContactList, secondaryContactList, address, request.isAgent, request.subscriptionLocalData.organisationName))
+            )
         }
     }
   }

--- a/app/controllers/subscription/manageAccount/SecondaryContactEmailController.scala
+++ b/app/controllers/subscription/manageAccount/SecondaryContactEmailController.scala
@@ -54,7 +54,7 @@ class SecondaryContactEmailController @Inject() (
             case Some(v) => form.fill(v)
             case None    => form
           }
-          Ok(view(preparedForm, contactName, request.isAgent, request.organisationName))
+          Ok(view(preparedForm, contactName, request.isAgent, request.subscriptionLocalData.organisationName))
 
         }
         .getOrElse(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad()))
@@ -70,7 +70,8 @@ class SecondaryContactEmailController @Inject() (
           form
             .bindFromRequest()
             .fold(
-              formWithErrors => Future.successful(BadRequest(view(formWithErrors, contactName, request.isAgent, request.organisationName))),
+              formWithErrors =>
+                Future.successful(BadRequest(view(formWithErrors, contactName, request.isAgent, request.subscriptionLocalData.organisationName))),
               value =>
                 for {
                   updatedAnswers <- Future.fromTry(request.subscriptionLocalData.set(SubSecondaryEmailPage, value))

--- a/app/controllers/subscription/manageAccount/SecondaryContactNameController.scala
+++ b/app/controllers/subscription/manageAccount/SecondaryContactNameController.scala
@@ -53,7 +53,7 @@ class SecondaryContactNameController @Inject() (
         case Some(v) => form.fill(v)
         case None    => form
       }
-      Ok(view(preparedForm, request.isAgent, request.organisationName))
+      Ok(view(preparedForm, request.isAgent, request.subscriptionLocalData.organisationName))
     }
 
   def onSubmit(): Action[AnyContent] =
@@ -61,7 +61,7 @@ class SecondaryContactNameController @Inject() (
       form
         .bindFromRequest()
         .fold(
-          formWithErrors => Future.successful(BadRequest(view(formWithErrors, request.isAgent, request.organisationName))),
+          formWithErrors => Future.successful(BadRequest(view(formWithErrors, request.isAgent, request.subscriptionLocalData.organisationName))),
           value =>
             for {
               updatedAnswers <- Future.fromTry(request.subscriptionLocalData.set(SubSecondaryContactNamePage, value))

--- a/app/controllers/subscription/manageAccount/SecondaryTelephoneController.scala
+++ b/app/controllers/subscription/manageAccount/SecondaryTelephoneController.scala
@@ -55,7 +55,7 @@ class SecondaryTelephoneController @Inject() (
           case Some(v) => form.fill(v)
           case None    => form
         }
-        Ok(view(preparedForm, contactName, request.isAgent, request.organisationName))
+        Ok(view(preparedForm, contactName, request.isAgent, request.subscriptionLocalData.organisationName))
 
       })
         .getOrElse(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad()))
@@ -71,7 +71,8 @@ class SecondaryTelephoneController @Inject() (
           form
             .bindFromRequest()
             .fold(
-              formWithErrors => Future.successful(BadRequest(view(formWithErrors, contactName, request.isAgent, request.organisationName))),
+              formWithErrors =>
+                Future.successful(BadRequest(view(formWithErrors, contactName, request.isAgent, request.subscriptionLocalData.organisationName))),
               value =>
                 for {
                   updatedAnswers <- Future.fromTry(request.subscriptionLocalData.set(SubSecondaryCapturePhonePage, value))

--- a/app/controllers/subscription/manageAccount/SecondaryTelephonePreferenceController.scala
+++ b/app/controllers/subscription/manageAccount/SecondaryTelephonePreferenceController.scala
@@ -56,7 +56,7 @@ class SecondaryTelephonePreferenceController @Inject() (
           case Some(v) => form.fill(v)
           case None    => form
         }
-        Ok(view(preparedForm, contactName, request.isAgent, request.organisationName))
+        Ok(view(preparedForm, contactName, request.isAgent, request.maybeSubscriptionLocalData.flatMap(_.organisationName)))
 
       })
         .getOrElse(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad()))
@@ -72,7 +72,8 @@ class SecondaryTelephonePreferenceController @Inject() (
           form
             .bindFromRequest()
             .fold(
-              formWithErrors => Future.successful(BadRequest(view(formWithErrors, contactName, request.isAgent, Some(request.organisationName)))),
+              formWithErrors =>
+                Future.successful(BadRequest(view(formWithErrors, contactName, request.isAgent, request.subscriptionLocalData.organisationName))),
               {
                 case nominatedSecondaryContactNumber @ true =>
                   for {

--- a/app/models/requests/DataRequest.scala
+++ b/app/models/requests/DataRequest.scala
@@ -45,8 +45,7 @@ final case class OptionalSubscriptionDataRequest[A](
   userId:                     String,
   maybeSubscriptionLocalData: Option[SubscriptionLocalData],
   enrolments:                 Set[Enrolment],
-  isAgent:                    Boolean = false,
-  organisationName:           Option[String]
+  isAgent:                    Boolean = false
 ) extends WrappedRequest[A](request)
 
 final case class SubscriptionDataRequest[A](
@@ -54,8 +53,7 @@ final case class SubscriptionDataRequest[A](
   userId:                String,
   subscriptionLocalData: SubscriptionLocalData,
   enrolments:            Set[Enrolment],
-  isAgent:               Boolean = false,
-  organisationName:      String
+  isAgent:               Boolean = false
 ) extends WrappedRequest[A](request)
 
 final case class SessionDataRequest[A](

--- a/app/models/subscription/SubscriptionLocalData.scala
+++ b/app/models/subscription/SubscriptionLocalData.scala
@@ -36,7 +36,8 @@ case class SubscriptionLocalData(
   subSecondaryEmail:           Option[String],
   subSecondaryCapturePhone:    Option[String],
   subSecondaryPhonePreference: Option[Boolean],
-  subRegisteredAddress:        NonUKAddress
+  subRegisteredAddress:        NonUKAddress,
+  organisationName:            Option[String]
 ) {
 
   private lazy val jsObj = Json.toJsObject(this)

--- a/app/views/subscriptionview/manageAccount/ContactByTelephoneView.scala.html
+++ b/app/views/subscriptionview/manageAccount/ContactByTelephoneView.scala.html
@@ -29,7 +29,7 @@
 )
 
 
-@(form: Form[_], userName: String, isAgent: Boolean, organisationName: String)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(form: Form[_], userName: String, isAgent: Boolean, organisationName: Option[String])(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @layout(pageTitle = title(form, messages("contactByTelephone.title"))) {
 
@@ -41,7 +41,7 @@
         }
 
         @if(isAgent) {
-            @sectionHeader(organisationName)
+            @sectionHeader(organisationName.getOrElse(messages("contactByTelephone.heading.caption")))
         } else {
             @sectionHeader(messages("contactByTelephone.heading.caption"))
         }

--- a/app/views/subscriptionview/manageAccount/ManageContactCheckYourAnswersView.scala.html
+++ b/app/views/subscriptionview/manageAccount/ManageContactCheckYourAnswersView.scala.html
@@ -27,13 +27,13 @@
         h2: HeadingH2
 )
 
-@(listPrimary: SummaryList, listSecondary: SummaryList, address: SummaryList, isAgent: Boolean, organisationName: String)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(listPrimary: SummaryList, listSecondary: SummaryList, address: SummaryList, isAgent: Boolean, organisationName: Option[String])(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @layout(pageTitle = titleNoForm(messages("manageContactCheckYourAnswers.title")), showBackLink = true) {
     @formHelper(action = controllers.subscription.manageAccount.routes.ManageContactCheckYourAnswersController.onSubmit) {
 
-            @if(isAgent) {
-                @sectionHeader(organisationName)
+            @if(isAgent && organisationName.isDefined) {
+                @sectionHeader(organisationName.get)
             }
             @h1(messages("manageContactCheckYourAnswers.heading.caption"), classes = "govuk-heading-l")
 

--- a/app/views/subscriptionview/manageAccount/SecondaryContactEmailView.scala.html
+++ b/app/views/subscriptionview/manageAccount/SecondaryContactEmailView.scala.html
@@ -28,7 +28,7 @@
         govukButton: GovukButton
 )
 
-@(form: Form[_], secondaryContactName: String, isAgent: Boolean, organisationName: String)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(form: Form[_], secondaryContactName: String, isAgent: Boolean, organisationName: Option[String])(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @layout(pageTitle = title(form, messages("secondaryContactEmail.title"))) {
 
@@ -39,8 +39,8 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @if(isAgent) {
-            @sectionHeader(organisationName)
+        @if(isAgent && organisationName.isDefined) {
+            @sectionHeader(organisationName.get)
         } else {
             @sectionHeader(messages("secondaryContactEmail.heading.caption"))
         }

--- a/app/views/subscriptionview/manageAccount/SecondaryContactNameView.scala.html
+++ b/app/views/subscriptionview/manageAccount/SecondaryContactNameView.scala.html
@@ -28,7 +28,7 @@
         govukButton: GovukButton
 )
 
-@(form: Form[_], isAgent: Boolean, organisationName: String)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(form: Form[_], isAgent: Boolean, organisationName: Option[String])(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @layout(pageTitle = title(form, messages("secondaryContactName.title"))) {
 
@@ -39,8 +39,8 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @if(isAgent) {
-            @sectionHeader(organisationName)
+        @if(isAgent && organisationName.isDefined) {
+            @sectionHeader(organisationName.get)
         } else {
             @sectionHeader(messages("taskList.task.contact.heading"))
         }

--- a/app/views/subscriptionview/manageAccount/SecondaryTelephoneView.scala.html
+++ b/app/views/subscriptionview/manageAccount/SecondaryTelephoneView.scala.html
@@ -28,7 +28,7 @@
         govukButton: GovukButton
 )
 
-@(form: Form[_], userName: String, isAgent: Boolean, organisationName: String)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(form: Form[_], userName: String, isAgent: Boolean, organisationName: Option[String])(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @layout(pageTitle = title(form, messages("captureTelephoneDetails.title"))) {
 
@@ -39,7 +39,7 @@
         }
 
         @if(isAgent) {
-            @sectionHeader(organisationName)
+            @sectionHeader(organisationName.getOrElse(messages("secondaryContactEmail.heading.caption")))
         } else {
             @sectionHeader(messages("secondaryContactEmail.heading.caption"))
         }

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -164,7 +164,7 @@ trait SpecBase
         bind[IdentifierAction].qualifiedWith("EnrolmentIdentifier").to[FakeIdentifierAction],
         bind[IdentifierAction].qualifiedWith("ASAEnrolmentIdentifier").to[FakeIdentifierAction],
         bind[DataRetrievalAction].toInstance(new FakeDataRetrievalAction(userAnswers)),
-        bind[SubscriptionDataRetrievalAction].toInstance(new FakeSubscriptionDataRetrievalAction(subscriptionLocalData, organisationName)),
+        bind[SubscriptionDataRetrievalAction].toInstance(new FakeSubscriptionDataRetrievalAction(subscriptionLocalData)),
         bind[SessionDataRetrievalAction].toInstance(new FakeSessionDataRetrievalAction(userAnswers))
       )
 

--- a/test/controllers/actions/FakeDataRetrievalAction.scala
+++ b/test/controllers/actions/FakeDataRetrievalAction.scala
@@ -32,8 +32,7 @@ class FakeDataRetrievalAction(dataToReturn: Option[UserAnswers]) extends DataRet
 }
 
 class FakeSubscriptionDataRetrievalAction(
-  subscriptionData: Option[SubscriptionLocalData],
-  organisationName: Option[String]
+  subscriptionData: Option[SubscriptionLocalData]
 ) extends SubscriptionDataRetrievalAction {
 
   override protected def transform[A](request: IdentifierRequest[A]): Future[OptionalSubscriptionDataRequest[A]] =
@@ -43,8 +42,7 @@ class FakeSubscriptionDataRetrievalAction(
         request.userId,
         subscriptionData,
         request.enrolments,
-        request.isAgent,
-        organisationName
+        request.isAgent
       )
     )
 

--- a/test/controllers/subscription/manageAccount/ContactByTelephoneControllerSpec.scala
+++ b/test/controllers/subscription/manageAccount/ContactByTelephoneControllerSpec.scala
@@ -62,7 +62,7 @@ class ContactByTelephoneControllerSpec extends SpecBase {
         val view = application.injector.instanceOf[ContactByTelephoneView]
         status(result) mustEqual OK
 
-        contentAsString(result) mustEqual view(formProvider.fill(false), "name", isAgent = false, "ABC Intl")(
+        contentAsString(result) mustEqual view(formProvider.fill(false), "name", isAgent = false, Some("ABC Intl"))(
           request,
           applicationConfig,
           messages(application)
@@ -90,7 +90,7 @@ class ContactByTelephoneControllerSpec extends SpecBase {
 
         val view = application.injector.instanceOf[ContactByTelephoneView]
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(formProvider.fill(true), "name", isAgent = false, "ABC Intl")(
+        contentAsString(result) mustEqual view(formProvider.fill(true), "name", isAgent = false, Some("ABC Intl"))(
           request,
           applicationConfig,
           messages(application)
@@ -147,7 +147,7 @@ class ContactByTelephoneControllerSpec extends SpecBase {
         val result  = route(application, request).value
         val view    = application.injector.instanceOf[ContactByTelephoneView]
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(formProvider.fill(false), "name", isAgent = false, "ABC Intl")(
+        contentAsString(result) mustEqual view(formProvider.fill(false), "name", isAgent = false, Some("ABC Intl"))(
           request,
           applicationConfig,
           messages(application)
@@ -181,7 +181,7 @@ class ContactByTelephoneControllerSpec extends SpecBase {
         val result  = route(application, request).value
         val view    = application.injector.instanceOf[ContactByTelephoneView]
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(formProvider.fill(true), "name", isAgent = false, "ABC Intl")(
+        contentAsString(result) mustEqual view(formProvider.fill(true), "name", isAgent = false, Some("ABC Intl"))(
           request,
           applicationConfig,
           messages(application)

--- a/test/controllers/subscription/manageAccount/SecondaryContactEmailControllerSpec.scala
+++ b/test/controllers/subscription/manageAccount/SecondaryContactEmailControllerSpec.scala
@@ -62,7 +62,7 @@ class SecondaryContactEmailControllerSpec extends SpecBase {
         val view = application.injector.instanceOf[SecondaryContactEmailView]
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(formProvider, "name", isAgent = false, "ABC Intl")(
+        contentAsString(result) mustEqual view(formProvider, "name", isAgent = false, Some("ABC Intl"))(
           request,
           applicationConfig,
           messages(application)
@@ -89,7 +89,7 @@ class SecondaryContactEmailControllerSpec extends SpecBase {
         val view = application.injector.instanceOf[SecondaryContactEmailView]
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(formProvider.fill("my@my.com"), "name", isAgent = false, "ABC Intl")(
+        contentAsString(result) mustEqual view(formProvider.fill("my@my.com"), "name", isAgent = false, Some("ABC Intl"))(
           request,
           applicationConfig,
           messages(application)
@@ -114,7 +114,7 @@ class SecondaryContactEmailControllerSpec extends SpecBase {
         val result    = route(application, request).value
 
         status(result) mustEqual BAD_REQUEST
-        contentAsString(result) mustEqual view(boundForm, "name", isAgent = false, "ABC Intl")(
+        contentAsString(result) mustEqual view(boundForm, "name", isAgent = false, Some("ABC Intl"))(
           request,
           applicationConfig,
           messages(application)
@@ -210,7 +210,7 @@ class SecondaryContactEmailControllerSpec extends SpecBase {
         val result = route(application, request).value
         val view   = application.injector.instanceOf[SecondaryContactEmailView]
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(formProvider, "name", isAgent = false, "ABC Intl")(
+        contentAsString(result) mustEqual view(formProvider, "name", isAgent = false, Some("ABC Intl"))(
           request,
           applicationConfig,
           messages(application)
@@ -246,7 +246,7 @@ class SecondaryContactEmailControllerSpec extends SpecBase {
         val result = route(application, request).value
         val view   = application.injector.instanceOf[SecondaryContactEmailView]
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(formProvider.fill("my@my.com"), "name", isAgent = false, "ABC Intl")(
+        contentAsString(result) mustEqual view(formProvider.fill("my@my.com"), "name", isAgent = false, Some("ABC Intl"))(
           request,
           applicationConfig,
           messages(application)
@@ -279,7 +279,7 @@ class SecondaryContactEmailControllerSpec extends SpecBase {
         val boundForm = formProvider.bind(Map("emailAddress" -> "12345"))
         val result    = route(application, request).value
         status(result) mustEqual BAD_REQUEST
-        contentAsString(result) mustEqual view(boundForm, "name", isAgent = false, "ABC Intl")(
+        contentAsString(result) mustEqual view(boundForm, "name", isAgent = false, Some("ABC Intl"))(
           request,
           applicationConfig,
           messages(application)

--- a/test/controllers/subscription/manageAccount/SecondaryContactNameControllerSpec.scala
+++ b/test/controllers/subscription/manageAccount/SecondaryContactNameControllerSpec.scala
@@ -60,7 +60,7 @@ class SecondaryContactNameControllerSpec extends SpecBase {
         val view = application.injector.instanceOf[SecondaryContactNameView]
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(formProvider(), isAgent = false, "ABC Intl")(
+        contentAsString(result) mustEqual view(formProvider(), isAgent = false, Some("ABC Intl"))(
           request,
           applicationConfig,
           messages(application)
@@ -83,7 +83,7 @@ class SecondaryContactNameControllerSpec extends SpecBase {
         val result = route(application, request).value
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(formProvider().fill("name"), isAgent = false, "ABC Intl")(
+        contentAsString(result) mustEqual view(formProvider().fill("name"), isAgent = false, Some("ABC Intl"))(
           request,
           applicationConfig,
           messages(application)
@@ -108,7 +108,11 @@ class SecondaryContactNameControllerSpec extends SpecBase {
         val result = route(application, request).value
 
         status(result) mustEqual BAD_REQUEST
-        contentAsString(result) mustEqual view(boundForm, isAgent = false, "ABC Intl")(request, applicationConfig, messages(application)).toString
+        contentAsString(result) mustEqual view(boundForm, isAgent = false, Some("ABC Intl"))(
+          request,
+          applicationConfig,
+          messages(application)
+        ).toString
       }
     }
 
@@ -169,7 +173,7 @@ class SecondaryContactNameControllerSpec extends SpecBase {
         val result = route(application, request).value
         val view   = application.injector.instanceOf[SecondaryContactNameView]
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(formProvider(), isAgent = false, "ABC Intl")(
+        contentAsString(result) mustEqual view(formProvider(), isAgent = false, Some("ABC Intl"))(
           request,
           applicationConfig,
           messages(application)
@@ -200,7 +204,7 @@ class SecondaryContactNameControllerSpec extends SpecBase {
         val view   = application.injector.instanceOf[SecondaryContactNameView]
         val result = route(application, request).value
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(formProvider().fill("name"), isAgent = false, "ABC Intl")(
+        contentAsString(result) mustEqual view(formProvider().fill("name"), isAgent = false, Some("ABC Intl"))(
           request,
           applicationConfig,
           messages(application)
@@ -232,7 +236,7 @@ class SecondaryContactNameControllerSpec extends SpecBase {
         val view      = application.injector.instanceOf[SecondaryContactNameView]
         val result    = route(application, request).value
         status(result) mustEqual BAD_REQUEST
-        contentAsString(result) mustEqual view(boundForm, isAgent = false, "ABC Intl")(
+        contentAsString(result) mustEqual view(boundForm, isAgent = false, Some("ABC Intl"))(
           request,
           applicationConfig,
           messages(application)

--- a/test/controllers/subscription/manageAccount/SecondaryTelephoneControllerSpec.scala
+++ b/test/controllers/subscription/manageAccount/SecondaryTelephoneControllerSpec.scala
@@ -64,7 +64,7 @@ class SecondaryTelephoneControllerSpec extends SpecBase {
         val view = application.injector.instanceOf[SecondaryTelephoneView]
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(formProvider, "name", isAgent = false, "ABC Intl")(
+        contentAsString(result) mustEqual view(formProvider, "name", isAgent = false, Some("ABC Intl"))(
           request,
           applicationConfig,
           messages(application)
@@ -89,7 +89,7 @@ class SecondaryTelephoneControllerSpec extends SpecBase {
         val result = route(application, request).value
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(formProvider.fill("1234567"), "name", isAgent = false, "ABC Intl")(
+        contentAsString(result) mustEqual view(formProvider.fill("1234567"), "name", isAgent = false, Some("ABC Intl"))(
           request,
           applicationConfig,
           messages(application)
@@ -114,7 +114,7 @@ class SecondaryTelephoneControllerSpec extends SpecBase {
         val result = route(application, request).value
 
         status(result) mustEqual BAD_REQUEST
-        contentAsString(result) mustEqual view(boundForm, "name", isAgent = false, "ABC Intl")(
+        contentAsString(result) mustEqual view(boundForm, "name", isAgent = false, Some("ABC Intl"))(
           request,
           applicationConfig,
           messages(application)
@@ -211,7 +211,7 @@ class SecondaryTelephoneControllerSpec extends SpecBase {
         val result = route(application, request).value
         val view   = application.injector.instanceOf[SecondaryTelephoneView]
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(formProvider, "name", isAgent = false, "ABC Intl")(
+        contentAsString(result) mustEqual view(formProvider, "name", isAgent = false, Some("ABC Intl"))(
           request,
           applicationConfig,
           messages(application)
@@ -242,7 +242,7 @@ class SecondaryTelephoneControllerSpec extends SpecBase {
         val view   = application.injector.instanceOf[SecondaryTelephoneView]
         val result = route(application, request).value
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(formProvider.fill("1234567"), "name", isAgent = false, "ABC Intl")(
+        contentAsString(result) mustEqual view(formProvider.fill("1234567"), "name", isAgent = false, Some("ABC Intl"))(
           request,
           applicationConfig,
           messages(application)
@@ -274,7 +274,7 @@ class SecondaryTelephoneControllerSpec extends SpecBase {
         val view      = application.injector.instanceOf[SecondaryTelephoneView]
         val result    = route(application, request).value
         status(result) mustEqual BAD_REQUEST
-        contentAsString(result) mustEqual view(boundForm, "name", isAgent = false, "ABC Intl")(
+        contentAsString(result) mustEqual view(boundForm, "name", isAgent = false, Some("ABC Intl"))(
           request,
           applicationConfig,
           messages(application)

--- a/test/helpers/SubscriptionLocalDataFixture.scala
+++ b/test/helpers/SubscriptionLocalDataFixture.scala
@@ -57,7 +57,8 @@ trait SubscriptionLocalDataFixture {
     subSecondaryEmail = None,
     subSecondaryCapturePhone = None,
     subSecondaryPhonePreference = Some(false),
-    subRegisteredAddress = NonUKAddress("", None, "", None, None, "")
+    subRegisteredAddress = NonUKAddress("", None, "", None, None, ""),
+    organisationName = None
   )
 
   val someSubscriptionLocalData: SubscriptionLocalData = SubscriptionLocalData(
@@ -73,7 +74,8 @@ trait SubscriptionLocalDataFixture {
     subSecondaryEmail = Some("doe@email.com"),
     subSecondaryCapturePhone = Some("123"),
     subSecondaryPhonePreference = Some(true),
-    subRegisteredAddress = NonUKAddress("line1", None, "line", None, None, "GB")
+    subRegisteredAddress = NonUKAddress("line1", None, "line", None, None, "GB"),
+    organisationName = Some("ABC Intl")
   )
 
   val subscriptionData: SubscriptionData = SubscriptionData(

--- a/test/views/subscriptionview/manageAccount/ManageContactCheckYourAnswersViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/ManageContactCheckYourAnswersViewSpec.scala
@@ -27,7 +27,7 @@ import views.html.subscriptionview.manageAccount.ManageContactCheckYourAnswersVi
 
 class ManageContactCheckYourAnswersViewSpec extends ViewSpecBase with SubscriptionLocalDataFixture {
   implicit val subscriptionDataRequest: SubscriptionDataRequest[AnyContent] =
-    SubscriptionDataRequest(request, "", someSubscriptionLocalData, Set.empty, isAgent = false, "OrgName")
+    SubscriptionDataRequest(request, "", someSubscriptionLocalData, Set.empty, isAgent = false)
 
   val page: ManageContactCheckYourAnswersView = inject[ManageContactCheckYourAnswersView]
 
@@ -37,7 +37,7 @@ class ManageContactCheckYourAnswersViewSpec extends ViewSpecBase with Subscripti
       subscriptionDataSecondaryContactList(),
       subscriptionDataAddress(inject[CountryOptions]),
       isAgent = false,
-      "OrgName"
+      Some("OrgName")
     )(
       request,
       appConfig,
@@ -51,7 +51,7 @@ class ManageContactCheckYourAnswersViewSpec extends ViewSpecBase with Subscripti
       subscriptionDataSecondaryContactList(),
       subscriptionDataAddress(inject[CountryOptions]),
       isAgent = false,
-      "OrgName"
+      Some("OrgName")
     )(request, appConfig, messages).toString()
   )
 

--- a/test/views/subscriptionview/manageAccount/ManageGroupDetailsCheckYourAnswersViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/ManageGroupDetailsCheckYourAnswersViewSpec.scala
@@ -27,7 +27,7 @@ import views.html.subscriptionview.manageAccount.ManageGroupDetailsCheckYourAnsw
 
 class ManageGroupDetailsCheckYourAnswersViewSpec extends ViewSpecBase with SubscriptionLocalDataFixture {
   implicit val subscriptionDataRequest: SubscriptionDataRequest[AnyContent] =
-    SubscriptionDataRequest(request, "", someSubscriptionLocalData, Set.empty, isAgent = false, "OrgName")
+    SubscriptionDataRequest(request, "", someSubscriptionLocalData, Set.empty, isAgent = false)
 
   val page: ManageGroupDetailsCheckYourAnswersView = inject[ManageGroupDetailsCheckYourAnswersView]
 

--- a/test/views/subscriptionview/manageAccount/SecondaryTelephoneViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/SecondaryTelephoneViewSpec.scala
@@ -27,7 +27,8 @@ class SecondaryTelephoneViewSpec extends ViewSpecBase {
   val formProvider = new CaptureTelephoneDetailsFormProvider
   val page: SecondaryTelephoneView = inject[SecondaryTelephoneView]
 
-  val view: Document = Jsoup.parse(page(formProvider("John Doe"), "John Doe", isAgent = false, "OrgName")(request, appConfig, messages).toString())
+  val view: Document =
+    Jsoup.parse(page(formProvider("John Doe"), "John Doe", isAgent = false, Some("OrgName"))(request, appConfig, messages).toString())
 
   "CaptureTelephoneDetailsView" should {
 


### PR DESCRIPTION
Refactors subscription actions to use `organisationName` from cached subscription data instead of fetching it separately via API calls, aligning with backend changes.

### Key Changes
- Added `organisationName: Option[String]` to `SubscriptionLocalData`
- Removed separate organisation name fetching logic from `SubscriptionDataRetrievalAction`
- Updated all manage account controllers and views to use cached organisation name
- Modified views to handle `organisationName` as optional with appropriate fallbacks

### Migration Notes
**Temporary Implementation:** The `organisationName` field is currently optional to prevent failures with existing cache entries. After the 28-day TTL period, all cached entries will include the organisation name, and the field can be made mandatory as part of [PIL-2232](https://jira.tools.tax.service.gov.uk/browse/PIL-2232).

**Views requiring update in PIL-2232:**
- `ContactByTelephoneView.scala.html`
- `ManageContactCheckYourAnswersView.scala.html` 
- `SecondaryContactEmailView.scala.html`
- `SecondaryContactNameView.scala.html`
- `SecondaryTelephoneView.scala.html`

### Benefits
- Reduces API calls by using cached data
- Improves performance and reliability
- Maintains backward compatibility through optional field handling