### PR TITLE
NOJIRA - Replaced Future() with Future.successful()

### DIFF
--- a/test/controllers/CheckYourAnswersControllerSpec.scala
+++ b/test/controllers/CheckYourAnswersControllerSpec.scala
@@ -156,7 +156,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency {
 
         running(application) {
           when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(userAnswer)))
-          when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+          when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
           val request = FakeRequest(GET, controllers.routes.CheckYourAnswersController.onPageLoad.url)
           val result  = route(application, request).value
           status(result) mustEqual OK
@@ -177,7 +177,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency {
           .build()
         running(application) {
           when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(userAnswer)))
-          when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+          when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
           val request = FakeRequest(GET, controllers.routes.CheckYourAnswersController.onPageLoad.url)
           val result  = route(application, request).value
           status(result) mustEqual OK
@@ -200,7 +200,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency {
           .build()
         running(application) {
           when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(userAnswer)))
-          when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+          when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
           val request = FakeRequest(GET, controllers.routes.CheckYourAnswersController.onPageLoad.url)
           val result  = route(application, request).value
           status(result) mustEqual OK
@@ -230,7 +230,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency {
           .build()
         running(application) {
           when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(userAnswer)))
-          when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+          when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
           val request = FakeRequest(GET, controllers.routes.CheckYourAnswersController.onPageLoad.url)
           val result  = route(application, request).value
           status(result) mustEqual OK

--- a/test/controllers/actions/DataRetrievalActionSpec.scala
+++ b/test/controllers/actions/DataRetrievalActionSpec.scala
@@ -39,7 +39,7 @@ class DataRetrievalActionSpec extends SpecBase {
 
       "must set userAnswers to 'None' in the request" in {
 
-        when(mockUserAnswersConnectors.get(any())(any())) thenReturn Future(None)(ec)
+        when(mockUserAnswersConnectors.get(any())(any())) thenReturn Future.successful(None)
         val action = new Harness(mockUserAnswersConnectors)
 
         val result = action.callTransform(IdentifierRequest(FakeRequest(), "id", Some("groupID"), userIdForEnrolment = "userId")).futureValue
@@ -52,7 +52,7 @@ class DataRetrievalActionSpec extends SpecBase {
 
       "must build a userAnswers object and add it to the request" in {
 
-        when(mockUserAnswersConnectors.get(any())(any())) thenReturn Future(Some(Json.obj("abc" -> "def")))(ec)
+        when(mockUserAnswersConnectors.get(any())(any())) thenReturn Future.successful(Some(Json.obj("abc" -> "def")))
         val action = new Harness(mockUserAnswersConnectors)
 
         val result = action.callTransform(new IdentifierRequest(FakeRequest(), "id", Some("groupID"), userIdForEnrolment = "userId")).futureValue

--- a/test/controllers/actions/SessionDataRetrievalActionSpec.scala
+++ b/test/controllers/actions/SessionDataRetrievalActionSpec.scala
@@ -38,7 +38,7 @@ class SessionDataRetrievalActionSpec extends SpecBase {
       "set userAnswers to 'None' in the request" in {
 
         val sessionRepository = mock[SessionRepository]
-        when(sessionRepository.get("id")) thenReturn Future(None)
+        when(sessionRepository.get("id")) thenReturn Future.successful(None)
         val action = new Harness(sessionRepository)
 
         val result = action.callTransform(IdentifierRequest(FakeRequest(), "id", Some("groupID"), userIdForEnrolment = "userId")).futureValue
@@ -52,7 +52,7 @@ class SessionDataRetrievalActionSpec extends SpecBase {
       "build a userAnswers object and add it to the request" in {
 
         val sessionRepository = mock[SessionRepository]
-        when(sessionRepository.get("id")) thenReturn Future(Some(UserAnswers("id")))
+        when(sessionRepository.get("id")) thenReturn Future.successful(Some(UserAnswers("id")))
         val action = new Harness(sessionRepository)
 
         val result = action.callTransform(IdentifierRequest(FakeRequest(), "id", Some("groupID"), userIdForEnrolment = "userId")).futureValue

--- a/test/controllers/bta/HavePillar2TopUpTaxIdControllerSpec.scala
+++ b/test/controllers/bta/HavePillar2TopUpTaxIdControllerSpec.scala
@@ -101,7 +101,7 @@ class HavePillar2TopUpTaxIdControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.bta.routes.HavePillar2TopUpTaxIdController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(("value", "true"))
@@ -125,7 +125,7 @@ class HavePillar2TopUpTaxIdControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.bta.routes.HavePillar2TopUpTaxIdController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(("value", "false"))

--- a/test/controllers/fm/ContactNfmByTelephoneControllerSpec.scala
+++ b/test/controllers/fm/ContactNfmByTelephoneControllerSpec.scala
@@ -132,7 +132,7 @@ class ContactNfmByTelephoneControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.fm.routes.ContactNfmByTelephoneController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(

--- a/test/controllers/fm/NfmCaptureTelephoneDetailsControllerSpec.scala
+++ b/test/controllers/fm/NfmCaptureTelephoneDetailsControllerSpec.scala
@@ -130,7 +130,7 @@ class NfmCaptureTelephoneDetailsControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.fm.routes.NfmCaptureTelephoneDetailsController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(

--- a/test/controllers/fm/NfmContactNameControllerSpec.scala
+++ b/test/controllers/fm/NfmContactNameControllerSpec.scala
@@ -109,7 +109,7 @@ class NfmContactNameControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.fm.routes.NfmContactNameController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(

--- a/test/controllers/fm/NfmEmailAddressControllerSpec.scala
+++ b/test/controllers/fm/NfmEmailAddressControllerSpec.scala
@@ -123,7 +123,7 @@ class NfmEmailAddressControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.fm.routes.NfmEmailAddressController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(

--- a/test/controllers/fm/NfmEntityTypeControllerSpec.scala
+++ b/test/controllers/fm/NfmEntityTypeControllerSpec.scala
@@ -182,11 +182,11 @@ class NfmEntityTypeControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         when(mockIncorporatedEntityIdentificationFrontendConnector.createLimitedCompanyJourney(any(), any())(any()))
           .thenReturn(
-            Future(
+            Future.successful(
               GrsCreateRegistrationResponse(
                 "/report-pillar2-top-up-taxes/test-only/stub-grs-journey-data?continueUrl=normalmode&entityType=UkLimitedCompany"
               )
@@ -220,10 +220,10 @@ class NfmEntityTypeControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         when(mockPartnershipIdentificationFrontendConnector.createPartnershipJourney(any(), any(), any())(any()))
           .thenReturn(
-            Future(
+            Future.successful(
               GrsCreateRegistrationResponse(
                 "/report-pillar2-top-up-taxes/test-only/stub-grs-journey-data?continueUrl=normalmode&entityType=LimitedLiabilityPartnership"
               )
@@ -256,7 +256,7 @@ class NfmEntityTypeControllerSpec extends SpecBase {
       running(application) {
         val request = FakeRequest(POST, controllers.fm.routes.NfmEntityTypeController.onSubmit(NormalMode).url)
           .withFormUrlEncodedBody(("value", EntityType.Other.toString))
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(jsonTobeReturned))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(jsonTobeReturned))
         val result = route(application, request).value
 
         status(result) mustEqual SEE_OTHER

--- a/test/controllers/fm/NfmNameRegistrationControllerSpec.scala
+++ b/test/controllers/fm/NfmNameRegistrationControllerSpec.scala
@@ -111,7 +111,7 @@ class NfmNameRegistrationControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.fm.routes.NfmNameRegistrationController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(

--- a/test/controllers/fm/NfmRegisteredAddressControllerSpec.scala
+++ b/test/controllers/fm/NfmRegisteredAddressControllerSpec.scala
@@ -130,7 +130,7 @@ class NfmRegisteredAddressControllerSpec extends SpecBase {
 
     ".onSubmit" should {
       "redirect to next page with valid data onSubmit" in {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         running(applicationOverride) {
           val result = route(applicationOverride, postRequest()).value
 
@@ -142,7 +142,7 @@ class NfmRegisteredAddressControllerSpec extends SpecBase {
       "in a form with errors, include/not include UK in country list based on previous answers" should {
         "include UK if NfmUkBasedPage is true" in {
 
-          when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+          when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
           running(application) {
             val result = route(application, postRequest("postalCode" -> textOver35Chars)).value

--- a/test/controllers/fm/NfmUKAddressControllerSpec.scala
+++ b/test/controllers/fm/NfmUKAddressControllerSpec.scala
@@ -72,7 +72,7 @@ class NfmUKAddressControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, routes.NfmRegisteredAddressController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(
@@ -98,7 +98,7 @@ class NfmUKAddressControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val longChars =
           "27 house 27 house 27 house 27 house 27 house 27 house 27 house 27 house 27 house 27 house27 house 27 house 27 house 27 house 27 house 27 house 27 house 27 house 27 house 27 house27 house 27 house 27 house 27 house 27 house 27 house 27 house 27 house 27 house 27 house27 house 27 house 27 house 27 house 27 house 27 house 27 house 27 house 27 house 27 house"
         val request =
@@ -127,7 +127,7 @@ class NfmUKAddressControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.fm.routes.NfmRegisteredAddressController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(

--- a/test/controllers/fm/NominateFilingMemberYesNoControllerSpec.scala
+++ b/test/controllers/fm/NominateFilingMemberYesNoControllerSpec.scala
@@ -91,7 +91,7 @@ class NominateFilingMemberYesNoControllerSpec extends SpecBase {
           FakeRequest(POST, controllers.fm.routes.NominateFilingMemberYesNoController.onSubmit(NormalMode).url).withFormUrlEncodedBody(
             "value" -> "$$"
           )
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val result    = route(application, request).value
         val boundForm = formProvider().bind(Map("value" -> "$$"))
         val view      = application.injector.instanceOf[NominateFilingMemberYesNoView]
@@ -106,7 +106,7 @@ class NominateFilingMemberYesNoControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.fm.routes.NominateFilingMemberYesNoController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(("nominateFilingMember", "true"))

--- a/test/controllers/registration/CaptureTelephoneDetailsControllerSpec.scala
+++ b/test/controllers/registration/CaptureTelephoneDetailsControllerSpec.scala
@@ -115,7 +115,7 @@ class CaptureTelephoneDetailsControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.registration.routes.CaptureTelephoneDetailsController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(("phoneNumber", "1234567890"))

--- a/test/controllers/registration/ContactUPEByTelephoneControllerSpec.scala
+++ b/test/controllers/registration/ContactUPEByTelephoneControllerSpec.scala
@@ -104,7 +104,7 @@ class ContactUPEByTelephoneControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.registration.routes.ContactUPEByTelephoneController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(
@@ -125,7 +125,7 @@ class ContactUPEByTelephoneControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.registration.routes.ContactUPEByTelephoneController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(

--- a/test/controllers/registration/EntityTypeControllerSpec.scala
+++ b/test/controllers/registration/EntityTypeControllerSpec.scala
@@ -175,11 +175,11 @@ class EntityTypeControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         when(mockIncorporatedEntityIdentificationFrontendConnector.createLimitedCompanyJourney(any(), any())(any()))
           .thenReturn(
-            Future(
+            Future.successful(
               GrsCreateRegistrationResponse(
                 "/report-pillar2-top-up-taxes/test-only/stub-grs-journey-data?continueUrl=normalmode&entityType=UkLimitedCompany"
               )
@@ -207,10 +207,10 @@ class EntityTypeControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         when(mockPartnershipIdentificationFrontendConnector.createPartnershipJourney(any(), any(), any())(any()))
           .thenReturn(
-            Future(
+            Future.successful(
               GrsCreateRegistrationResponse(
                 "/report-pillar2-top-up-taxes/test-only/stub-grs-journey-data?continueUrl=normalmode&entityType=LimitedLiabilityPartnership"
               )
@@ -245,7 +245,7 @@ class EntityTypeControllerSpec extends SpecBase {
         val request = FakeRequest(POST, controllers.registration.routes.EntityTypeController.onSubmit(NormalMode).url)
           .withFormUrlEncodedBody(("value", EntityType.Other.toString))
         when(mockUserAnswersConnectors.save(any(), any())(any()))
-          .thenReturn(Future(jsonTobeReturned))
+          .thenReturn(Future.successful(jsonTobeReturned))
         val result = route(application, request).value
 
         status(result) mustEqual SEE_OTHER

--- a/test/controllers/registration/GrsReturnControllerSpec.scala
+++ b/test/controllers/registration/GrsReturnControllerSpec.scala
@@ -55,7 +55,7 @@ class GrsReturnControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         when(mockIncorporatedEntityIdentificationFrontendConnector.getJourneyData(any())(any()))
           .thenReturn(Future.successful(validRegisterWithIdResponse))
@@ -78,7 +78,7 @@ class GrsReturnControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         when(mockPartnershipIdentificationFrontendConnector.getJourneyData(any())(any()))
           .thenReturn(Future.successful(validRegisterWithIdResponseForLLP))
@@ -101,7 +101,7 @@ class GrsReturnControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         when(mockPartnershipIdentificationFrontendConnector.getJourneyData(any())(any()))
           .thenReturn(Future.successful(validRegisterWithIdResponseForLLP))
         val request = FakeRequest(GET, controllers.registration.routes.GrsReturnController.continueUpe("journeyId").url)
@@ -118,7 +118,7 @@ class GrsReturnControllerSpec extends SpecBase {
         .overrides(bind[IncorporatedEntityIdentificationFrontendConnector].toInstance(mockIncorporatedEntityIdentificationFrontendConnector))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         when(mockIncorporatedEntityIdentificationFrontendConnector.getJourneyData(any())(any()))
           .thenReturn(Future.successful(validRegisterWithIdResponse.copy(registration = GrsRegistrationResult(Registered, None, None))))
         val request = FakeRequest(GET, controllers.registration.routes.GrsReturnController.continueUpe("journeyId").url)
@@ -135,7 +135,7 @@ class GrsReturnControllerSpec extends SpecBase {
         .overrides(bind[PartnershipIdentificationFrontendConnector].toInstance(mockPartnershipIdentificationFrontendConnector))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         when(mockPartnershipIdentificationFrontendConnector.getJourneyData(any())(any()))
           .thenReturn(Future.successful(validRegisterWithIdResponseForLLP.copy(registration = GrsRegistrationResult(Registered, None, None))))
         val request = FakeRequest(GET, controllers.registration.routes.GrsReturnController.continueUpe("journeyId").url)
@@ -153,7 +153,7 @@ class GrsReturnControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         when(mockIncorporatedEntityIdentificationFrontendConnector.getJourneyData(any())(any()))
           .thenReturn(Future.successful(validRegisterWithIdResponse))
@@ -175,7 +175,7 @@ class GrsReturnControllerSpec extends SpecBase {
         .overrides(bind[IncorporatedEntityIdentificationFrontendConnector].toInstance(mockIncorporatedEntityIdentificationFrontendConnector))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         when(mockIncorporatedEntityIdentificationFrontendConnector.getJourneyData(any())(any()))
           .thenReturn(Future.successful(validRegisterWithIdResponse.copy(registration = GrsRegistrationResult(Registered, None, None))))
         val request = FakeRequest(GET, controllers.registration.routes.GrsReturnController.continueFm("journeyId").url)
@@ -193,7 +193,7 @@ class GrsReturnControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         when(mockPartnershipIdentificationFrontendConnector.getJourneyData(any())(any()))
           .thenReturn(Future.successful(validRegisterWithIdResponseForLLP))
@@ -216,7 +216,7 @@ class GrsReturnControllerSpec extends SpecBase {
         .overrides(bind[PartnershipIdentificationFrontendConnector].toInstance(mockPartnershipIdentificationFrontendConnector))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         when(mockPartnershipIdentificationFrontendConnector.getJourneyData(any())(any()))
           .thenReturn(Future.successful(validRegisterWithIdResponseForLLP.copy(registration = GrsRegistrationResult(Registered, None, None))))
         val request = FakeRequest(GET, controllers.registration.routes.GrsReturnController.continueFm("journeyId").url)
@@ -234,7 +234,7 @@ class GrsReturnControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         when(mockIncorporatedEntityIdentificationFrontendConnector.getJourneyData(any())(any()))
           .thenReturn(Future.successful(validRegisterWithIdResponse))
@@ -257,7 +257,7 @@ class GrsReturnControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         when(mockPartnershipIdentificationFrontendConnector.getJourneyData(any())(any()))
           .thenReturn(Future.successful(validRegisterWithIdResponseForLLP))
@@ -280,7 +280,7 @@ class GrsReturnControllerSpec extends SpecBase {
         .overrides(bind[PartnershipIdentificationFrontendConnector].toInstance(mockPartnershipIdentificationFrontendConnector))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         when(mockPartnershipIdentificationFrontendConnector.getJourneyData(any())(any()))
           .thenReturn(Future.successful(validRegisterWithIdResponseForLLP.copy(companyProfile = None)))
         val request = FakeRequest(GET, controllers.registration.routes.GrsReturnController.continueRfm("journeyId").url)
@@ -297,7 +297,7 @@ class GrsReturnControllerSpec extends SpecBase {
         .overrides(bind[PartnershipIdentificationFrontendConnector].toInstance(mockPartnershipIdentificationFrontendConnector))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         when(mockPartnershipIdentificationFrontendConnector.getJourneyData(any())(any()))
           .thenReturn(Future.successful(validRegisterWithIdResponseForLLP.copy(sautr = None)))
         val request = FakeRequest(GET, controllers.registration.routes.GrsReturnController.continueRfm("journeyId").url)
@@ -314,7 +314,7 @@ class GrsReturnControllerSpec extends SpecBase {
         .overrides(bind[PartnershipIdentificationFrontendConnector].toInstance(mockPartnershipIdentificationFrontendConnector))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         when(mockPartnershipIdentificationFrontendConnector.getJourneyData(any())(any()))
           .thenReturn(Future.successful(validRegisterWithIdResponseForLLP.copy(registration = GrsRegistrationResult(Registered, None, None))))
         val request = FakeRequest(GET, controllers.registration.routes.GrsReturnController.continueRfm("journeyId").url)
@@ -331,7 +331,7 @@ class GrsReturnControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         val request = FakeRequest(GET, controllers.registration.routes.GrsReturnController.continueRfm("journeyId").url)
 
@@ -353,7 +353,7 @@ class GrsReturnControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         when(mockIncorporatedEntityIdentificationFrontendConnector.getJourneyData(any())(any()))
           .thenReturn(Future.successful(validRegisterWithIdResponseWithoutPartner))
@@ -377,7 +377,7 @@ class GrsReturnControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         when(mockPartnershipIdentificationFrontendConnector.getJourneyData(any())(any()))
           .thenReturn(Future.successful(validRegisterWithIdResponseForLLPWithoutPartner))
@@ -401,7 +401,7 @@ class GrsReturnControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         when(mockIncorporatedEntityIdentificationFrontendConnector.getJourneyData(any())(any()))
           .thenReturn(Future.successful(failedIdentifierLimited))
@@ -424,7 +424,7 @@ class GrsReturnControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         when(mockPartnershipIdentificationFrontendConnector.getJourneyData(any())(any()))
           .thenReturn(Future.successful(failedIdentifierLLP))
@@ -448,7 +448,7 @@ class GrsReturnControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         when(mockIncorporatedEntityIdentificationFrontendConnector.getJourneyData(any())(any()))
           .thenReturn(Future.successful(registrationFailedLimited))
@@ -471,7 +471,7 @@ class GrsReturnControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         when(mockPartnershipIdentificationFrontendConnector.getJourneyData(any())(any()))
           .thenReturn(Future.successful(registrationFailedLLP))
@@ -495,7 +495,7 @@ class GrsReturnControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         when(mockIncorporatedEntityIdentificationFrontendConnector.getJourneyData(any())(any()))
           .thenReturn(Future.successful(registrationFailedLimited))
@@ -518,7 +518,7 @@ class GrsReturnControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         when(mockPartnershipIdentificationFrontendConnector.getJourneyData(any())(any()))
           .thenReturn(Future.successful(failedIdentifierLLP))
@@ -541,7 +541,7 @@ class GrsReturnControllerSpec extends SpecBase {
         .overrides(bind[PartnershipIdentificationFrontendConnector].toInstance(mockPartnershipIdentificationFrontendConnector))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         when(mockPartnershipIdentificationFrontendConnector.getJourneyData(any())(any()))
           .thenReturn(
             Future.successful(

--- a/test/controllers/registration/UpeContactEmailControllerSpec.scala
+++ b/test/controllers/registration/UpeContactEmailControllerSpec.scala
@@ -124,7 +124,7 @@ class UpeContactEmailControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.registration.routes.UpeContactEmailController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(

--- a/test/controllers/registration/UpeContactNameControllerSpec.scala
+++ b/test/controllers/registration/UpeContactNameControllerSpec.scala
@@ -85,7 +85,7 @@ class UpeContactNameControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.registration.routes.UpeContactNameController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(
@@ -115,7 +115,7 @@ class UpeContactNameControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val stringInput = randomStringGenerator(201)
         val request =
           FakeRequest(POST, routes.UpeContactNameController.onSubmit(NormalMode).url).withFormUrlEncodedBody("value" -> stringInput)

--- a/test/controllers/registration/UpeNameRegistrationControllerSpec.scala
+++ b/test/controllers/registration/UpeNameRegistrationControllerSpec.scala
@@ -103,7 +103,7 @@ class UpeNameRegistrationControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.registration.routes.UpeNameRegistrationController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(

--- a/test/controllers/registration/UpeRegisteredAddressControllerSpec.scala
+++ b/test/controllers/registration/UpeRegisteredAddressControllerSpec.scala
@@ -47,7 +47,7 @@ class UpeRegisteredAddressControllerSpec extends SpecBase {
 
   def application: Application = applicationBuilder(Some(defaultUa)).build()
   def applicationOverride: Application = {
-    when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+    when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
     applicationBuilder(Some(defaultUa))
       .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))

--- a/test/controllers/registration/UpeUKAddressControllerSpec.scala
+++ b/test/controllers/registration/UpeUKAddressControllerSpec.scala
@@ -64,7 +64,7 @@ class UpeUKAddressControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(GET, controllers.registration.routes.UpeRegisteredAddressController.onPageLoad(NormalMode).url).withFormUrlEncodedBody(
             ("addressLine1", "27 house"),
@@ -87,7 +87,7 @@ class UpeUKAddressControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, routes.UpeRegisteredAddressController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(
@@ -112,7 +112,7 @@ class UpeUKAddressControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val badHouse = "27 house" * 120
         val request =
           FakeRequest(POST, routes.UpeRegisteredAddressController.onSubmit(NormalMode).url)

--- a/test/controllers/rfm/CorporatePositionControllerSpec.scala
+++ b/test/controllers/rfm/CorporatePositionControllerSpec.scala
@@ -92,8 +92,8 @@ class CorporatePositionControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
-        when(mockSessionRepository.get(any())).thenReturn(Future(Some(ua)))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
+        when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(ua)))
 
         val request = FakeRequest(POST, controllers.rfm.routes.CorporatePositionController.onSubmit(NormalMode).url)
           .withFormUrlEncodedBody("value" -> CorporatePosition.Upe.toString)
@@ -118,8 +118,8 @@ class CorporatePositionControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
-        when(mockSessionRepository.get(any())).thenReturn(Future(Some(ua)))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
+        when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(ua)))
         val request = FakeRequest(POST, controllers.rfm.routes.CorporatePositionController.onSubmit(NormalMode).url)
           .withFormUrlEncodedBody("value" -> CorporatePosition.NewNfm.toString)
 
@@ -141,7 +141,7 @@ class CorporatePositionControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockSessionRepository.get(any())).thenReturn(Future(Some(ua)))
+        when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(ua)))
         val request =
           FakeRequest(POST, controllers.rfm.routes.CorporatePositionController.onPageLoad(NormalMode).url)
             .withFormUrlEncodedBody(("value", ""))
@@ -159,7 +159,7 @@ class CorporatePositionControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockSessionRepository.get(any())).thenReturn(Future(None))
+        when(mockSessionRepository.get(any())).thenReturn(Future.successful(None))
         val request =
           FakeRequest(POST, controllers.rfm.routes.CorporatePositionController.onPageLoad(NormalMode).url)
             .withFormUrlEncodedBody(("value", ""))
@@ -189,7 +189,7 @@ class CorporatePositionControllerSpec extends SpecBase {
       running(application) {
         when(mockNavigator.nextPage(any(), any(), any())).thenReturn(expectedNextPage)
         when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.obj()))
-        when(mockSessionRepository.get(any())).thenReturn(Future(None))
+        when(mockSessionRepository.get(any())).thenReturn(Future.successful(None))
         val request =
           FakeRequest(POST, controllers.rfm.routes.CorporatePositionController.onPageLoad(NormalMode).url)
             .withFormUrlEncodedBody(("value", "newNfm"))

--- a/test/controllers/rfm/GroupRegistrationDateReportControllerSpec.scala
+++ b/test/controllers/rfm/GroupRegistrationDateReportControllerSpec.scala
@@ -80,7 +80,7 @@ class GroupRegistrationDateReportControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         val request = FakeRequest(POST, controllers.rfm.routes.GroupRegistrationDateReportController.onSubmit(NormalMode).url)
           .withFormUrlEncodedBody(
@@ -104,7 +104,7 @@ class GroupRegistrationDateReportControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         val request = FakeRequest(POST, controllers.rfm.routes.GroupRegistrationDateReportController.onSubmit(NormalMode).url)
           .withFormUrlEncodedBody(
@@ -128,7 +128,7 @@ class GroupRegistrationDateReportControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         val request = FakeRequest(POST, controllers.rfm.routes.GroupRegistrationDateReportController.onSubmit(NormalMode).url)
           .withFormUrlEncodedBody(

--- a/test/controllers/rfm/RfmAddSecondaryContactControllerSpec.scala
+++ b/test/controllers/rfm/RfmAddSecondaryContactControllerSpec.scala
@@ -99,7 +99,7 @@ class RfmAddSecondaryContactControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         val request = FakeRequest(POST, controllers.rfm.routes.RfmAddSecondaryContactController.onSubmit(NormalMode).url)
           .withFormUrlEncodedBody("value" -> "true")

--- a/test/controllers/rfm/RfmCapturePrimaryTelephoneControllerSpec.scala
+++ b/test/controllers/rfm/RfmCapturePrimaryTelephoneControllerSpec.scala
@@ -87,7 +87,7 @@ class RfmCapturePrimaryTelephoneControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.rfm.routes.RfmCapturePrimaryTelephoneController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(

--- a/test/controllers/rfm/RfmContactAddressControllerSpec.scala
+++ b/test/controllers/rfm/RfmContactAddressControllerSpec.scala
@@ -38,7 +38,7 @@ class RfmContactAddressControllerSpec extends SpecBase {
   val defaultUa:   UserAnswers = emptyUserAnswers.set(RfmPrimaryContactNamePage, "Name").success.value
   def application: Application = applicationBuilder(userAnswers = Some(defaultUa)).build()
   def applicationOverride: Application = {
-    when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+    when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
     applicationBuilder(userAnswers = Some(defaultUa))
       .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))

--- a/test/controllers/rfm/RfmContactByTelephoneControllerSpec.scala
+++ b/test/controllers/rfm/RfmContactByTelephoneControllerSpec.scala
@@ -110,7 +110,7 @@ class RfmContactByTelephoneControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.rfm.routes.RfmContactByTelephoneController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(("value", "true"))
@@ -155,7 +155,7 @@ class RfmContactByTelephoneControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.rfm.routes.RfmContactByTelephoneController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(("value", "false"))

--- a/test/controllers/rfm/RfmContactCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/rfm/RfmContactCheckYourAnswersControllerSpec.scala
@@ -55,7 +55,7 @@ class RfmContactCheckYourAnswersControllerSpec extends SpecBase with SummaryList
         .build()
       running(application) {
         when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(sessionRepositoryUserAnswers)))
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request = FakeRequest(GET, controllers.rfm.routes.RfmContactCheckYourAnswersController.onPageLoad.url)
         val result  = route(application, request).value
         status(result) mustEqual OK
@@ -103,7 +103,7 @@ class RfmContactCheckYourAnswersControllerSpec extends SpecBase with SummaryList
         .build()
       running(application) {
         when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(sessionRepositoryUserAnswers)))
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request = FakeRequest(GET, controllers.rfm.routes.RfmContactCheckYourAnswersController.onPageLoad.url)
         val result  = route(application, request).value
         status(result) mustEqual OK
@@ -154,7 +154,7 @@ class RfmContactCheckYourAnswersControllerSpec extends SpecBase with SummaryList
         .build()
       running(application) {
         when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(sessionRepositoryUserAnswers)))
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request = FakeRequest(GET, controllers.rfm.routes.RfmContactCheckYourAnswersController.onPageLoad.url)
         val result  = route(application, request).value
         status(result) mustEqual OK
@@ -208,7 +208,7 @@ class RfmContactCheckYourAnswersControllerSpec extends SpecBase with SummaryList
         .build()
       running(application) {
         when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(sessionRepositoryUserAnswers)))
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request = FakeRequest(GET, controllers.rfm.routes.RfmContactCheckYourAnswersController.onPageLoad.url)
         val result  = route(application, request).value
         status(result) mustEqual OK
@@ -248,7 +248,7 @@ class RfmContactCheckYourAnswersControllerSpec extends SpecBase with SummaryList
         .build()
       running(application) {
         when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(sessionRepositoryUserAnswers)))
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request = FakeRequest(GET, controllers.rfm.routes.RfmContactCheckYourAnswersController.onPageLoad.url)
         val result  = route(application, request).value
         status(result) mustEqual SEE_OTHER

--- a/test/controllers/rfm/RfmEntityTypeControllerSpec.scala
+++ b/test/controllers/rfm/RfmEntityTypeControllerSpec.scala
@@ -143,11 +143,11 @@ class RfmEntityTypeControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         when(mockIncorporatedEntityIdentificationFrontendConnector.createLimitedCompanyJourney(any(), any())(any()))
           .thenReturn(
-            Future(
+            Future.successful(
               GrsCreateRegistrationResponse(
                 "/report-pillar2-top-up-taxes/test-only/stub-grs-journey-data?continueUrl=normalmode&entityType=UkLimitedCompany"
               )
@@ -181,10 +181,10 @@ class RfmEntityTypeControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         when(mockPartnershipIdentificationFrontendConnector.createPartnershipJourney(any(), any(), any())(any()))
           .thenReturn(
-            Future(
+            Future.successful(
               GrsCreateRegistrationResponse(
                 "/report-pillar2-top-up-taxes/test-only/stub-grs-journey-data?continueUrl=normalmode&entityType=LimitedLiabilityPartnership"
               )
@@ -218,7 +218,7 @@ class RfmEntityTypeControllerSpec extends SpecBase {
       running(application) {
         val request = FakeRequest(POST, controllers.rfm.routes.RfmEntityTypeController.onSubmit(NormalMode).url)
           .withFormUrlEncodedBody(("value", EntityType.Other.toString))
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(jsonTobeReturned))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(jsonTobeReturned))
         val result = route(application, request).value
 
         status(result) mustEqual SEE_OTHER
@@ -242,7 +242,7 @@ class RfmEntityTypeControllerSpec extends SpecBase {
 
       running(application) {
         val request = FakeRequest(GET, controllers.rfm.routes.RfmEntityTypeController.onPageLoad(NormalMode).url)
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(jsonTobeReturned))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(jsonTobeReturned))
         val view = application.injector.instanceOf[RfmEntityTypeView]
 
         val result = route(application, request).value

--- a/test/controllers/rfm/RfmNameRegistrationControllerSpec.scala
+++ b/test/controllers/rfm/RfmNameRegistrationControllerSpec.scala
@@ -85,7 +85,7 @@ class RfmNameRegistrationControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         val request = FakeRequest(POST, controllers.rfm.routes.RfmNameRegistrationController.onSubmit(NormalMode).url)
           .withFormUrlEncodedBody("value" -> "name")

--- a/test/controllers/rfm/RfmNewFilingMemberDetailControllerSpec.scala
+++ b/test/controllers/rfm/RfmNewFilingMemberDetailControllerSpec.scala
@@ -83,7 +83,7 @@ class RfmNewFilingMemberDetailControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         val request = FakeRequest(POST, controllers.rfm.routes.RfmPrimaryContactNameController.onSubmit(NormalMode).url)
           .withFormUrlEncodedBody("value" -> "name")

--- a/test/controllers/rfm/RfmPrimaryContactEmailControllerSpec.scala
+++ b/test/controllers/rfm/RfmPrimaryContactEmailControllerSpec.scala
@@ -107,7 +107,7 @@ class RfmPrimaryContactEmailControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.rfm.routes.RfmPrimaryContactEmailController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(("emailAddress", "AshleySmith@email.com"))

--- a/test/controllers/rfm/RfmPrimaryContactNameControllerSpec.scala
+++ b/test/controllers/rfm/RfmPrimaryContactNameControllerSpec.scala
@@ -85,7 +85,7 @@ class RfmPrimaryContactNameControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         val request = FakeRequest(POST, controllers.rfm.routes.RfmPrimaryContactNameController.onSubmit(NormalMode).url)
           .withFormUrlEncodedBody("value" -> "name")

--- a/test/controllers/rfm/RfmRegisteredAddressControllerSpec.scala
+++ b/test/controllers/rfm/RfmRegisteredAddressControllerSpec.scala
@@ -143,7 +143,7 @@ class RfmRegisteredAddressControllerSpec extends SpecBase {
 
     ".onSubmit" should {
       "redirect to NoIdCheckYourAnswersController with valid data onSubmit" in {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         running(applicationOverride) {
           val result = route(applicationOverride, postRequest()).value
 
@@ -169,7 +169,7 @@ class RfmRegisteredAddressControllerSpec extends SpecBase {
       "in a form with errors, include/not include UK in country list based on previous answers" should {
         "include UK if RfmUkBasedPage is true" in {
 
-          when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+          when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
           running(application) {
             val result = route(application, postRequest("postalCode" -> textOver35Chars)).value

--- a/test/controllers/rfm/RfmSecondaryContactEmailControllerSpec.scala
+++ b/test/controllers/rfm/RfmSecondaryContactEmailControllerSpec.scala
@@ -88,7 +88,7 @@ class RfmSecondaryContactEmailControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.rfm.routes.RfmSecondaryContactEmailController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(("emailAddress", "12345"))
@@ -116,7 +116,7 @@ class RfmSecondaryContactEmailControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         val request = FakeRequest(POST, controllers.rfm.routes.RfmSecondaryContactEmailController.onSubmit(NormalMode).url)
           .withFormUrlEncodedBody(("emailAddress", "AshleySmith@email.com"))

--- a/test/controllers/rfm/RfmSecondaryContactNameControllerSpec.scala
+++ b/test/controllers/rfm/RfmSecondaryContactNameControllerSpec.scala
@@ -89,7 +89,7 @@ class RfmSecondaryContactNameControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         val request = FakeRequest(POST, controllers.rfm.routes.RfmSecondaryContactNameController.onSubmit(NormalMode).url)
           .withFormUrlEncodedBody("value" -> "alexy")

--- a/test/controllers/rfm/RfmSecondaryTelephoneControllerSpec.scala
+++ b/test/controllers/rfm/RfmSecondaryTelephoneControllerSpec.scala
@@ -97,7 +97,7 @@ class RfmSecondaryTelephoneControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         val request = FakeRequest(POST, controllers.rfm.routes.RfmSecondaryTelephoneController.onSubmit(NormalMode).url)
           .withFormUrlEncodedBody(("phoneNumber", "1234567"))

--- a/test/controllers/rfm/RfmSecondaryTelephonePreferenceControllerSpec.scala
+++ b/test/controllers/rfm/RfmSecondaryTelephonePreferenceControllerSpec.scala
@@ -95,7 +95,7 @@ class RfmSecondaryTelephonePreferenceControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
         val request = FakeRequest(POST, controllers.rfm.routes.RfmSecondaryTelephonePreferenceController.onSubmit(NormalMode).url)
           .withFormUrlEncodedBody(("value", "true"))

--- a/test/controllers/rfm/SecurityCheckControllerSpec.scala
+++ b/test/controllers/rfm/SecurityCheckControllerSpec.scala
@@ -133,7 +133,7 @@ class SecurityCheckControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         when(mockEnrolmentStoreProxyConnector.getGroupIds(any())(any())).thenReturn(Future.successful(Some(GroupIds(Seq(PlrReference), Seq.empty))))
 
         val request = FakeRequest(POST, controllers.rfm.routes.SecurityCheckController.onSubmit(NormalMode).url)

--- a/test/controllers/rfm/UkBankAccountBasedFilingMemberControllerSpec.scala
+++ b/test/controllers/rfm/UkBankAccountBasedFilingMemberControllerSpec.scala
@@ -98,7 +98,7 @@ class UkBankAccountBasedFilingMemberControllerSpec extends SpecBase {
           .build()
 
         running(application) {
-          when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+          when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
           val request =
             FakeRequest(POST, controllers.rfm.routes.UkBasedFilingMemberController.onSubmit(NormalMode).url).withFormUrlEncodedBody("value" -> "true")
           val result = route(application, request).value

--- a/test/controllers/subscription/CaptureSubscriptionAddressControllerSpec.scala
+++ b/test/controllers/subscription/CaptureSubscriptionAddressControllerSpec.scala
@@ -36,7 +36,7 @@ class CaptureSubscriptionAddressControllerSpec extends SpecBase {
   val formProvider = new CaptureSubscriptionAddressFormProvider()
 
   def application: Application = {
-    when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+    when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
     applicationBuilder(userAnswers = Some(emptyUserAnswers.setOrException(SubAddSecondaryContactPage, true)))
       .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
@@ -46,7 +46,7 @@ class CaptureSubscriptionAddressControllerSpec extends SpecBase {
   def getRequest: FakeRequest[AnyContentAsEmpty.type] =
     FakeRequest(GET, controllers.subscription.routes.CaptureSubscriptionAddressController.onPageLoad(NormalMode).url)
   def postRequest(alterations: (String, String)*): FakeRequest[AnyContentAsFormUrlEncoded] = {
-    when(mockSubscriptionConnector.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+    when(mockSubscriptionConnector.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
     val address = Map(
       "addressLine1" -> "27 House",

--- a/test/controllers/subscription/ContactByTelephoneControllerSpec.scala
+++ b/test/controllers/subscription/ContactByTelephoneControllerSpec.scala
@@ -127,7 +127,7 @@ class ContactByTelephoneControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.subscription.routes.ContactByTelephoneController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(

--- a/test/controllers/subscription/ContactCaptureTelephoneDetailsControllerSpec.scala
+++ b/test/controllers/subscription/ContactCaptureTelephoneDetailsControllerSpec.scala
@@ -91,7 +91,7 @@ class ContactCaptureTelephoneDetailsControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.subscription.routes.ContactCaptureTelephoneDetailsController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(("phoneNumber", "33333222" * 100))
@@ -113,7 +113,7 @@ class ContactCaptureTelephoneDetailsControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.subscription.routes.ContactCaptureTelephoneDetailsController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(

--- a/test/controllers/subscription/ContactCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/subscription/ContactCheckYourAnswersControllerSpec.scala
@@ -57,7 +57,7 @@ class ContactCheckYourAnswersControllerSpec extends SpecBase with SummaryListFlu
       val application = applicationBuilder(userAnswers = Some(subDataWithAddress)).build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request = FakeRequest(GET, controllers.subscription.routes.ContactCheckYourAnswersController.onPageLoad.url)
         val result  = route(application, request).value
         status(result) mustEqual OK

--- a/test/controllers/subscription/ContactEmailAddressControllerSpec.scala
+++ b/test/controllers/subscription/ContactEmailAddressControllerSpec.scala
@@ -104,7 +104,7 @@ class ContactEmailAddressControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.subscription.routes.ContactEmailAddressController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(

--- a/test/controllers/subscription/ContactNameComplianceControllerSpec.scala
+++ b/test/controllers/subscription/ContactNameComplianceControllerSpec.scala
@@ -102,7 +102,7 @@ class ContactNameComplianceControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.subscription.routes.ContactNameComplianceController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(

--- a/test/controllers/subscription/DuplicateSafeIdControllerSpec.scala
+++ b/test/controllers/subscription/DuplicateSafeIdControllerSpec.scala
@@ -78,7 +78,7 @@ class DuplicateSafeIdControllerSpec extends SpecBase {
           FakeRequest(POST, controllers.subscription.routes.DuplicateSafeIdController.onSubmit.url).withFormUrlEncodedBody(
             "nominateFilingMember" -> "$$"
           )
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val result    = route(application, request).value
         val boundForm = formProvider().bind(Map("nominateFilingMember" -> "$$"))
         val view      = application.injector.instanceOf[DuplicateSafeIdView]
@@ -93,7 +93,7 @@ class DuplicateSafeIdControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.subscription.routes.DuplicateSafeIdController.onSubmit.url)
             .withFormUrlEncodedBody(("nominateFilingMember", "true"))
@@ -109,7 +109,7 @@ class DuplicateSafeIdControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.subscription.routes.DuplicateSafeIdController.onSubmit.url)
             .withFormUrlEncodedBody(("nominateFilingMember", "false"))

--- a/test/controllers/subscription/GroupAccountingPeriodControllerSpec.scala
+++ b/test/controllers/subscription/GroupAccountingPeriodControllerSpec.scala
@@ -80,7 +80,7 @@ class GroupAccountingPeriodControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.subscription.routes.GroupAccountingPeriodController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(
@@ -106,7 +106,7 @@ class GroupAccountingPeriodControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.subscription.routes.GroupAccountingPeriodController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(

--- a/test/controllers/subscription/MneOrDomesticControllerSpec.scala
+++ b/test/controllers/subscription/MneOrDomesticControllerSpec.scala
@@ -93,7 +93,7 @@ class MneOrDomesticControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.subscription.routes.MneOrDomesticController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(

--- a/test/controllers/subscription/SecondaryContactEmailControllerSpec.scala
+++ b/test/controllers/subscription/SecondaryContactEmailControllerSpec.scala
@@ -87,7 +87,7 @@ class SecondaryContactEmailControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.subscription.routes.SecondaryContactEmailController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(("emailAddress", "12345"))
@@ -127,7 +127,7 @@ class SecondaryContactEmailControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.subscription.routes.SecondaryContactEmailController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(

--- a/test/controllers/subscription/SecondaryContactNameControllerSpec.scala
+++ b/test/controllers/subscription/SecondaryContactNameControllerSpec.scala
@@ -105,7 +105,7 @@ class SecondaryContactNameControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.subscription.routes.SecondaryContactNameController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(

--- a/test/controllers/subscription/SecondaryTelephoneControllerSpec.scala
+++ b/test/controllers/subscription/SecondaryTelephoneControllerSpec.scala
@@ -128,7 +128,7 @@ class SecondaryTelephoneControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.subscription.routes.SecondaryTelephoneController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(

--- a/test/controllers/subscription/SecondaryTelephonePreferenceControllerSpec.scala
+++ b/test/controllers/subscription/SecondaryTelephonePreferenceControllerSpec.scala
@@ -127,7 +127,7 @@ class SecondaryTelephonePreferenceControllerSpec extends SpecBase {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.subscription.routes.SecondaryTelephonePreferenceController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(

--- a/test/controllers/subscription/UseContactPrimaryControllerSpec.scala
+++ b/test/controllers/subscription/UseContactPrimaryControllerSpec.scala
@@ -485,7 +485,7 @@ class UseContactPrimaryControllerSpec extends SpecBase with ViewInstances {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.subscription.routes.UseContactPrimaryController.onPageLoad(NormalMode).url)
             .withFormUrlEncodedBody(("value", ""))
@@ -519,7 +519,7 @@ class UseContactPrimaryControllerSpec extends SpecBase with ViewInstances {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.subscription.routes.UseContactPrimaryController.onPageLoad(NormalMode).url)
             .withFormUrlEncodedBody(("value", ""))
@@ -551,7 +551,7 @@ class UseContactPrimaryControllerSpec extends SpecBase with ViewInstances {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.subscription.routes.UseContactPrimaryController.onPageLoad(NormalMode).url)
         val result = route(application, request).value
@@ -573,7 +573,7 @@ class UseContactPrimaryControllerSpec extends SpecBase with ViewInstances {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.subscription.routes.UseContactPrimaryController.onPageLoad(NormalMode).url)
         val result = route(application, request).value
@@ -596,7 +596,7 @@ class UseContactPrimaryControllerSpec extends SpecBase with ViewInstances {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.subscription.routes.UseContactPrimaryController.onPageLoad(NormalMode).url)
         val result = route(application, request).value
@@ -618,7 +618,7 @@ class UseContactPrimaryControllerSpec extends SpecBase with ViewInstances {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.subscription.routes.UseContactPrimaryController.onPageLoad(NormalMode).url)
         val result = route(application, request).value
@@ -648,7 +648,7 @@ class UseContactPrimaryControllerSpec extends SpecBase with ViewInstances {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.subscription.routes.UseContactPrimaryController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(
@@ -679,7 +679,7 @@ class UseContactPrimaryControllerSpec extends SpecBase with ViewInstances {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.subscription.routes.UseContactPrimaryController.onSubmit(NormalMode).url)
             .withFormUrlEncodedBody(
@@ -697,7 +697,7 @@ class UseContactPrimaryControllerSpec extends SpecBase with ViewInstances {
         .overrides(bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors))
         .build()
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.subscription.routes.UseContactPrimaryController.onPageLoad(NormalMode).url)
         val result = route(application, request).value

--- a/test/controllers/subscription/manageAccount/CaptureSubscriptionAddressControllerSpec.scala
+++ b/test/controllers/subscription/manageAccount/CaptureSubscriptionAddressControllerSpec.scala
@@ -62,7 +62,7 @@ class CaptureSubscriptionAddressControllerSpec extends SpecBase {
   def getRequest: FakeRequest[AnyContentAsEmpty.type] =
     FakeRequest(GET, controllers.subscription.manageAccount.routes.CaptureSubscriptionAddressController.onPageLoad.url)
   def postRequest(alterations: (String, String)*): FakeRequest[AnyContentAsFormUrlEncoded] = {
-    when(mockSubscriptionConnector.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+    when(mockSubscriptionConnector.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
 
     val address = Map(
       "addressLine1" -> "27 House",

--- a/test/controllers/subscription/manageAccount/ContactCaptureTelephoneDetailsControllerSpec.scala
+++ b/test/controllers/subscription/manageAccount/ContactCaptureTelephoneDetailsControllerSpec.scala
@@ -97,7 +97,7 @@ class ContactCaptureTelephoneDetailsControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.subscription.manageAccount.routes.ContactCaptureTelephoneDetailsController.onSubmit.url)
             .withFormUrlEncodedBody(("phoneNumber", "33333222" * 100))
@@ -227,7 +227,7 @@ class ContactCaptureTelephoneDetailsControllerSpec extends SpecBase {
         )
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.subscription.manageAccount.routes.ContactCaptureTelephoneDetailsController.onSubmit.url)
             .withFormUrlEncodedBody(("phoneNumber", "33333222" * 100))

--- a/test/controllers/subscription/manageAccount/ManageContactCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/subscription/manageAccount/ManageContactCheckYourAnswersControllerSpec.scala
@@ -123,7 +123,7 @@ class ManageContactCheckYourAnswersControllerSpec extends SpecBase with SummaryL
         .build()
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request = FakeRequest(GET, controllers.subscription.manageAccount.routes.ManageContactCheckYourAnswersController.onPageLoad.url)
         val result  = route(application, request).value
         status(result) mustEqual OK
@@ -152,7 +152,7 @@ class ManageContactCheckYourAnswersControllerSpec extends SpecBase with SummaryL
         )
 
       running(application) {
-        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request = FakeRequest(GET, controllers.subscription.manageAccount.routes.ManageContactCheckYourAnswersController.onPageLoad.url)
         val result  = route(application, request).value
         status(result) mustEqual OK

--- a/test/controllers/subscription/manageAccount/SecondaryContactEmailControllerSpec.scala
+++ b/test/controllers/subscription/manageAccount/SecondaryContactEmailControllerSpec.scala
@@ -104,7 +104,7 @@ class SecondaryContactEmailControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        when(mockSubscriptionConnector.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockSubscriptionConnector.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(POST, controllers.subscription.manageAccount.routes.SecondaryContactEmailController.onPageLoad.url)
             .withFormUrlEncodedBody(("emailAddress", "12345"))
@@ -268,7 +268,7 @@ class SecondaryContactEmailControllerSpec extends SpecBase {
         )
 
       running(application) {
-        when(mockSubscriptionConnector.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+        when(mockSubscriptionConnector.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
         val request =
           FakeRequest(
             POST,

--- a/test/services/SubscriptionServiceSpec.scala
+++ b/test/services/SubscriptionServiceSpec.scala
@@ -69,7 +69,7 @@ class SubscriptionServiceSpec extends SpecBase {
           when(mockSubscriptionConnector.subscribe(any())(any())).thenReturn(Future.successful("ID"))
           when(mockEnrolmentConnector.enrolAndActivate(any())(any())).thenReturn(Future.successful(Done))
           when(mockEnrolmentStoreProxyConnector.getGroupIds(any())(any())).thenReturn(Future.successful(None))
-          when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+          when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
           when(mockUserAnswersConnectors.getUserAnswer(any())(any())).thenReturn(Future.successful(Some(userAnswer)))
 
           val result = service.createSubscription(userAnswer)
@@ -97,7 +97,7 @@ class SubscriptionServiceSpec extends SpecBase {
           when(mockSubscriptionConnector.subscribe(any())(any())).thenReturn(Future.successful("ID"))
           when(mockEnrolmentConnector.enrolAndActivate(any())(any())).thenReturn(Future.successful(Done))
           when(mockEnrolmentStoreProxyConnector.getGroupIds(any())(any())).thenReturn(Future.successful(None))
-          when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+          when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
           when(mockUserAnswersConnectors.getUserAnswer(any())(any())).thenReturn(Future.successful(Some(userAnswer)))
 
           val result = service.createSubscription(userAnswer)
@@ -126,7 +126,7 @@ class SubscriptionServiceSpec extends SpecBase {
           when(mockSubscriptionConnector.subscribe(any())(any())).thenReturn(Future.successful("ID"))
           when(mockEnrolmentConnector.enrolAndActivate(any())(any())).thenReturn(Future.successful(Done))
           when(mockEnrolmentStoreProxyConnector.getGroupIds(any())(any())).thenReturn(Future.successful(None))
-          when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+          when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
           when(mockUserAnswersConnectors.getUserAnswer(any())(any())).thenReturn(Future.successful(Some(userAnswer)))
 
           val result = service.createSubscription(userAnswer)
@@ -220,7 +220,7 @@ class SubscriptionServiceSpec extends SpecBase {
           when(mockSubscriptionConnector.subscribe(any())(any())).thenReturn(Future.failed(models.InternalIssueError))
           when(mockEnrolmentConnector.enrolAndActivate(any())(any())).thenReturn(Future.successful(Done))
           when(mockEnrolmentStoreProxyConnector.getGroupIds(any())(any())).thenReturn(Future.successful(None))
-          when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+          when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
           when(mockUserAnswersConnectors.getUserAnswer(any())(any())).thenReturn(Future.successful(Some(userAnswer)))
           val result = service.createSubscription(userAnswer)
           result.failed.futureValue mustBe models.InternalIssueError
@@ -251,7 +251,7 @@ class SubscriptionServiceSpec extends SpecBase {
           when(mockSubscriptionConnector.subscribe(any())(any())).thenReturn(Future.successful("ID"))
           when(mockEnrolmentConnector.enrolAndActivate(any())(any())).thenReturn(Future.failed(models.InternalIssueError))
           when(mockEnrolmentStoreProxyConnector.getGroupIds(any())(any())).thenReturn(Future.successful(None))
-          when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+          when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
           when(mockUserAnswersConnectors.getUserAnswer(any())(any())).thenReturn(Future.successful(Some(userAnswer)))
           val result = service.createSubscription(userAnswer)
           result.failed.futureValue mustBe models.InternalIssueError
@@ -303,7 +303,7 @@ class SubscriptionServiceSpec extends SpecBase {
         running(application) {
           when(mockRegistrationConnector.registerUltimateParent(any())(any())).thenReturn(Future.successful("DuplicateID"))
           when(mockRegistrationConnector.registerFilingMember(any())(any())).thenReturn(Future.successful("DuplicateID"))
-          when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future(Json.toJson(Json.obj())))
+          when(mockUserAnswersConnectors.save(any(), any())(any())).thenReturn(Future.successful(Json.toJson(Json.obj())))
           when(mockUserAnswersConnectors.getUserAnswer(any())(any())).thenReturn(Future.successful(Some(userAnswer)))
 
           val result = service.createSubscription(userAnswer)


### PR DESCRIPTION
Replaced instances of `Future()` with `Future.successful()` to improve performance, resource consumption and thread pool usage.