### PR TITLE
[PIL-2315] - add check using pattern matching for double clicking button

### DIFF
--- a/app/controllers/AgentController.scala
+++ b/app/controllers/AgentController.scala
@@ -117,21 +117,16 @@ class AgentController @Inject() (
 
   def onSubmitConfirmClientDetails: Action[AnyContent] =
     (identify andThen getData andThen requireData).async { implicit request =>
-      request.userAnswers.get(AgentClientPillar2ReferencePage) match {
-        case Some(_) =>
-          Future.successful(Redirect(routes.DashboardController.onPageLoad))
-        case None =>
-          request.userAnswers
-            .get(UnauthorisedClientPillar2ReferencePage)
-            .map { clientPillar2Reference =>
-              for {
-                updatedAnswers <- Future.fromTry(request.userAnswers.set(AgentClientPillar2ReferencePage, clientPillar2Reference))
-                dataToSave     <- Future.fromTry(updatedAnswers.remove(UnauthorisedClientPillar2ReferencePage))
-                _              <- sessionRepository.set(dataToSave)
-              } yield Redirect(routes.DashboardController.onPageLoad)
-            }
-            .getOrElse(Future.successful(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad())))
-      }
+      request.userAnswers
+        .get(UnauthorisedClientPillar2ReferencePage)
+        .map { clientPillar2Reference =>
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(AgentClientPillar2ReferencePage, clientPillar2Reference))
+            dataToSave     <- Future.fromTry(updatedAnswers.remove(UnauthorisedClientPillar2ReferencePage))
+            _              <- sessionRepository.set(dataToSave)
+          } yield Redirect(routes.DashboardController.onPageLoad)
+        }
+        .getOrElse(Future.successful(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad())))
     }
 
   def onPageLoadNoClientMatch: Action[AnyContent] =

--- a/app/controllers/repayments/RepaymentsCheckYourAnswersController.scala
+++ b/app/controllers/repayments/RepaymentsCheckYourAnswersController.scala
@@ -69,61 +69,70 @@ class RepaymentsCheckYourAnswersController @Inject() (
 
   def onSubmit(): Action[AnyContent] =
     (identify andThen getSessionData andThen requireSessionData) { implicit request =>
-      if (request.userAnswers.isRepaymentsJourneyCompleted) {
-        for {
-          optionalSessionData <- sessionRepository.get(request.userAnswers.id)
-          sessionData = optionalSessionData.getOrElse(UserAnswers(request.userId))
-          updatedAnswers <- Future.fromTry(sessionData.set(RepaymentsStatusPage, InProgress))
-          _              <- sessionRepository.set(updatedAnswers)
-        } yield (): Unit
-        val repaymentsStatus = (for {
-          repaymentData      <- OptionT.fromOption[Future](repaymentService.getRepaymentData(request.userAnswers))
-          _                  <- OptionT.liftF(repaymentService.sendRepaymentDetails(repaymentData))
-          repaymentAuditData <- fromOption[Future](request.userAnswers.getRepaymentAuditDetail)
-          _                  <- OptionT.liftF(auditService.auditRepayments(repaymentAuditData))
-        } yield SuccessfullyCompleted).value
-          .flatMap {
-            case Some(result) => Future.successful(result)
-            case _            => Future.successful(UnexpectedResponseError)
+      request.userAnswers.get(RepaymentsStatusPage) match {
+        case Some(SuccessfullyCompleted) =>
+          Redirect(controllers.repayments.routes.RepaymentsWaitingRoomController.onPageLoad())
+        case _ =>
+          if (request.userAnswers.isRepaymentsJourneyCompleted) {
+            for {
+              optionalSessionData <- sessionRepository.get(request.userAnswers.id)
+              sessionData = optionalSessionData.getOrElse(UserAnswers(request.userId))
+              updatedAnswers <- Future.fromTry(sessionData.set(RepaymentsStatusPage, InProgress))
+              _              <- sessionRepository.set(updatedAnswers)
+            } yield (): Unit
+            val repaymentsStatus = (for {
+              repaymentData      <- OptionT.fromOption[Future](repaymentService.getRepaymentData(request.userAnswers))
+              _                  <- OptionT.liftF(repaymentService.sendRepaymentDetails(repaymentData))
+              repaymentAuditData <- fromOption[Future](request.userAnswers.getRepaymentAuditDetail)
+              _                  <- OptionT.liftF(auditService.auditRepayments(repaymentAuditData))
+            } yield SuccessfullyCompleted).value
+              .flatMap {
+                case Some(result) => Future.successful(result)
+                case _            => Future.successful(UnexpectedResponseError)
+              }
+              .recover {
+                case UnexpectedResponse => UnexpectedResponseError
+                case _: Exception => IncompleteDataError
+              }
+            for {
+              updatedStatus <- repaymentsStatus
+              success = (updatedStatus == SuccessfullyCompleted)
+              optionalSessionData <- sessionRepository.get(request.userAnswers.id)
+              sessionData = optionalSessionData.getOrElse(UserAnswers(request.userId))
+              updatedAnswers <- if (success) {
+                                  Future.fromTry(
+                                    sessionData
+                                      .set(RepaymentsStatusPage, updatedStatus)
+                                      .flatMap(_.set(RepaymentConfirmationTimestampPage, ViewHelpers.getDateTimeGMT))
+                                  )
+                                } else Future.successful(sessionData)
+              updatedAnswers0 <-
+                if (success) Future.fromTry(updatedAnswers.set(RepaymentCompletionStatus, true)) else Future.successful(updatedAnswers)
+              updatedAnswers1 <-
+                if (success) Future.fromTry(updatedAnswers0.remove(RepaymentAccountNameConfirmationPage)) else Future.successful(updatedAnswers0)
+              updatedAnswers2 <-
+                if (success) Future.fromTry(updatedAnswers1.remove(RepaymentsContactByTelephonePage)) else Future.successful(updatedAnswers1)
+              updatedAnswers3 <-
+                if (success) Future.fromTry(updatedAnswers2.remove(RepaymentsContactEmailPage)) else Future.successful(updatedAnswers2)
+              updatedAnswers4 <-
+                if (success) Future.fromTry(updatedAnswers3.remove(RepaymentsContactNamePage)) else Future.successful(updatedAnswers3)
+              updatedAnswers5 <-
+                if (success) Future.fromTry(updatedAnswers4.remove(RepaymentsRefundAmountPage)) else Future.successful(updatedAnswers4)
+              updatedAnswers6 <-
+                if (success) Future.fromTry(updatedAnswers5.remove(RepaymentsTelephoneDetailsPage)) else Future.successful(updatedAnswers5)
+              updatedAnswers7 <-
+                if (success) Future.fromTry(updatedAnswers6.remove(UkOrAbroadBankAccountPage)) else Future.successful(updatedAnswers6)
+              updatedAnswers8 <-
+                if (success) Future.fromTry(updatedAnswers7.remove(ReasonForRequestingRefundPage)) else Future.successful(updatedAnswers7)
+              updatedAnswers9  <- if (success) Future.fromTry(updatedAnswers8.remove(NonUKBankPage)) else Future.successful(updatedAnswers8)
+              updatedAnswers10 <- if (success) Future.fromTry(updatedAnswers9.remove(BankAccountDetailsPage)) else Future.successful(updatedAnswers9)
+              _                <- sessionRepository.set(updatedAnswers10)
+            } yield (): Unit
+            Redirect(controllers.repayments.routes.RepaymentsWaitingRoomController.onPageLoad())
+          } else {
+            Redirect(controllers.repayments.routes.RepaymentsIncompleteDataController.onPageLoad)
           }
-          .recover {
-            case UnexpectedResponse => UnexpectedResponseError
-            case _: Exception => IncompleteDataError
-          }
-        for {
-          updatedStatus <- repaymentsStatus
-          success = (updatedStatus == SuccessfullyCompleted)
-          optionalSessionData <- sessionRepository.get(request.userAnswers.id)
-          sessionData = optionalSessionData.getOrElse(UserAnswers(request.userId))
-          updatedAnswers <- if (success) {
-                              Future.fromTry(
-                                sessionData
-                                  .set(RepaymentsStatusPage, updatedStatus)
-                                  .flatMap(_.set(RepaymentConfirmationTimestampPage, ViewHelpers.getDateTimeGMT))
-                              )
-                            } else Future.successful(sessionData)
-          updatedAnswers0 <- if (success) Future.fromTry(updatedAnswers.set(RepaymentCompletionStatus, true)) else Future.successful(updatedAnswers)
-          updatedAnswers1 <-
-            if (success) Future.fromTry(updatedAnswers0.remove(RepaymentAccountNameConfirmationPage)) else Future.successful(updatedAnswers0)
-          updatedAnswers2 <-
-            if (success) Future.fromTry(updatedAnswers1.remove(RepaymentsContactByTelephonePage)) else Future.successful(updatedAnswers1)
-          updatedAnswers3 <- if (success) Future.fromTry(updatedAnswers2.remove(RepaymentsContactEmailPage)) else Future.successful(updatedAnswers2)
-          updatedAnswers4 <- if (success) Future.fromTry(updatedAnswers3.remove(RepaymentsContactNamePage)) else Future.successful(updatedAnswers3)
-          updatedAnswers5 <- if (success) Future.fromTry(updatedAnswers4.remove(RepaymentsRefundAmountPage)) else Future.successful(updatedAnswers4)
-          updatedAnswers6 <-
-            if (success) Future.fromTry(updatedAnswers5.remove(RepaymentsTelephoneDetailsPage)) else Future.successful(updatedAnswers5)
-          updatedAnswers7 <- if (success) Future.fromTry(updatedAnswers6.remove(UkOrAbroadBankAccountPage)) else Future.successful(updatedAnswers6)
-          updatedAnswers8 <-
-            if (success) Future.fromTry(updatedAnswers7.remove(ReasonForRequestingRefundPage)) else Future.successful(updatedAnswers7)
-          updatedAnswers9  <- if (success) Future.fromTry(updatedAnswers8.remove(NonUKBankPage)) else Future.successful(updatedAnswers8)
-          updatedAnswers10 <- if (success) Future.fromTry(updatedAnswers9.remove(BankAccountDetailsPage)) else Future.successful(updatedAnswers9)
-          _                <- sessionRepository.set(updatedAnswers10)
-        } yield (): Unit
-        Redirect(controllers.repayments.routes.RepaymentsWaitingRoomController.onPageLoad())
-      } else {
-        Redirect(controllers.repayments.routes.RepaymentsIncompleteDataController.onPageLoad)
       }
-
     }
 
   private def contactDetailsList()(implicit messages: Messages, userAnswers: UserAnswers) =

--- a/app/views/AgentClientConfirmDetailsView.scala.html
+++ b/app/views/AgentClientConfirmDetailsView.scala.html
@@ -40,8 +40,11 @@
 
         @paragraphMessageWithLink(linkMessage = messages("agent.clientConfirm.link"), linkUrl = routes.AgentController.onPageLoadClientPillarId.url)
 
-        @govukButton(
-            ButtonViewModel(messages("site.confirm-and-continue")).withAttribute("id", "continue")
-        )
+        @govukButton(Button(
+            element = Some("button"),
+            content = messages("site.confirm-and-continue"),
+            preventDoubleClick = Some(true),
+            attributes = Map("id" -> "continue"),
+        ))
     }
 }

--- a/app/views/AgentClientConfirmDetailsView.scala.html
+++ b/app/views/AgentClientConfirmDetailsView.scala.html
@@ -40,11 +40,8 @@
 
         @paragraphMessageWithLink(linkMessage = messages("agent.clientConfirm.link"), linkUrl = routes.AgentController.onPageLoadClientPillarId.url)
 
-        @govukButton(Button(
-            element = Some("button"),
-            content = messages("site.confirm-and-continue"),
-            preventDoubleClick = Some(true),
-            attributes = Map("id" -> "continue"),
-        ))
+        @govukButton(
+            ButtonViewModel(messages("site.confirm-and-continue")).withAttribute("id", "continue")
+        )
     }
 }

--- a/app/views/subscriptionview/manageAccount/ManageContactCheckYourAnswersView.scala.html
+++ b/app/views/subscriptionview/manageAccount/ManageContactCheckYourAnswersView.scala.html
@@ -49,7 +49,6 @@
             @govukButton(Button(
                 element = Some("button"),
                 content = messages("site.manage.save-and-continue"),
-                preventDoubleClick = Some(true),
                 attributes = Map("id" -> "submit"),
                 classes = "govuk-!-margin-top-4")
             )

--- a/app/views/subscriptionview/manageAccount/ManageGroupDetailsCheckYourAnswersView.scala.html
+++ b/app/views/subscriptionview/manageAccount/ManageGroupDetailsCheckYourAnswersView.scala.html
@@ -41,7 +41,6 @@
         @govukButton(Button(
             element = Some("button"),
             content = messages("site.manage.save-and-continue"),
-            preventDoubleClick = Some(true),
             attributes = Map("id" -> "submit"),
             classes = "govuk-!-margin-top-6"))
     }


### PR DESCRIPTION
This PR handles idempotency wen it comes to clicking buttons which send off some information to ETMP

Our previous solution had a technical issue where even though the property `preventDoubleClicks` was added to the button, it would still end up double clicking when network speeds were slow enough (3g speed and lower)

This solution handles it in a more "backend" style approach where before the logic that is tied to that button is executed, we will first check if the task has already been done. If not, we will start the logic again and if so, we will simply go straight to the redirected page.  This approach means that on double clicks and even on multiclicks, it should remain far more robust