### PR TITLE
PIL-1898: Add UKTR banner functionality to homepage

### DIFF
--- a/app/views/HomepageView.scala.html
+++ b/app/views/HomepageView.scala.html
@@ -77,14 +77,14 @@
      <div>
       <div class="card-label card-label-with-tag">
        <h2 class="govuk-heading-m">@messages("homepage.returns.title")</h2>
-       <span class="govuk-tag @{
-         maybeUktrBannerScenario.get match {
-           case "Due" => "govuk-tag--blue"
-           case "Overdue" => "govuk-tag--red"  
-           case "Incomplete" => "govuk-tag--blue"
-           case _ => "govuk-tag--blue"
-         }
-       }">@maybeUktrBannerScenario.get</span>
+       @defining(maybeUktrBannerScenario.get match {
+         case "Due" => "background-color: #bfdbfe; color: #1e40af;"
+         case "Overdue" => "background-color: #fecaca; color: #dc2626;"
+         case "Incomplete" => "background-color: #e9d5ff; color: #7c3aed;"
+         case _ => "background-color: #bfdbfe; color: #1e40af;"
+       }) { style =>
+         <span class="govuk-tag" style="@style">@maybeUktrBannerScenario.get</span>
+       }
       </div>
       <div class="card-content">
        <ul class="govuk-list">

--- a/app/views/HomepageView.scala.html
+++ b/app/views/HomepageView.scala.html
@@ -25,7 +25,7 @@
 
 @this(layout: Layout, heading: heading, paragraphBody: paragraphBody, link: link, card: HomepageCard, govukNotificationBanner : GovukNotificationBanner)
 
-@(organisationName: String, registrationDate: String, maybeBTNBannerDate: Option[LocalDate], plrReference: String, isAgent: Boolean)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(organisationName: String, registrationDate: String, maybeBTNBannerDate: Option[LocalDate], maybeUktrBannerScenario: Option[String], plrReference: String, isAgent: Boolean)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @submissionFrontendPath = @{s"${appConfig.submissionFrontendHost}/report-pillar2-submission-top-up-taxes"}
 @maybeAgentKey = @{if(isAgent) ".agent" else ""}
@@ -42,10 +42,26 @@
  </div>
 }
 
+@uktrBannerHtml = {
+ <div style="max-width: fit-content">
+  @paragraphBody(messages(s"homepage.uktrBanner$maybeAgentKey.${maybeUktrBannerScenario.get}.title"), "govuk-notification-banner__heading")
+  @paragraphBody(messages(s"homepage.uktrBanner$maybeAgentKey.${maybeUktrBannerScenario.get}.body"))
+  @link(
+   text = messages("homepage.uktrBanner.linkText"),
+   call = Call("GET", s"$submissionFrontendPath/due-and-overdue-returns"),
+   classes = Some("govuk-notification-banner__link")
+  )
+ </div>
+}
+
 @layout(pageTitle = noTitle, showBackLink = false, twoThirdsPagelayout = false) {
 
  @if(maybeBTNBannerDate.isDefined) {
   @govukNotificationBanner(NotificationBanner(content = HtmlContent(bannerHtml)))
+ }
+
+ @if(maybeUktrBannerScenario.isDefined) {
+  @govukNotificationBanner(NotificationBanner(content = HtmlContent(uktrBannerHtml)))
  }
 
  @heading(messages("homepage.title"), "govuk-heading-l")

--- a/app/views/HomepageView.scala.html
+++ b/app/views/HomepageView.scala.html
@@ -48,7 +48,7 @@
   @paragraphBody(messages(s"homepage.uktrBanner$maybeAgentKey.${maybeUktrBannerScenario.get}.body"))
   @link(
    text = messages("homepage.uktrBanner.linkText"),
-   call = Call("GET", s"$submissionFrontendPath/due-and-overdue-returns"),
+   call = Call("GET", s"$submissionFrontendPath/due-and-overdue-returns?activeTab=${maybeUktrBannerScenario.get.toLowerCase}"),
    classes = Some("govuk-notification-banner__link")
   )
  </div>
@@ -72,13 +72,41 @@
  </p>
 
  <div class="card-group">
-   @card(
-    title = messages("homepage.returns.title"),
-    links = Seq(
-     (messages("homepage.returns.dueOverdueReturns.linkText"), s"$submissionFrontendPath/due-and-overdue-returns", None),
-     (messages("homepage.returns.submissionHistory.linkText"), s"$submissionFrontendPath/submission-history", None),
+   @if(maybeUktrBannerScenario.isDefined) {
+    <div class="card-half-width">
+     <div>
+      <div class="card-label card-label-with-tag">
+       <h2 class="govuk-heading-m">@messages("homepage.returns.title")</h2>
+       <span class="govuk-tag @{
+         maybeUktrBannerScenario.get match {
+           case "Due" => "govuk-tag--blue"
+           case "Overdue" => "govuk-tag--red"  
+           case "Incomplete" => "govuk-tag--blue"
+           case _ => "govuk-tag--blue"
+         }
+       }">@maybeUktrBannerScenario.get</span>
+      </div>
+      <div class="card-content">
+       <ul class="govuk-list">
+        <li class="card-links">
+         <a href="@{s"$submissionFrontendPath/due-and-overdue-returns?activeTab=${maybeUktrBannerScenario.get.toLowerCase}"}" class="govuk-link">@messages("homepage.returns.dueOverdueReturns.linkText")</a>
+        </li>
+        <li class="card-links">
+         <a href="@{s"$submissionFrontendPath/submission-history"}" class="govuk-link">@messages("homepage.returns.submissionHistory.linkText")</a>
+        </li>
+       </ul>
+      </div>
+     </div>
+    </div>
+   } else {
+    @card(
+     title = messages("homepage.returns.title"),
+     links = Seq(
+      (messages("homepage.returns.dueOverdueReturns.linkText"), s"$submissionFrontendPath/due-and-overdue-returns", None),
+      (messages("homepage.returns.submissionHistory.linkText"), s"$submissionFrontendPath/submission-history", None),
+     )
     )
-   )
+   }
 
    @card(
     title = messages("homepage.payments.title"),

--- a/app/views/HomepageView.scala.html
+++ b/app/views/HomepageView.scala.html
@@ -77,14 +77,14 @@
      <div>
       <div class="card-label card-label-with-tag">
        <h2 class="govuk-heading-m">@messages("homepage.returns.title")</h2>
-       @defining(maybeUktrBannerScenario.get match {
-         case "Due" => "background-color: #bfdbfe; color: #1e40af;"
-         case "Overdue" => "background-color: #fecaca; color: #dc2626;"
-         case "Incomplete" => "background-color: #e9d5ff; color: #7c3aed;"
-         case _ => "background-color: #bfdbfe; color: #1e40af;"
-       }) { style =>
-         <span class="govuk-tag" style="@style">@maybeUktrBannerScenario.get</span>
-       }
+       <span class="govuk-tag @{
+         maybeUktrBannerScenario.get match {
+           case "Due" => "govuk-tag--blue"
+           case "Overdue" => "govuk-tag--red"  
+           case "Incomplete" => "govuk-tag--purple"
+           case _ => "govuk-tag--blue"
+         }
+       }" aria-label="@{maybeUktrBannerScenario.get} returns" title="@{maybeUktrBannerScenario.get} returns">@maybeUktrBannerScenario.get</span>
       </div>
       <div class="card-content">
        <ul class="govuk-list">

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -870,21 +870,20 @@ homepage.btnActiveBanner.body = You have told us you do not need to submit a UK 
 homepage.btnActiveBanner.agent.body = You or your client have told us the group does not need to submit a UK Tax Return for the accounting period ending {0} or for any future accounting periods. If your client meets the annual revenue threshold for Pillar 2 Top-up Taxes in future, a UK Tax Return should be submitted.
 homepage.btnActiveBanner.linkText = Find out more about Below-Threshold Notification
 
-# UKTR Banner Messages
-homepage.uktrBanner.due.title = You have one or more returns due
-homepage.uktrBanner.due.body = Submit your returns before the due date to avoid penalties.
-homepage.uktrBanner.agent.due.title = You have one or more returns due
-homepage.uktrBanner.agent.due.body = Submit your returns before the due date to avoid penalties.
+homepage.uktrBanner.Due.title = You have one or more returns due
+homepage.uktrBanner.Due.body = Submit your returns before the due date to avoid penalties.
+homepage.uktrBanner.agent.Due.title = You have one or more returns due
+homepage.uktrBanner.agent.Due.body = Submit your returns before the due date to avoid penalties.
 
-homepage.uktrBanner.overdue.title = You have one or more returns due
-homepage.uktrBanner.overdue.body = Submit your returns before the due date to avoid penalties.
-homepage.uktrBanner.agent.overdue.title = You have one or more returns due
-homepage.uktrBanner.agent.overdue.body = Submit your returns before the due date to avoid penalties.
+homepage.uktrBanner.Overdue.title = You have one or more returns due
+homepage.uktrBanner.Overdue.body = Submit your returns before the due date to avoid penalties.
+homepage.uktrBanner.agent.Overdue.title = You have one or more returns due
+homepage.uktrBanner.agent.Overdue.body = Submit your returns before the due date to avoid penalties.
 
-homepage.uktrBanner.incomplete.title = You have overdue or incomplete returns
-homepage.uktrBanner.incomplete.body = You must submit or complete these returns as soon as possible.
-homepage.uktrBanner.agent.incomplete.title = You have overdue or incomplete returns
-homepage.uktrBanner.agent.incomplete.body = You must submit or complete these returns as soon as possible.
+homepage.uktrBanner.Incomplete.title = You have overdue or incomplete returns
+homepage.uktrBanner.Incomplete.body = You must submit or complete these returns as soon as possible.
+homepage.uktrBanner.agent.Incomplete.title = You have overdue or incomplete returns
+homepage.uktrBanner.agent.Incomplete.body = You must submit or complete these returns as soon as possible.
 
 homepage.uktrBanner.linkText = View all due and overdue returns
 ###############################################

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -869,6 +869,24 @@ homepage.btnActiveBanner.title = {0} has a Below-Threshold Notification.
 homepage.btnActiveBanner.body = You have told us you do not need to submit a UK Tax Return for the accounting period ending {0} or for any future accounting periods. In the future, if you meet the annual revenue threshold for Pillar 2 Top-up Taxes, you should submit a UK Tax Return.
 homepage.btnActiveBanner.agent.body = You or your client have told us the group does not need to submit a UK Tax Return for the accounting period ending {0} or for any future accounting periods. If your client meets the annual revenue threshold for Pillar 2 Top-up Taxes in future, a UK Tax Return should be submitted.
 homepage.btnActiveBanner.linkText = Find out more about Below-Threshold Notification
+
+# UKTR Banner Messages
+homepage.uktrBanner.due.title = You have one or more returns due
+homepage.uktrBanner.due.body = Submit your returns before the due date to avoid penalties.
+homepage.uktrBanner.agent.due.title = You have one or more returns due
+homepage.uktrBanner.agent.due.body = Submit your returns before the due date to avoid penalties.
+
+homepage.uktrBanner.overdue.title = You have one or more returns due
+homepage.uktrBanner.overdue.body = Submit your returns before the due date to avoid penalties.
+homepage.uktrBanner.agent.overdue.title = You have one or more returns due
+homepage.uktrBanner.agent.overdue.body = Submit your returns before the due date to avoid penalties.
+
+homepage.uktrBanner.incomplete.title = You have overdue or incomplete returns
+homepage.uktrBanner.incomplete.body = You must submit or complete these returns as soon as possible.
+homepage.uktrBanner.agent.incomplete.title = You have overdue or incomplete returns
+homepage.uktrBanner.agent.incomplete.body = You must submit or complete these returns as soon as possible.
+
+homepage.uktrBanner.linkText = View all due and overdue returns
 ###############################################
 #
 # Dashboard

--- a/test/controllers/DashboardControllerSpec.scala
+++ b/test/controllers/DashboardControllerSpec.scala
@@ -99,6 +99,7 @@ class DashboardControllerSpec extends SpecBase with ModelGenerators {
             subscriptionData.upeDetails.organisationName,
             subscriptionData.upeDetails.registrationDate.format(DateTimeFormatter.ofPattern("d MMMM yyyy")),
             None,
+            None,
             "12345678",
             isAgent = false
           )(

--- a/test/controllers/DashboardControllerSpec.scala
+++ b/test/controllers/DashboardControllerSpec.scala
@@ -35,8 +35,8 @@ import uk.gov.hmrc.auth.core.retrieve.{Credentials, ~}
 import uk.gov.hmrc.http.HeaderCarrier
 import views.html.{DashboardView, HomepageView}
 
-import java.time.{LocalDate, ZonedDateTime}
 import java.time.format.DateTimeFormatter
+import java.time.{LocalDate, ZonedDateTime}
 import java.util.UUID
 import scala.concurrent.Future
 
@@ -113,6 +113,7 @@ class DashboardControllerSpec extends SpecBase with ModelGenerators {
       "newHomepageEnabled is false" in {
         val application =
           applicationBuilder(userAnswers = None, enrolments)
+            .configure("features.newHomepageEnabled" -> false)
             .overrides(
               bind[SessionRepository].toInstance(mockSessionRepository),
               bind[SubscriptionService].toInstance(mockSubscriptionService)

--- a/test/views/HomepageViewSpec.scala
+++ b/test/views/HomepageViewSpec.scala
@@ -35,6 +35,15 @@ class HomepageViewSpec extends ViewSpecBase {
   val organisationView: Document =
     Jsoup.parse(page(organisationName, date, None, None, plrRef, isAgent = false)(request, appConfig, messages).toString())
 
+  val organisationViewWithDueScenario: Document =
+    Jsoup.parse(page(organisationName, date, None, Some("Due"), plrRef, isAgent = false)(request, appConfig, messages).toString())
+
+  val organisationViewWithOverdueScenario: Document =
+    Jsoup.parse(page(organisationName, date, None, Some("Overdue"), plrRef, isAgent = false)(request, appConfig, messages).toString())
+
+  val organisationViewWithIncompleteScenario: Document =
+    Jsoup.parse(page(organisationName, date, None, Some("Incomplete"), plrRef, isAgent = false)(request, appConfig, messages).toString())
+
   val agentView: Document =
     Jsoup.parse(page(organisationName, date, None, None, plrRef, isAgent = true)(request, appConfig, messages).toString())
 
@@ -106,6 +115,54 @@ class HomepageViewSpec extends ViewSpecBase {
 
     "not display notification banner if no date is found" in {
       organisationView.getElementsByClass("govuk-notification-banner").isEmpty mustBe true
+    }
+
+    "display UKTR Due status tag with blue color when Due scenario is provided" in {
+      val returnsCard = organisationViewWithDueScenario.getElementsByClass("card-half-width").first()
+
+      returnsCard.getElementsByTag("h2").text() mustBe "Returns"
+
+      val cardHeader = returnsCard.getElementsByClass("card-label-with-tag").first()
+      val statusTag  = cardHeader.getElementsByClass("govuk-tag govuk-tag--blue")
+      statusTag.size() mustBe 1
+      statusTag.first().text() mustBe "Due"
+
+      val links = returnsCard.getElementsByTag("a")
+      links.get(0).attr("href") must include("?activeTab=due")
+      links.get(0).text() mustBe "View all due and overdue returns"
+      links.get(1).text() mustBe "View submission history"
+    }
+
+    "display UKTR Overdue status tag with red color when Overdue scenario is provided" in {
+      val returnsCard = organisationViewWithOverdueScenario.getElementsByClass("card-half-width").first()
+
+      returnsCard.getElementsByTag("h2").text() mustBe "Returns"
+
+      val cardHeader = returnsCard.getElementsByClass("card-label-with-tag").first()
+      val statusTag  = cardHeader.getElementsByClass("govuk-tag govuk-tag--red")
+      statusTag.size() mustBe 1
+      statusTag.first().text() mustBe "Overdue"
+
+      val links = returnsCard.getElementsByTag("a")
+      links.get(0).attr("href") must include("?activeTab=overdue")
+      links.get(0).text() mustBe "View all due and overdue returns"
+      links.get(1).text() mustBe "View submission history"
+    }
+
+    "display UKTR Incomplete status tag with blue color when Incomplete scenario is provided" in {
+      val returnsCard = organisationViewWithIncompleteScenario.getElementsByClass("card-half-width").first()
+
+      returnsCard.getElementsByTag("h2").text() mustBe "Returns"
+
+      val cardHeader = returnsCard.getElementsByClass("card-label-with-tag").first()
+      val statusTag  = cardHeader.getElementsByClass("govuk-tag govuk-tag--blue")
+      statusTag.size() mustBe 1
+      statusTag.first().text() mustBe "Incomplete"
+
+      val links = returnsCard.getElementsByTag("a")
+      links.get(0).attr("href") must include("?activeTab=incomplete")
+      links.get(0).text() mustBe "View all due and overdue returns"
+      links.get(1).text() mustBe "View submission history"
     }
 
     "display notification banner" in {

--- a/test/views/HomepageViewSpec.scala
+++ b/test/views/HomepageViewSpec.scala
@@ -33,10 +33,10 @@ class HomepageViewSpec extends ViewSpecBase {
   private val apEndDate        = Option(LocalDate.of(2024, 1, 1))
 
   val organisationView: Document =
-    Jsoup.parse(page(organisationName, date, None, plrRef, isAgent = false)(request, appConfig, messages).toString())
+    Jsoup.parse(page(organisationName, date, None, None, plrRef, isAgent = false)(request, appConfig, messages).toString())
 
   val agentView: Document =
-    Jsoup.parse(page(organisationName, date, None, plrRef, isAgent = true)(request, appConfig, messages).toString())
+    Jsoup.parse(page(organisationName, date, None, None, plrRef, isAgent = true)(request, appConfig, messages).toString())
 
   "HomepageView for a group" should {
     "display page header correctly" in {
@@ -110,7 +110,7 @@ class HomepageViewSpec extends ViewSpecBase {
 
     "display notification banner" in {
       val accountInactiveOrgView: Document =
-        Jsoup.parse(page(organisationName, date, apEndDate, plrRef, isAgent = false)(request, appConfig, messages).toString())
+        Jsoup.parse(page(organisationName, date, apEndDate, None, plrRef, isAgent = false)(request, appConfig, messages).toString())
 
       val bannerContent = accountInactiveOrgView.getElementsByClass("govuk-notification-banner").first()
 
@@ -192,7 +192,7 @@ class HomepageViewSpec extends ViewSpecBase {
 
     "display notification banner" in {
       val accountInactiveAgentView: Document =
-        Jsoup.parse(page(organisationName, date, apEndDate, plrRef, isAgent = true)(request, appConfig, messages).toString())
+        Jsoup.parse(page(organisationName, date, apEndDate, None, plrRef, isAgent = true)(request, appConfig, messages).toString())
 
       val bannerContent = accountInactiveAgentView.getElementsByClass("govuk-notification-banner").first()
 

--- a/test/views/HomepageViewSpec.scala
+++ b/test/views/HomepageViewSpec.scala
@@ -117,15 +117,16 @@ class HomepageViewSpec extends ViewSpecBase {
       organisationView.getElementsByClass("govuk-notification-banner").isEmpty mustBe true
     }
 
-    "display UKTR Due status tag with blue color when Due scenario is provided" in {
+    "display UKTR Due status tag with light blue background when Due scenario is provided" in {
       val returnsCard = organisationViewWithDueScenario.getElementsByClass("card-half-width").first()
 
       returnsCard.getElementsByTag("h2").text() mustBe "Returns"
 
       val cardHeader = returnsCard.getElementsByClass("card-label-with-tag").first()
-      val statusTag  = cardHeader.getElementsByClass("govuk-tag govuk-tag--blue")
+      val statusTag  = cardHeader.getElementsByClass("govuk-tag")
       statusTag.size() mustBe 1
       statusTag.first().text() mustBe "Due"
+      statusTag.first().attr("style") must include("background-color: #bfdbfe")
 
       val links = returnsCard.getElementsByTag("a")
       links.get(0).attr("href") must include("?activeTab=due")
@@ -133,15 +134,16 @@ class HomepageViewSpec extends ViewSpecBase {
       links.get(1).text() mustBe "View submission history"
     }
 
-    "display UKTR Overdue status tag with red color when Overdue scenario is provided" in {
+    "display UKTR Overdue status tag with light pink background when Overdue scenario is provided" in {
       val returnsCard = organisationViewWithOverdueScenario.getElementsByClass("card-half-width").first()
 
       returnsCard.getElementsByTag("h2").text() mustBe "Returns"
 
       val cardHeader = returnsCard.getElementsByClass("card-label-with-tag").first()
-      val statusTag  = cardHeader.getElementsByClass("govuk-tag govuk-tag--red")
+      val statusTag  = cardHeader.getElementsByClass("govuk-tag")
       statusTag.size() mustBe 1
       statusTag.first().text() mustBe "Overdue"
+      statusTag.first().attr("style") must include("background-color: #fecaca")
 
       val links = returnsCard.getElementsByTag("a")
       links.get(0).attr("href") must include("?activeTab=overdue")
@@ -149,15 +151,16 @@ class HomepageViewSpec extends ViewSpecBase {
       links.get(1).text() mustBe "View submission history"
     }
 
-    "display UKTR Incomplete status tag with blue color when Incomplete scenario is provided" in {
+    "display UKTR Incomplete status tag with purple background when Incomplete scenario is provided" in {
       val returnsCard = organisationViewWithIncompleteScenario.getElementsByClass("card-half-width").first()
 
       returnsCard.getElementsByTag("h2").text() mustBe "Returns"
 
       val cardHeader = returnsCard.getElementsByClass("card-label-with-tag").first()
-      val statusTag  = cardHeader.getElementsByClass("govuk-tag govuk-tag--blue")
+      val statusTag  = cardHeader.getElementsByClass("govuk-tag")
       statusTag.size() mustBe 1
       statusTag.first().text() mustBe "Incomplete"
+      statusTag.first().attr("style") must include("background-color: #e9d5ff")
 
       val links = returnsCard.getElementsByTag("a")
       links.get(0).attr("href") must include("?activeTab=incomplete")

--- a/test/views/HomepageViewSpec.scala
+++ b/test/views/HomepageViewSpec.scala
@@ -117,16 +117,17 @@ class HomepageViewSpec extends ViewSpecBase {
       organisationView.getElementsByClass("govuk-notification-banner").isEmpty mustBe true
     }
 
-    "display UKTR Due status tag with light blue background when Due scenario is provided" in {
+    "display UKTR Due status tag with blue style when Due scenario is provided" in {
       val returnsCard = organisationViewWithDueScenario.getElementsByClass("card-half-width").first()
 
       returnsCard.getElementsByTag("h2").text() mustBe "Returns"
 
       val cardHeader = returnsCard.getElementsByClass("card-label-with-tag").first()
-      val statusTag  = cardHeader.getElementsByClass("govuk-tag")
+      val statusTag  = cardHeader.getElementsByClass("govuk-tag govuk-tag--blue")
       statusTag.size() mustBe 1
       statusTag.first().text() mustBe "Due"
-      statusTag.first().attr("style") must include("background-color: #bfdbfe")
+      statusTag.first().attr("aria-label") mustBe "Due returns"
+      statusTag.first().attr("title") mustBe "Due returns"
 
       val links = returnsCard.getElementsByTag("a")
       links.get(0).attr("href") must include("?activeTab=due")
@@ -134,16 +135,17 @@ class HomepageViewSpec extends ViewSpecBase {
       links.get(1).text() mustBe "View submission history"
     }
 
-    "display UKTR Overdue status tag with light pink background when Overdue scenario is provided" in {
+    "display UKTR Overdue status tag with red style when Overdue scenario is provided" in {
       val returnsCard = organisationViewWithOverdueScenario.getElementsByClass("card-half-width").first()
 
       returnsCard.getElementsByTag("h2").text() mustBe "Returns"
 
       val cardHeader = returnsCard.getElementsByClass("card-label-with-tag").first()
-      val statusTag  = cardHeader.getElementsByClass("govuk-tag")
+      val statusTag  = cardHeader.getElementsByClass("govuk-tag govuk-tag--red")
       statusTag.size() mustBe 1
       statusTag.first().text() mustBe "Overdue"
-      statusTag.first().attr("style") must include("background-color: #fecaca")
+      statusTag.first().attr("aria-label") mustBe "Overdue returns"
+      statusTag.first().attr("title") mustBe "Overdue returns"
 
       val links = returnsCard.getElementsByTag("a")
       links.get(0).attr("href") must include("?activeTab=overdue")
@@ -151,16 +153,17 @@ class HomepageViewSpec extends ViewSpecBase {
       links.get(1).text() mustBe "View submission history"
     }
 
-    "display UKTR Incomplete status tag with purple background when Incomplete scenario is provided" in {
+    "display UKTR Incomplete status tag with purple style when Incomplete scenario is provided" in {
       val returnsCard = organisationViewWithIncompleteScenario.getElementsByClass("card-half-width").first()
 
       returnsCard.getElementsByTag("h2").text() mustBe "Returns"
 
       val cardHeader = returnsCard.getElementsByClass("card-label-with-tag").first()
-      val statusTag  = cardHeader.getElementsByClass("govuk-tag")
+      val statusTag  = cardHeader.getElementsByClass("govuk-tag govuk-tag--purple")
       statusTag.size() mustBe 1
       statusTag.first().text() mustBe "Incomplete"
-      statusTag.first().attr("style") must include("background-color: #e9d5ff")
+      statusTag.first().attr("aria-label") mustBe "Incomplete returns"
+      statusTag.first().attr("title") mustBe "Incomplete returns"
 
       val links = returnsCard.getElementsByTag("a")
       links.get(0).attr("href") must include("?activeTab=incomplete")


### PR DESCRIPTION
- **PIL-1898: Implement UKTR banner notifications on homepage**
- **PIL-1898: Update UKTR banner message keys to title case and complete implementation**
- **PIL-1898: Fix homepage status tag colors to match due-and-overdue-returns page - Due: Blue (govuk-tag--blue) - Overdue: Red (govuk-tag--red) - Incomplete: Blue (govuk-tag--blue)**
- **PIL-1898: Update homepage status tag colors to match prototype**
- **PIL-1898: Follow prototype exactly - use GOV.UK Design System tag classes - Due: govuk-tag--blue - Overdue: govuk-tag--red - Incomplete: govuk-tag--purple**
- **PIL-1898: Fix DashboardControllerSpec - explicitly set newHomepageEnabled to false in test**
