### PR TITLE
PIL-2270: Moving content tests from acceptance tests to unit tests

### DIFF
--- a/test-utils/generators/Generators.scala
+++ b/test-utils/generators/Generators.scala
@@ -186,6 +186,12 @@ trait Generators extends UserAnswersGenerator with PageGenerators with ModelGene
     chars     <- listOfN(length, arbitrary[Char])
   } yield chars.mkString
 
+  def stringsShorterThan(maxLength: Int): Gen[String] = for {
+    maxLength <- maxLength
+    length    <- Gen.chooseNum(1, maxLength - 1)
+    chars     <- listOfN(length, arbitrary[Char])
+  } yield chars.mkString
+
   def stringsExceptSpecificValues(excluded: Seq[String]): Gen[String] =
     nonEmptyString suchThat (!excluded.contains(_))
 

--- a/test/forms/GroupRegistrationDateReportFormProviderSpec.scala
+++ b/test/forms/GroupRegistrationDateReportFormProviderSpec.scala
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import forms.behaviours.DateBehaviours
+import play.api.data.{Form, FormError}
+
+import java.time.LocalDate
+
+class GroupRegistrationDateReportFormProviderSpec extends DateBehaviours {
+
+  val formProvider = new GroupRegistrationDateReportFormProvider()
+  val form: Form[LocalDate] = formProvider()
+
+  "throw a form error for when all date fields are empty" in {
+    val data = Map(
+      "rfmRegistrationDate.day"   -> "",
+      "rfmRegistrationDate.month" -> "",
+      "rfmRegistrationDate.year"  -> ""
+    )
+
+    form.bind(data).errors mustBe Seq(
+      FormError("rfmRegistrationDate", "groupRegistrationDateReport.error.startDate.required.all")
+    )
+  }
+
+  "throw a form error for when both month and year are missing" in {
+    val data = Map(
+      "rfmRegistrationDate.day"   -> "15",
+      "rfmRegistrationDate.month" -> "",
+      "rfmRegistrationDate.year"  -> ""
+    )
+
+    form.bind(data).errors mustBe Seq(
+      FormError("rfmRegistrationDate", "groupRegistrationDateReport.error.startDate.required.two", Seq("month", "year"))
+    )
+  }
+
+  "throw a form error for when both day and year are missing" in {
+    val data = Map(
+      "rfmRegistrationDate.day"   -> "",
+      "rfmRegistrationDate.month" -> "1",
+      "rfmRegistrationDate.year"  -> ""
+    )
+
+    form.bind(data).errors mustBe Seq(
+      FormError("rfmRegistrationDate", "groupRegistrationDateReport.error.startDate.required.two", Seq("day", "year"))
+    )
+  }
+
+  "throw a form error for when both day and month are missing" in {
+    val data = Map(
+      "rfmRegistrationDate.day"   -> "",
+      "rfmRegistrationDate.month" -> "",
+      "rfmRegistrationDate.year"  -> "2024"
+    )
+
+    form.bind(data).errors mustBe Seq(
+      FormError("rfmRegistrationDate", "groupRegistrationDateReport.error.startDate.required.two", Seq("day", "month"))
+    )
+  }
+
+  "throw a form error for when year is missing" in {
+    val data = Map(
+      "rfmRegistrationDate.day"   -> "15",
+      "rfmRegistrationDate.month" -> "1",
+      "rfmRegistrationDate.year"  -> ""
+    )
+
+    form.bind(data).errors mustBe Seq(
+      FormError("rfmRegistrationDate", "groupRegistrationDateReport.error.startDate.required", Seq("year"))
+    )
+  }
+
+  "throw a form error for when month is missing" in {
+    val data = Map(
+      "rfmRegistrationDate.day"   -> "15",
+      "rfmRegistrationDate.month" -> "",
+      "rfmRegistrationDate.year"  -> "2024"
+    )
+
+    form.bind(data).errors mustBe Seq(
+      FormError("rfmRegistrationDate", "groupRegistrationDateReport.error.startDate.required", Seq("month"))
+    )
+  }
+
+  "throw a form error for when day is missing" in {
+    val data = Map(
+      "rfmRegistrationDate.day"   -> "",
+      "rfmRegistrationDate.month" -> "1",
+      "rfmRegistrationDate.year"  -> "2024"
+    )
+
+    form.bind(data).errors mustBe Seq(
+      FormError("rfmRegistrationDate", "groupRegistrationDateReport.error.startDate.required", Seq("day"))
+    )
+  }
+
+  "throw a form error for when day and month are invalid" in {
+    val data = Map(
+      "rfmRegistrationDate.day"   -> "0",
+      "rfmRegistrationDate.month" -> "0",
+      "rfmRegistrationDate.year"  -> "2024"
+    )
+
+    form.bind(data).errors mustBe Seq(
+      FormError("rfmRegistrationDate", "groupRegistrationDateReport.error.rfmRegistrationDate.dayMonth.invalid")
+    )
+  }
+
+  "throw a form error for when month and year are invalid" in {
+    val data = Map(
+      "rfmRegistrationDate.day"   -> "1",
+      "rfmRegistrationDate.month" -> "aa",
+      "rfmRegistrationDate.year"  -> "y2024"
+    )
+
+    form.bind(data).errors mustBe Seq(
+      FormError("rfmRegistrationDate", "groupRegistrationDateReport.error.rfmRegistrationDate.monthYear.invalid")
+    )
+  }
+
+  "throw a form error for when day, month and year are invalid" in {
+    val data = Map(
+      "rfmRegistrationDate.day"   -> "aa",
+      "rfmRegistrationDate.month" -> "m3",
+      "rfmRegistrationDate.year"  -> "y2024"
+    )
+
+    form.bind(data).errors mustBe Seq(
+      FormError("rfmRegistrationDate", "groupRegistrationDateReport.error.rfmRegistrationDate.dayMonthYear.invalid")
+    )
+  }
+
+  "throw a form error for when day is invalid length" in {
+    val data = Map(
+      "rfmRegistrationDate.day"   -> "32",
+      "rfmRegistrationDate.month" -> "11",
+      "rfmRegistrationDate.year"  -> "2024"
+    )
+
+    form.bind(data).errors mustBe Seq(
+      FormError("rfmRegistrationDate", "groupRegistrationDateReport.error.startDate.day.length")
+    )
+  }
+
+  "throw a form error for when month is invalid length" in {
+    val data = Map(
+      "rfmRegistrationDate.day"   -> "10",
+      "rfmRegistrationDate.month" -> "13",
+      "rfmRegistrationDate.year"  -> "2024"
+    )
+
+    form.bind(data).errors mustBe Seq(
+      FormError("rfmRegistrationDate", "groupRegistrationDateReport.error.startDate.month.nan")
+    )
+  }
+
+  "throw a form error for when year is invalid length" in {
+    val data = Map(
+      "rfmRegistrationDate.day"   -> "10",
+      "rfmRegistrationDate.month" -> "10",
+      "rfmRegistrationDate.year"  -> "20244"
+    )
+
+    form.bind(data).errors mustBe Seq(
+      FormError("rfmRegistrationDate", "groupRegistrationDateReport.error.startDate.year.length")
+    )
+  }
+
+  "throw a form error for when registration date is before 31 December 2023" in {
+    val data = Map(
+      "rfmRegistrationDate.day"   -> "10",
+      "rfmRegistrationDate.month" -> "10",
+      "rfmRegistrationDate.year"  -> "2023"
+    )
+
+    form.bind(data).errors mustBe Seq(
+      FormError("rfmRegistrationDate", "groupRegistrationDateReport.error.startDate.dayMonthYear.minimum")
+    )
+  }
+
+  "throw a form error for when registration date is in the future" in {
+    val futureDate = LocalDate.now.plusDays(1)
+    val data = Map(
+      "rfmRegistrationDate.day"   -> futureDate.getDayOfMonth.toString,
+      "rfmRegistrationDate.month" -> futureDate.getMonthValue.toString,
+      "rfmRegistrationDate.year"  -> futureDate.getYear.toString
+    )
+
+    form.bind(data).errors mustBe Seq(
+      FormError("rfmRegistrationDate", "groupRegistrationDateReport.error.startDate.dayMonthYear.maximum")
+    )
+  }
+
+}

--- a/test/forms/NfmEntityTypeFormProviderSpec.scala
+++ b/test/forms/NfmEntityTypeFormProviderSpec.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class NfmEntityTypeFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "nfmEntityType.error.required"
+
+  val formProvider = new NfmEntityTypeFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like mandatoryField(
+      formProvider,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/RfmNameRegistrationFormProviderSpec.scala
+++ b/test/forms/RfmNameRegistrationFormProviderSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import forms.behaviours.StringFieldBehaviours
+import play.api.data.FormError
+
+class RfmNameRegistrationFormProviderSpec extends StringFieldBehaviours {
+
+  val REQUIRED_KEY = "rfm.nameRegistration.error.required"
+  val LENGTH_KEY   = "rfm.nameRegistration.error.length"
+  val MAX_LENGTH   = 105
+  val XSS_KEY      = "name.error.xss.allowAmpersand"
+  val XSS_REGEX    = """^[^<>"]*$"""
+
+  val form = new RfmNameRegistrationFormProvider()()
+
+  ".value" - {
+
+    val FIELD_NAME = "value"
+
+    behave like fieldThatBindsValidData(
+      form,
+      FIELD_NAME,
+      nonEmptyRegexConformingStringWithMaxLength(XSS_REGEX, MAX_LENGTH)
+    )
+
+    behave like fieldWithMaxLength(
+      form,
+      FIELD_NAME,
+      maxLength = MAX_LENGTH,
+      lengthError = FormError(FIELD_NAME, LENGTH_KEY, Seq(MAX_LENGTH)),
+      generator = Some(longStringsConformingToRegex(XSS_REGEX, MAX_LENGTH))
+    )
+
+    behave like fieldWithRegex(
+      form,
+      FIELD_NAME,
+      regex = XSS_REGEX,
+      regexViolationGen = stringsWithAtLeastOneSpecialChar("<>\"", MAX_LENGTH),
+      regexError = FormError(FIELD_NAME, XSS_KEY)
+    )
+
+    behave like mandatoryField(
+      form,
+      FIELD_NAME,
+      requiredError = FormError(FIELD_NAME, REQUIRED_KEY)
+    )
+
+  }
+}

--- a/test/forms/RfmSecondaryContactEmailFormProviderSpec.scala
+++ b/test/forms/RfmSecondaryContactEmailFormProviderSpec.scala
@@ -24,8 +24,8 @@ import play.api.data.FormError
 class RfmSecondaryContactEmailFormProviderSpec extends StringFieldBehaviours {
 
   val requiredKey  = "rfm.secondaryContactEmail.error.required"
-  val lengthKey = "rfm.secondaryContactEmail.error.length"
-  val xssKey = "rfm.secondaryContactEmail.error.format"
+  val lengthKey    = "rfm.secondaryContactEmail.error.length"
+  val xssKey       = "rfm.secondaryContactEmail.error.format"
   val formProvider = new RfmSecondaryContactEmailFormProvider()
 
   ".value" - {

--- a/test/forms/RfmSecondaryContactEmailFormProviderSpec.scala
+++ b/test/forms/RfmSecondaryContactEmailFormProviderSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import forms.Validation.EMAIL_REGEX
+import forms.behaviours.StringFieldBehaviours
+import mapping.Constants.MAX_LENGTH_132
+import play.api.data.FormError
+
+class RfmSecondaryContactEmailFormProviderSpec extends StringFieldBehaviours {
+
+  val requiredKey  = "rfm.secondaryContactEmail.error.required"
+  val lengthKey = "rfm.secondaryContactEmail.error.length"
+  val xssKey = "rfm.secondaryContactEmail.error.format"
+  val formProvider = new RfmSecondaryContactEmailFormProvider()
+
+  ".value" - {
+
+    val fieldName = "emailAddress"
+
+    behave like fieldWithMaxLength(
+      formProvider("name"),
+      fieldName,
+      maxLength = MAX_LENGTH_132,
+      lengthError = FormError(fieldName, lengthKey, Seq(MAX_LENGTH_132)),
+      generator = Some(longStringsConformingToRegex(EMAIL_REGEX, MAX_LENGTH_132))
+    )
+
+    behave like fieldWithRegex(
+      formProvider("name"),
+      fieldName,
+      regex = EMAIL_REGEX,
+      regexViolationGen = stringsWithAtLeastOneSpecialChar("<>\"", MAX_LENGTH_132),
+      regexError = FormError(fieldName, xssKey)
+    )
+
+    behave like mandatoryField(
+      formProvider("name"),
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey, Seq("name"))
+    )
+  }
+}

--- a/test/forms/RfmSecondaryTelephonePreferenceFormProviderSpec.scala
+++ b/test/forms/RfmSecondaryTelephonePreferenceFormProviderSpec.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class RfmSecondaryTelephonePreferenceFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "rfm.secondaryTelephonePreference.error.required"
+
+  val formProvider = new RfmSecondaryTelephonePreferenceFormProvider()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like mandatoryField(
+      formProvider("name"),
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey, Seq("name"))
+    )
+  }
+}

--- a/test/forms/RfmSecurityCheckFormProviderSpec.scala
+++ b/test/forms/RfmSecurityCheckFormProviderSpec.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import forms.behaviours.StringFieldBehaviours
+import play.api.data.FormError
+
+class RfmSecurityCheckFormProviderSpec extends StringFieldBehaviours {
+
+  val REQUIRED_KEY         = "rfm.securityCheck.error.required"
+  val LENGTH_KEY           = "rfm.securityCheck.error.length"
+  val EQUAL_LENGTH         = 15
+  val XSS_KEY              = "rfm.securityCheck.error.format"
+  val XSS_REGEX            = """^X[A-Z]PLR[0-9]{10}$"""
+  val INVALID_FORMAT_VALUE = "XAPLR&123456789"
+
+  val form = new RfmSecurityCheckFormProvider()()
+
+  ".value" - {
+
+    val FIELD_NAME = "value"
+
+    behave like fieldThatBindsValidData(
+      form,
+      FIELD_NAME,
+      nonEmptyRegexConformingStringWithMaxLength(XSS_REGEX, EQUAL_LENGTH)
+    )
+
+    behave like fieldWithMaxLength(
+      form,
+      FIELD_NAME,
+      maxLength = EQUAL_LENGTH,
+      lengthError = FormError(FIELD_NAME, LENGTH_KEY, Seq(EQUAL_LENGTH)),
+      generator = Some(longStringsConformingToRegex(XSS_REGEX, EQUAL_LENGTH))
+    )
+
+    behave like fieldWithMinLength(
+      form,
+      FIELD_NAME,
+      maxLength = EQUAL_LENGTH,
+      lengthError = FormError(FIELD_NAME, LENGTH_KEY, Seq(EQUAL_LENGTH))
+    )
+
+    behave like fieldWithRegex(
+      form,
+      FIELD_NAME,
+      regex = XSS_REGEX,
+      regexViolationGen = INVALID_FORMAT_VALUE,
+      regexError = FormError(FIELD_NAME, XSS_KEY)
+    )
+
+    behave like mandatoryField(
+      form,
+      FIELD_NAME,
+      requiredError = FormError(FIELD_NAME, REQUIRED_KEY)
+    )
+
+  }
+}

--- a/test/forms/RfmSecurityCheckFormProviderSpec.scala
+++ b/test/forms/RfmSecurityCheckFormProviderSpec.scala
@@ -51,7 +51,7 @@ class RfmSecurityCheckFormProviderSpec extends StringFieldBehaviours {
     behave like fieldWithMinLength(
       form,
       FIELD_NAME,
-      maxLength = EQUAL_LENGTH,
+      minLength = EQUAL_LENGTH,
       lengthError = FormError(FIELD_NAME, LENGTH_KEY, Seq(EQUAL_LENGTH))
     )
 

--- a/test/forms/UPERegisteredInUKConfirmationFormProviderSpec.scala
+++ b/test/forms/UPERegisteredInUKConfirmationFormProviderSpec.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class UPERegisteredInUKConfirmationFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "isUPERegisteredInUK.error.required"
+
+  val formProvider = new UPERegisteredInUKConfirmationFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like mandatoryField(
+      formProvider,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/UpeContactEmailFormProviderSpec.scala
+++ b/test/forms/UpeContactEmailFormProviderSpec.scala
@@ -18,22 +18,26 @@ package forms
 
 import forms.Validation.EMAIL_REGEX
 import forms.behaviours.StringFieldBehaviours
+import mapping.Constants
 import mapping.Constants.MAX_LENGTH_132
 import play.api.data.FormError
 
-class RfmSecondaryContactEmailFormProviderSpec extends StringFieldBehaviours {
+class UpeContactEmailFormProviderSpec extends StringFieldBehaviours {
 
-  val requiredKey  = "rfm.secondaryContactEmail.error.required"
-  val lengthKey    = "rfm.secondaryContactEmail.error.length"
-  val xssKey       = "rfm.secondaryContactEmail.error.format"
-  val formProvider = new RfmSecondaryContactEmailFormProvider()
+  val requiredKey = "upe-input-business-contact.email.error.required"
+  val lengthKey   = "upe-input-business-contact.email.error.length"
+  val invalidKey  = "upe-input-business-contact.email.error.invalid"
+  val contactName = "name"
+  val maxLength: Int = Constants.MAX_LENGTH_132
+  val validEmailAddress = "testteam@email.com"
+  val form              = new UpeContactEmailFormProvider()(contactName)
 
   ".emailAddress" - {
 
     val fieldName = "emailAddress"
 
     behave like fieldWithMaxLength(
-      formProvider("name"),
+      form,
       fieldName,
       maxLength = MAX_LENGTH_132,
       lengthError = FormError(fieldName, lengthKey, Seq(MAX_LENGTH_132)),
@@ -41,17 +45,17 @@ class RfmSecondaryContactEmailFormProviderSpec extends StringFieldBehaviours {
     )
 
     behave like fieldWithRegex(
-      formProvider("name"),
+      form,
       fieldName,
       regex = EMAIL_REGEX,
       regexViolationGen = stringsWithAtLeastOneSpecialChar("<>\"", MAX_LENGTH_132),
-      regexError = FormError(fieldName, xssKey)
+      regexError = FormError(fieldName, invalidKey)
     )
 
     behave like mandatoryField(
-      formProvider("name"),
+      form,
       fieldName,
-      requiredError = FormError(fieldName, requiredKey, Seq("name"))
+      requiredError = FormError(fieldName, requiredKey, Seq(contactName))
     )
   }
 }

--- a/test/forms/behaviours/StringFieldBehaviours.scala
+++ b/test/forms/behaviours/StringFieldBehaviours.scala
@@ -30,6 +30,15 @@ trait StringFieldBehaviours extends FieldBehaviours {
       }
     }
 
+  def fieldWithMinLength(form: Form[_], fieldName: String, maxLength: Int, lengthError: FormError, generator: Option[Gen[String]] = None): Unit =
+    s"not bind strings less than $maxLength characters" in {
+      val gen = generator.getOrElse(stringsShorterThan(maxLength))
+      forAll(gen -> "shortString") { string =>
+        val result = form.bind(Map(fieldName -> string)).apply(fieldName)
+        result.errors must contain only lengthError
+      }
+    }
+
   def fieldWithRegex(
     form:              Form[_],
     fieldName:         String,

--- a/test/forms/behaviours/StringFieldBehaviours.scala
+++ b/test/forms/behaviours/StringFieldBehaviours.scala
@@ -30,9 +30,9 @@ trait StringFieldBehaviours extends FieldBehaviours {
       }
     }
 
-  def fieldWithMinLength(form: Form[_], fieldName: String, maxLength: Int, lengthError: FormError, generator: Option[Gen[String]] = None): Unit =
-    s"not bind strings less than $maxLength characters" in {
-      val gen = generator.getOrElse(stringsShorterThan(maxLength))
+  def fieldWithMinLength(form: Form[_], fieldName: String, minLength: Int, lengthError: FormError, generator: Option[Gen[String]] = None): Unit =
+    s"not bind strings less than $minLength characters" in {
+      val gen = generator.getOrElse(stringsShorterThan(minLength))
       forAll(gen -> "shortString") { string =>
         val result = form.bind(Map(fieldName -> string)).apply(fieldName)
         result.errors must contain only lengthError

--- a/test/views/EntityTypeViewSpec.scala
+++ b/test/views/EntityTypeViewSpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import base.ViewSpecBase
+import forms.EntityTypeFormProvider
+import models.NormalMode
+import org.jsoup.Jsoup
+import org.jsoup.nodes.{Document, Element}
+import org.jsoup.select.Elements
+import views.html.EntityTypeView
+
+class EntityTypeViewSpec extends ViewSpecBase {
+
+  lazy val formProvider: EntityTypeFormProvider = new EntityTypeFormProvider
+  lazy val page:         EntityTypeView         = inject[EntityTypeView]
+  lazy val view:         Document               = Jsoup.parse(page(formProvider(), NormalMode)(request, appConfig, messages).toString())
+  lazy val pageTitle:    String                 = "What entity type is the ultimate parent?"
+
+  "Entity Type View" should {
+
+    "have a title" in {
+      view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+    }
+
+    "have a caption" in {
+      view.getElementsByClass("govuk-caption-l").text mustBe "Group details"
+    }
+
+    "have a unique H1 heading" in {
+      val h1Elements: Elements = view.getElementsByTag("h1")
+      h1Elements.size() mustBe 1
+      h1Elements.text() mustBe pageTitle
+    }
+
+    "have radio buttons with hint text" in {
+      val radioButtonSection: Element = view.getElementsByClass("govuk-radios").first
+      val radioButtons = radioButtonSection.getElementsByClass("govuk-label govuk-radios__label")
+
+      radioButtons.size() mustBe 3
+      radioButtons.get(0).text mustBe "UK limited company"
+      radioButtonSection.getElementById("value_0-item-hint").text mustBe "This includes public limited companies."
+      radioButtons.get(1).text mustBe "Limited liability partnership"
+      radioButtonSection.getElementsByClass("govuk-radios__divider").text mustBe "or"
+      radioButtons.get(2).text mustBe "Entity type not listed"
+      radioButtonSection.getElementById("value_2-item-hint").text mustBe "Select to create a HMRC record."
+    }
+
+    "have a button" in {
+      view.getElementsByClass("govuk-button").text mustBe "Save and continue"
+    }
+  }
+}

--- a/test/views/IncompleteSubscriptionDataViewSpec.scala
+++ b/test/views/IncompleteSubscriptionDataViewSpec.scala
@@ -30,7 +30,8 @@ class IncompleteSubscriptionDataViewSpec extends ViewSpecBase {
 
   "Incomplete Subscription Data view" should {
     "have a title" in {
-      view.title() mustBe s"Register your group - Report Pillar 2 Top-up Taxes - GOV.UK" //TODO: Different title/H1 - raising a ticket to resolve later
+      view
+        .title() mustBe s"Register your group - Report Pillar 2 Top-up Taxes - GOV.UK" //TODO: Different title/H1 - raising a ticket to resolve later
     }
 
     "have a unique H1 heading" in {

--- a/test/views/IncompleteSubscriptionDataViewSpec.scala
+++ b/test/views/IncompleteSubscriptionDataViewSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import base.ViewSpecBase
+import org.jsoup.Jsoup
+import org.jsoup.nodes.{Document, Element}
+import org.jsoup.select.Elements
+import views.html.IncompleteSubscriptionDataView
+
+class IncompleteSubscriptionDataViewSpec extends ViewSpecBase {
+
+  lazy val page:      IncompleteSubscriptionDataView = inject[IncompleteSubscriptionDataView]
+  lazy val view:      Document                       = Jsoup.parse(page()(request, appConfig, messages).toString())
+  lazy val pageTitle: String                         = "You have one or more incomplete registration tasks"
+
+  "Incomplete Subscription Data view" should {
+    "have a title" in {
+      view.title() mustBe s"Register your group - Report Pillar 2 Top-up Taxes - GOV.UK" //TODO: Different title/H1 - raising a ticket to resolve later
+    }
+
+    "have a unique H1 heading" in {
+      val h1Elements: Elements = view.getElementsByTag("h1")
+      h1Elements.size() mustBe 1
+      h1Elements.text() mustBe pageTitle
+    }
+
+    "have a paragraph with a link" in {
+      val paragraph: Element = view.getElementsByClass("govuk-body").first()
+
+      paragraph.text mustBe "You must go back to register your group and complete any in progress tasks."
+      paragraph.getElementsByTag("a").text() mustBe "go back to register your group and complete any in progress tasks."
+      paragraph.getElementsByTag("a").attr("href") mustBe
+        controllers.routes.TaskListController.onPageLoad.url
+    }
+
+  }
+
+}

--- a/test/views/TaskListViewSpec.scala
+++ b/test/views/TaskListViewSpec.scala
@@ -17,7 +17,7 @@
 package views
 
 import base.ViewSpecBase
-import models.NormalMode
+import models.{CheckMode, NormalMode}
 import models.tasklist.SectionStatus.{CannotStart, Completed, NotStarted}
 import models.tasklist.SectionViewModel
 import org.jsoup.Jsoup
@@ -31,7 +31,7 @@ class TaskListViewSpec extends ViewSpecBase {
     Seq(
       SectionViewModel(
         "Edit Ultimate Parent Entity details",
-        Some(controllers.registration.routes.StartPageRegistrationController.onPageLoad(NormalMode)),
+        Some(controllers.registration.routes.StartPageRegistrationController.onPageLoad(CheckMode)),
         Completed
       ),
       SectionViewModel(
@@ -88,8 +88,10 @@ class TaskListViewSpec extends ViewSpecBase {
       val statuses = view.getElementsByClass("hmrc-status-tag")
 
       tasks.first.text mustBe "Edit Ultimate Parent Entity details"
+      tasks.first.getElementsByTag("a").attr("href") mustBe controllers.registration.routes.StartPageRegistrationController.onPageLoad(CheckMode).url
       statuses.first.text mustBe "Completed"
       tasks.get(1).text mustBe "Add filing member details"
+      tasks.get(1).getElementsByTag("a").attr("href") mustBe controllers.fm.routes.NominateFilingMemberYesNoController.onPageLoad(NormalMode).url
       statuses.get(1).text mustBe "Not started"
       tasks.get(2).text mustBe "Further group details"
       statuses.get(2).text mustBe "Cannot start yet"

--- a/test/views/TaskListViewSpec.scala
+++ b/test/views/TaskListViewSpec.scala
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import base.ViewSpecBase
+import models.NormalMode
+import models.tasklist.SectionStatus.{CannotStart, Completed, NotStarted}
+import models.tasklist.SectionViewModel
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.select.Elements
+import views.html.TaskListView
+
+class TaskListViewSpec extends ViewSpecBase {
+
+  val groupDetailsSections: Seq[SectionViewModel] =
+    Seq(
+      SectionViewModel(
+        "Edit Ultimate Parent Entity details",
+        Some(controllers.registration.routes.StartPageRegistrationController.onPageLoad(NormalMode)),
+        Completed
+      ),
+      SectionViewModel(
+        "Add filing member details",
+        Some(controllers.fm.routes.NominateFilingMemberYesNoController.onPageLoad(NormalMode)),
+        NotStarted
+      ),
+      SectionViewModel("Further group details", None, CannotStart)
+    )
+  val contactDetailsSection: SectionViewModel = SectionViewModel("Contact details", None, CannotStart)
+  val reviewAndSubmitSection: SectionViewModel =
+    SectionViewModel("Check your answers before submitting your registration", None, CannotStart)
+  val completedSectionCounter = 1
+
+  lazy val page: TaskListView = inject[TaskListView]
+  lazy val view: Document =
+    Jsoup.parse(
+      page(groupDetailsSections, contactDetailsSection, reviewAndSubmitSection, completedSectionCounter)(request, messages, appConfig).toString()
+    )
+  lazy val pageTitle: String = "Register your group"
+
+  "Task List View" should {
+
+    "have a title" in {
+      view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+    }
+
+    "have a unique H1 heading" in {
+      val h1Elements: Elements = view.getElementsByTag("h1")
+      h1Elements.size() mustBe 1
+      h1Elements.text() mustBe pageTitle
+    }
+
+    "have a paragraph" in {
+      view.getElementsByClass("govuk-body").first.text mustBe
+        "The information you enter will be saved as you progress. If you sign out, the information you have already entered will be saved for 28 days. After that time you will need to enter all of the information again."
+    }
+
+    "have a registration status H2 heading" in {
+      view.getElementsByTag("h2").first.text mustBe "Registration incomplete"
+    }
+
+    "have a number of tasks completed paragraph" in {
+      view.getElementsByClass("govuk-body").get(1).text mustBe "You have completed 1 of 5 tasks."
+    }
+
+    "have a group details H2" in {
+      view.getElementsByTag("h2").get(1).text mustBe "Group details"
+    }
+
+    "have a group details section" in {
+      view.getElementsByClass("app-task-list__item").get(1)
+      val tasks    = view.getElementsByClass("app-task-list__task-name")
+      val statuses = view.getElementsByClass("hmrc-status-tag")
+
+      tasks.first.text mustBe "Edit Ultimate Parent Entity details"
+      statuses.first.text mustBe "Completed"
+      tasks.get(1).text mustBe "Add filing member details"
+      statuses.get(1).text mustBe "Not started"
+      tasks.get(2).text mustBe "Further group details"
+      statuses.get(2).text mustBe "Cannot start yet"
+    }
+
+    "have a contact details H2" in {
+      view.getElementsByTag("h2").get(2).text mustBe "Contact details"
+    }
+
+    "have a contact details section" in {
+      val section = view.getElementsByClass("app-task-list__item").get(3)
+      section.getElementsByClass("app-task-list__task-name").text mustBe "Contact details"
+      section.getElementsByClass("hmrc-status-tag").text mustBe "Cannot start yet"
+    }
+
+    "have a review and submit H2" in {
+      view.getElementsByTag("h2").get(3).text mustBe "Review and submit"
+    }
+
+    "have a review and submit section" in {
+      val section = view.getElementsByClass("app-task-list__item").get(4)
+      section.getElementsByClass("app-task-list__task-name").first.text mustBe "Check your answers before submitting your registration"
+      section.getElementsByClass("hmrc-status-tag").first.text mustBe "Cannot start yet"
+    }
+
+    "have a review and submit paragraph" in {
+      view.getElementsByClass("govuk-body").get(2).text mustBe
+        "At the ‘Review and submit’ section of this registration, you can amend your answers and print or save them for your own records."
+    }
+  }
+}

--- a/test/views/errors/ErrorTemplateSpec.scala
+++ b/test/views/errors/ErrorTemplateSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.errors
+
+import base.ViewSpecBase
+import org.jsoup.Jsoup
+import org.jsoup.nodes.{Document, Element}
+import org.jsoup.select.Elements
+import views.html.errors.ErrorTemplate
+
+class ErrorTemplateSpec extends ViewSpecBase {
+
+  lazy val page: ErrorTemplate = inject[ErrorTemplate]
+  val heading = "This page can't be found"
+  val message = "Please check that you have entered the correct web address"
+  lazy val view: Document = Jsoup.parse(page(pageTitle = heading, heading = heading, message = message)(request, appConfig, messages).toString())
+
+  "Error Template" should {
+
+    "have a title" in {
+      view.title() mustBe s"$heading - Report Pillar 2 Top-up Taxes - GOV.UK"
+    }
+
+    "have a unique H1 heading" in {
+      val h1Elements: Elements = view.getElementsByTag("h1")
+      h1Elements.size() mustBe 1
+      h1Elements.text() mustBe heading
+    }
+
+    "have a paragraph" in {
+      view.getElementsByClass("govuk-body").get(0).text mustBe message
+    }
+
+    "have a paragraph with a link" in {
+      val paragraphText: Element = view.getElementsByClass("govuk-body").get(1)
+
+      paragraphText.text mustBe "You must return to your Pillar 2 Top-up Taxes registration and complete the required tasks."
+      paragraphText.getElementsByTag("a").text() mustBe "return to your Pillar 2 Top-up Taxes registration"
+      paragraphText.getElementsByTag("a").attr("href") mustBe
+        controllers.routes.TaskListController.onPageLoad.url
+    }
+
+  }
+}

--- a/test/views/errors/RegistrationOrSubscriptionFailedViewSpec.scala
+++ b/test/views/errors/RegistrationOrSubscriptionFailedViewSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.errors
+
+import base.ViewSpecBase
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.select.Elements
+import views.html.errors.RegistrationOrSubscriptionFailedView
+
+class RegistrationOrSubscriptionFailedViewSpec extends ViewSpecBase {
+
+  lazy val page:      RegistrationOrSubscriptionFailedView = inject[RegistrationOrSubscriptionFailedView]
+  lazy val view:      Document                             = Jsoup.parse(page()(request, appConfig, messages).toString())
+  lazy val pageTitle: String                               = "Sorry, there is a problem with the service"
+
+  "Agent Error View" should {
+
+    "have a title" in {
+      view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+    }
+
+    "have a unique H1 heading" in {
+      val h1Elements: Elements = view.getElementsByTag("h1")
+      h1Elements.size() mustBe 1
+      h1Elements.text() mustBe pageTitle
+    }
+
+    "have paragraph contents" in {
+      view.getElementsByClass("govuk-body").get(0).text mustBe "You must still register, please try again later."
+      view.getElementsByClass("govuk-body").get(1).text mustBe
+        "We have saved your answers and they will be available for 28 days. After that time you will need to enter all of the information again."
+    }
+
+    "have a link" in {
+      val link = view.getElementsByClass("govuk-body").last().getElementsByTag("a")
+
+      link.text mustBe "Return to registration to try again"
+      link.attr("href") mustBe controllers.routes.TaskListController.onPageLoad.url
+    }
+
+  }
+}

--- a/test/views/registrationview/RegistrationNotCalledNfmViewSpec.scala
+++ b/test/views/registrationview/RegistrationNotCalledNfmViewSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.registrationview
+
+import base.ViewSpecBase
+import models.NormalMode
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.select.Elements
+import views.html.registrationview.RegistrationNotCalledUpeView
+
+class RegistrationNotCalledNfmViewSpec extends ViewSpecBase {
+
+  lazy val page:      RegistrationNotCalledUpeView = inject[RegistrationNotCalledUpeView]
+  lazy val view:      Document                     = Jsoup.parse(page()(request, appConfig, messages).toString())
+  lazy val pageTitle: String                       = "Sorry, there is a problem with the service"
+
+  "Registration Not Called Nfm View" should {
+
+    "have a title" in {
+      view
+        .title() mustBe s"Register your group - Report Pillar 2 Top-up Taxes - GOV.UK" //TODO: Different title/H1 - raising a ticket to resolve later
+    }
+
+    "have a unique H1 heading" in {
+      val h1Elements: Elements = view.getElementsByTag("h1")
+      h1Elements.size() mustBe 1
+      h1Elements.text() mustBe pageTitle
+    }
+
+    "have paragraph contents" in {
+      val paragraphs = view.getElementsByClass("govuk-body")
+      paragraphs.get(0).text mustBe "Try again later."
+      paragraphs.get(1).text mustBe "Your company details could not be confirmed."
+    }
+
+    "have a paragraph with a link" in {
+      val paragraph = view.getElementsByClass("govuk-body").get(2)
+
+      paragraph.getElementsByTag("a").text mustBe "Go back to select the entity type to try again."
+      paragraph.getElementsByTag("a").attr("href") mustBe controllers.registration.routes.EntityTypeController.onPageLoad(NormalMode).url
+    }
+
+  }
+}

--- a/test/views/registrationview/RegistrationNotCalledUpeViewSpec.scala
+++ b/test/views/registrationview/RegistrationNotCalledUpeViewSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.registrationview
+
+import base.ViewSpecBase
+import models.NormalMode
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.select.Elements
+import views.html.registrationview.RegistrationNotCalledUpeView
+
+class RegistrationNotCalledUpeViewSpec extends ViewSpecBase {
+
+  lazy val page:      RegistrationNotCalledUpeView = inject[RegistrationNotCalledUpeView]
+  lazy val view:      Document                     = Jsoup.parse(page()(request, appConfig, messages).toString())
+  lazy val pageTitle: String                       = "Sorry, there is a problem with the service"
+
+  "Registration Not Called Upe View" should {
+
+    "have a title" in {
+      view.title() mustBe "Register your group - Report Pillar 2 Top-up Taxes - GOV.UK" //TODO: Different title/H1 - raising a ticket to resolve later
+    }
+
+    "have a unique H1 heading" in {
+      val h1Elements: Elements = view.getElementsByTag("h1")
+      h1Elements.size() mustBe 1
+      h1Elements.text() mustBe pageTitle
+    }
+
+    "have paragraph contents" in {
+      val paragraphs = view.getElementsByClass("govuk-body")
+      paragraphs.get(0).text mustBe "Try again later."
+      paragraphs.get(1).text mustBe "Your company details could not be confirmed."
+    }
+
+    "have a paragraph with a link" in {
+      val paragraph = view.getElementsByClass("govuk-body").get(2)
+
+      paragraph.getElementsByTag("a").text mustBe "Go back to select the entity type to try again."
+      paragraph.getElementsByTag("a").attr("href") mustBe controllers.registration.routes.EntityTypeController.onPageLoad(NormalMode).url
+    }
+
+  }
+}

--- a/test/views/registrationview/UpeCheckYourAnswersViewSpec.scala
+++ b/test/views/registrationview/UpeCheckYourAnswersViewSpec.scala
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.registrationview
+
+import base.ViewSpecBase
+import models.{CheckMode, UKAddress, UserAnswers}
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.select.Elements
+import org.mockito.Mockito.when
+import pages._
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryList
+import viewmodels.checkAnswers._
+import viewmodels.govuk.summarylist._
+import views.html.registrationview.UpeCheckYourAnswersView
+
+class UpeCheckYourAnswersViewSpec extends ViewSpecBase {
+
+  lazy val countryCode: String = "UAE"
+  lazy val country:     String = "United Arab Emirates"
+
+  lazy val upeRegisteredAddress: UKAddress = UKAddress(
+    addressLine1 = "Address Line 1 UPE",
+    addressLine2 = None,
+    addressLine3 = "City UPE",
+    addressLine4 = None,
+    postalCode = "INVALID",
+    countryCode = countryCode
+  )
+
+  lazy val userAnswers: UserAnswers = emptyUserAnswers
+    .setOrException(UpeNameRegistrationPage, "Test UPE")
+    .setOrException(UpeRegisteredAddressPage, upeRegisteredAddress)
+    .setOrException(UpeContactNamePage, "Contact UPE")
+    .setOrException(UpeContactEmailPage, "testcontactupe@email.com")
+    .setOrException(UpePhonePreferencePage, true)
+    .setOrException(UpeCapturePhonePage, "1234569")
+
+  when(mockCountryOptions.getCountryNameFromCode(countryCode)).thenReturn(country)
+
+  val summaryList: SummaryList = SummaryListViewModel(
+    rows = Seq(
+      UpeNameRegistrationSummary.row(userAnswers),
+      UpeRegisteredAddressSummary.row(userAnswers, mockCountryOptions),
+      UpeContactNameSummary.row(userAnswers),
+      UpeContactEmailSummary.row(userAnswers),
+      UpeTelephonePreferenceSummary.row(userAnswers),
+      UPEContactTelephoneSummary.row(userAnswers)
+    ).flatten
+  )
+
+  lazy val page: UpeCheckYourAnswersView = inject[UpeCheckYourAnswersView]
+  lazy val view: Document = Jsoup.parse(
+    page(summaryList)(request, appConfig, messages).toString()
+  )
+  lazy val pageTitle: String = "Check your answers for ultimate parent details"
+
+  "Upe Check Your Answers View" should {
+
+    "have a title" in {
+      view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+    }
+
+    "have the correct section caption" in {
+      view.getElementsByClass("govuk-caption-l").text mustBe "Group details"
+    }
+
+    "have a unique H1 heading" in {
+      val h1Elements: Elements = view.getElementsByTag("h1")
+      h1Elements.size mustBe 1
+      h1Elements.text mustBe pageTitle
+    }
+
+    "have a summary list keys" in {
+      view.getElementsByClass("govuk-summary-list__key").get(0).text mustBe "Name"
+      view.getElementsByClass("govuk-summary-list__key").get(1).text mustBe "Address"
+      view.getElementsByClass("govuk-summary-list__key").get(2).text mustBe "Contact name"
+      view.getElementsByClass("govuk-summary-list__key").get(3).text mustBe "Email address"
+      view.getElementsByClass("govuk-summary-list__key").get(4).text mustBe "Can we contact by phone?"
+      view.getElementsByClass("govuk-summary-list__key").get(5).text mustBe "Phone number"
+    }
+
+    "have a summary list items" in {
+      view.getElementsByClass("govuk-summary-list__value").get(0).text mustBe "Test UPE"
+      view.getElementsByClass("govuk-summary-list__value").get(1).text mustBe "Address Line 1 UPE City UPE INVALID United Arab Emirates"
+      view.getElementsByClass("govuk-summary-list__value").get(2).text mustBe "Contact UPE"
+      view.getElementsByClass("govuk-summary-list__value").get(3).text mustBe "testcontactupe@email.com"
+      view.getElementsByClass("govuk-summary-list__value").get(4).text mustBe "Yes"
+      view.getElementsByClass("govuk-summary-list__value").get(5).text mustBe "1234569"
+    }
+
+    "have a summary list links" in {
+      view.getElementsByClass("govuk-summary-list__actions").get(0).text mustBe "Change the name of the Ultimate Parent Entity"
+      view.getElementsByClass("govuk-summary-list__actions").get(0).getElementsByTag("a").attr("href") mustBe
+        controllers.registration.routes.UpeNameRegistrationController.onPageLoad(CheckMode).url
+
+      view.getElementsByClass("govuk-summary-list__actions").get(1).text mustBe "Change the registered office address of the Ultimate Parent Entity"
+      view.getElementsByClass("govuk-summary-list__actions").get(1).getElementsByTag("a").attr("href") mustBe
+        controllers.registration.routes.UpeRegisteredAddressController.onPageLoad(CheckMode).url
+
+      view
+        .getElementsByClass("govuk-summary-list__actions")
+        .get(2)
+        .text mustBe "Change the name of the person or team we should contact from the Ultimate Parent Entity"
+      view.getElementsByClass("govuk-summary-list__actions").get(2).getElementsByTag("a").attr("href") mustBe
+        controllers.registration.routes.UpeContactNameController.onPageLoad(CheckMode).url
+
+      view.getElementsByClass("govuk-summary-list__actions").get(3).text mustBe "Change the email address for the Ultimate Parent Entity contact"
+      view.getElementsByClass("govuk-summary-list__actions").get(3).getElementsByTag("a").attr("href") mustBe
+        controllers.registration.routes.UpeContactEmailController.onPageLoad(CheckMode).url
+
+      view.getElementsByClass("govuk-summary-list__actions").get(4).text mustBe "Change can we contact the Ultimate Parent Entity by phone"
+      view.getElementsByClass("govuk-summary-list__actions").get(4).getElementsByTag("a").attr("href") mustBe
+        controllers.registration.routes.ContactUPEByPhoneController.onPageLoad(CheckMode).url
+
+      view.getElementsByClass("govuk-summary-list__actions").get(5).text mustBe "Change the phone number for the Ultimate Parent Entity contact"
+      view.getElementsByClass("govuk-summary-list__actions").get(5).getElementsByTag("a").attr("href") mustBe
+        controllers.registration.routes.CapturePhoneDetailsController.onPageLoad(CheckMode).url
+    }
+  }
+
+  "have a button" in {
+    view.getElementsByClass("govuk-button").text mustBe "Confirm and continue"
+  }
+}

--- a/test/views/registrationview/UpeContactEmailViewSpec.scala
+++ b/test/views/registrationview/UpeContactEmailViewSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.registrationview
+
+import base.ViewSpecBase
+import forms.UpeContactEmailFormProvider
+import models.NormalMode
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.select.Elements
+import views.html.registrationview.UpeContactEmailView
+
+class UpeContactEmailViewSpec extends ViewSpecBase {
+
+  lazy val formProvider: UpeContactEmailFormProvider = new UpeContactEmailFormProvider()
+  lazy val page:         UpeContactEmailView         = inject[UpeContactEmailView]
+  lazy val pageTitle:    String                      = "What is the email address?"
+
+  "Upe Contact Email View" should {
+    val view: Document = Jsoup.parse(
+      page(formProvider("userName"), NormalMode, "userName")(request, appConfig, messages).toString()
+    )
+
+    "have a title" in {
+      view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+    }
+
+    "have a unique H1 heading" in {
+      val h1Elements: Elements = view.getElementsByTag("h1")
+      h1Elements.size() mustBe 1
+      h1Elements.text() mustBe "What is the email address for userName?"
+    }
+
+    "have the correct section caption" in {
+      view.getElementsByClass("govuk-caption-l").text mustBe "Group details"
+    }
+
+    "have a hint" in {
+      view.getElementsByClass("govuk-hint").first.text mustBe "We will use this to confirm your records."
+    }
+
+    "have a save and continue button" in {
+      view.getElementsByClass("govuk-button").text mustBe "Save and continue"
+    }
+  }
+}

--- a/test/views/registrationview/UpeContactNameViewSpec.scala
+++ b/test/views/registrationview/UpeContactNameViewSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.registrationview
+
+import base.ViewSpecBase
+import forms.UpeContactNameFormProvider
+import models.NormalMode
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.select.Elements
+import views.html.registrationview.UpeContactNameView
+
+class UpeContactNameViewSpec extends ViewSpecBase {
+
+  lazy val formProvider: UpeContactNameFormProvider = new UpeContactNameFormProvider()
+  lazy val page:         UpeContactNameView         = inject[UpeContactNameView]
+  lazy val pageTitle:    String                     = "What is the name of the person or team from the Ultimate Parent Entity to keep on record?"
+
+  "Upe Contact Name View" should {
+    val view: Document = Jsoup.parse(
+      page(formProvider(), NormalMode)(request, appConfig, messages).toString()
+    )
+
+    "have a title" in {
+      view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+    }
+
+    "have a unique H1 heading" in {
+      val h1Elements: Elements = view.getElementsByTag("h1")
+      h1Elements.size() mustBe 1
+      h1Elements.text() mustBe pageTitle
+    }
+
+    "have the correct section caption" in {
+      view.getElementsByClass("govuk-caption-l").text mustBe "Group details"
+    }
+
+    "have a hint" in {
+      view.getElementsByClass("govuk-hint").first.text mustBe "For example, ‘Tax team’ or ‘Ashley Smith’."
+    }
+
+    "have a save and continue button" in {
+      view.getElementsByClass("govuk-button").text mustBe "Save and continue"
+    }
+  }
+}

--- a/test/views/rfm/AgentViewSpec.scala
+++ b/test/views/rfm/AgentViewSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.rfm
+
+import base.ViewSpecBase
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.select.Elements
+import views.html.rfm.AgentView
+
+class AgentViewSpec extends ViewSpecBase {
+
+  lazy val page:      AgentView = inject[AgentView]
+  lazy val view:      Document  = Jsoup.parse(page()(request, appConfig, messages).toString())
+  lazy val pageTitle: String    = "Sorry, you’re unable to use this service"
+
+  "Agent View" should {
+
+    "have a title" in {
+      view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+    }
+
+    "have a unique H1 heading" in {
+      val h1Elements: Elements = view.getElementsByTag("h1")
+      h1Elements.size() mustBe 1
+      h1Elements.text() mustBe pageTitle
+    }
+
+    "have paragraph contents" in {
+      val paragraphs = view.getElementsByClass("govuk-body")
+      paragraphs.get(0).text mustBe "You’ve signed in using an agent’s Government Gateway user ID."
+      paragraphs.get(1).text mustBe "Agents cannot use this service to replace a nominated filing member."
+      paragraphs.get(2).text mustBe
+        "Someone with an administrator’s Government Gateway user ID who is the new nominated filing member will need to replace the current filing member."
+    }
+
+    "have a link" in {
+      val link = view.getElementsByClass("govuk-body").last().getElementsByTag("a")
+      link.text mustBe "Find out more about who can use this service"
+      link.attr("href") mustBe controllers.rfm.routes.StartPageController.onPageLoad.url
+    }
+
+  }
+
+}

--- a/test/views/rfm/AlreadyEnrolledViewSpec.scala
+++ b/test/views/rfm/AlreadyEnrolledViewSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.rfm
+
+import base.ViewSpecBase
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.select.Elements
+import views.html.rfm.AlreadyEnrolledView
+
+class AlreadyEnrolledViewSpec extends ViewSpecBase {
+
+  lazy val page:      AlreadyEnrolledView = inject[AlreadyEnrolledView]
+  lazy val view:      Document            = Jsoup.parse(page()(request, appConfig, messages).toString())
+  lazy val pageTitle: String              = "You cannot replace the current filing member for this group"
+
+  "Already Enrolled View" should {
+
+    "have a title" in {
+      view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+    }
+
+    "have a unique H1 heading" in {
+      val h1Elements: Elements = view.getElementsByTag("h1")
+      h1Elements.size() mustBe 1
+      h1Elements.text() mustBe pageTitle
+    }
+
+    "have paragraph contents" in {
+      val paragraphs = view.getElementsByClass("govuk-body")
+      paragraphs.get(0).text mustBe
+        "The Government Gateway user ID you entered as the replacement is currently registered as the nominated filing member for this group."
+      paragraphs.get(1).text mustBe
+        "To replace the nominated filing member for this group, the new nominated filing member will need to try again with their Government Gateway user ID."
+    }
+
+    "have a link" in {
+      val link = view.getElementsByClass("govuk-body").last().getElementsByTag("a")
+      link.text mustBe "Find out more about who can use this service"
+      link.attr("href") mustBe controllers.rfm.routes.StartPageController.onPageLoad.url
+    }
+
+  }
+
+}

--- a/test/views/rfm/AmendApiFailureViewSpec.scala
+++ b/test/views/rfm/AmendApiFailureViewSpec.scala
@@ -20,18 +20,29 @@ import base.ViewSpecBase
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
+import play.api.mvc.{AnyContent, Request}
+import play.api.test.CSRFTokenHelper.CSRFRequest
+import play.api.test.FakeRequest
 import views.html.rfm.AmendApiFailureView
 
 class AmendApiFailureViewSpec extends ViewSpecBase {
 
+  lazy val rfmRequest: Request[AnyContent] =
+    FakeRequest("GET", controllers.rfm.routes.AmendApiFailureController.onPageLoad.url).withCSRFToken
   lazy val page:      AmendApiFailureView = inject[AmendApiFailureView]
-  lazy val view:      Document            = Jsoup.parse(page()(request, appConfig, messages).toString())
+  lazy val view:      Document            = Jsoup.parse(page()(rfmRequest, appConfig, messages).toString())
   lazy val pageTitle: String              = "Sorry, there is a problem with the service"
 
   "Amend Api Failure View" should {
 
     "have a title" in {
       view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+    }
+
+    "have a non-clickable banner" in {
+      val serviceName = view.getElementsByClass("govuk-header__service-name").first()
+      serviceName.text mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.getElementsByTag("a") mustBe empty
     }
 
     "have a unique H1 heading" in {

--- a/test/views/rfm/IncompleteDataViewSpec.scala
+++ b/test/views/rfm/IncompleteDataViewSpec.scala
@@ -21,18 +21,29 @@ import forms.AgentClientPillar2ReferenceFormProvider
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
+import play.api.mvc.{AnyContent, Request}
+import play.api.test.CSRFTokenHelper.CSRFRequest
+import play.api.test.FakeRequest
 import views.html.rfm.IncompleteDataView
 
 class IncompleteDataViewSpec extends ViewSpecBase {
 
   lazy val formProvider: AgentClientPillar2ReferenceFormProvider = new AgentClientPillar2ReferenceFormProvider
   lazy val page:         IncompleteDataView                      = inject[IncompleteDataView]
-  lazy val view:         Document                                = Jsoup.parse(page()(request, appConfig, messages).toString())
-  lazy val pageTitle:    String                                  = "You have an incomplete task"
+  lazy val rfmRequest: Request[AnyContent] =
+    FakeRequest("GET", controllers.rfm.routes.RfmIncompleteDataController.onPageLoad.url).withCSRFToken
+  lazy val view:      Document = Jsoup.parse(page()(rfmRequest, appConfig, messages).toString())
+  lazy val pageTitle: String   = "You have an incomplete task"
 
   "Replace filing member incomplete data view" should {
     "have a title" in {
       view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+    }
+
+    "have a non-clickable banner" in {
+      val serviceName = view.getElementsByClass("govuk-header__service-name").first()
+      serviceName.text mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.getElementsByTag("a") mustBe empty
     }
 
     "have a unique H1 heading" in {

--- a/test/views/rfm/IndividualViewSpec.scala
+++ b/test/views/rfm/IndividualViewSpec.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.rfm
+
+import base.ViewSpecBase
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.select.Elements
+import views.html.rfm.IndividualView
+
+class IndividualViewSpec extends ViewSpecBase {
+
+  lazy val page:      IndividualView = inject[IndividualView]
+  lazy val view:      Document       = Jsoup.parse(page()(request, appConfig, messages).toString())
+  lazy val pageTitle: String         = "Sorry, you’re unable to use this service"
+
+  "Individual View" should {
+
+    "have a title" in {
+      view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+    }
+
+    "have a unique H1 heading" in {
+      val h1Elements: Elements = view.getElementsByTag("h1")
+      h1Elements.size() mustBe 1
+      h1Elements.text() mustBe pageTitle
+    }
+
+    "have a paragraph body" in {
+      view.getElementsByClass("govuk-body").get(0).text mustBe
+        "You’ve signed in with an individual account. Only users with an organisation account can replace their nominated filing member."
+    }
+
+    "have a paragraph with link" in {
+      val paragraph = view.getElementsByClass("govuk-body").get(1)
+      paragraph.text mustBe "If you need to replace a nominated filing member, sign in to Government Gateway with an organisation account."
+      val paragraphLink = paragraph.select("a")
+      paragraphLink.text mustBe "sign in to Government Gateway with an organisation account"
+      paragraphLink.attr("href") mustBe s"${appConfig.loginUrl}" + "?continue=" + s"${appConfig.rfmLoginContinueUrl}"
+    }
+
+    "have a link" in {
+      val link = view.getElementsByClass("govuk-body").last().getElementsByTag("a")
+      link.text mustBe "Find out more about who can use this service"
+      link.attr("href") mustBe controllers.rfm.routes.StartPageController.onPageLoad.url
+    }
+
+  }
+
+}

--- a/test/views/rfm/JourneyRecoveryViewSpec.scala
+++ b/test/views/rfm/JourneyRecoveryViewSpec.scala
@@ -20,18 +20,29 @@ import base.ViewSpecBase
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
+import play.api.mvc.{AnyContent, Request}
+import play.api.test.CSRFTokenHelper.CSRFRequest
+import play.api.test.FakeRequest
 import views.html.rfm.JourneyRecoveryView
 
 class JourneyRecoveryViewSpec extends ViewSpecBase {
 
+  lazy val rfmRequest: Request[AnyContent] =
+    FakeRequest("GET", controllers.rfm.routes.RfmJourneyRecoveryController.onPageLoad.url).withCSRFToken
   lazy val page:      JourneyRecoveryView = inject[JourneyRecoveryView]
-  lazy val view:      Document            = Jsoup.parse(page()(request, appConfig, messages).toString())
+  lazy val view:      Document            = Jsoup.parse(page()(rfmRequest, appConfig, messages).toString())
   lazy val pageTitle: String              = "There has been an error"
 
   "Replace filing member journey recovery view" should {
 
     "have a title" in {
       view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+    }
+
+    "have a non-clickable banner" in {
+      val serviceName = view.getElementsByClass("govuk-header__service-name").first()
+      serviceName.text mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.getElementsByTag("a") mustBe empty
     }
 
     "have a unique H1 heading" in {

--- a/test/views/rfm/RfmConfirmationViewSpec.scala
+++ b/test/views/rfm/RfmConfirmationViewSpec.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.rfm
+
+import base.ViewSpecBase
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.select.Elements
+import play.twirl.api.HtmlFormat
+import utils.ViewHelpers
+import views.html.rfm.RfmConfirmationView
+
+class RfmConfirmationViewSpec extends ViewSpecBase {
+  lazy val testPillar2ID: String              = "PLR2ID123"
+  lazy val testDateTime:  String              = HtmlFormat.escape(ViewHelpers.getDateTimeGMT).toString
+  lazy val page:          RfmConfirmationView = inject[RfmConfirmationView]
+  lazy val pageTitle:     String              = "Replace filing member successful"
+
+  lazy val view: Document =
+    Jsoup.parse(page(testPillar2ID, testDateTime)(request, appConfig, messages).toString())
+
+  "Rfm Confirmation View" should {
+    "have a title" in {
+      view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+    }
+
+    "have a panel with a unique H1 heading" in {
+      val h1Elements: Elements = view.getElementsByTag("h1")
+      h1Elements.size() mustBe 1
+      h1Elements.text() mustBe pageTitle
+      h1Elements.hasClass("govuk-panel__title") mustBe true
+    }
+
+    "have pillar 2 ID and date time confirmation paragraphs" in {
+      val paragraphText = view.getElementsByClass("govuk-body")
+      paragraphText.get(0).text mustEqual s"Group Pillar 2 Top-up Taxes ID: $testPillar2ID"
+      paragraphText.get(1).text mustEqual s"Your group’s filing member was replaced on $testDateTime"
+    }
+
+    "have an H2 heading for new filing member obligations" in {
+      view.getElementsByTag("h2").first.text mustBe "As the new filing member, you have taken over the obligations to:"
+    }
+
+    "have a bullet list with filing member obligations" in {
+      val bulletItems: Elements = view.getElementsByClass("govuk-list--bullet").select("li")
+
+      bulletItems.get(0).text mustBe "act as HMRC’s primary contact in relation to the group’s Pillar 2 Top-up Taxes compliance"
+      bulletItems.get(1).text mustBe "submit your group’s Pillar 2 Top-up Taxes returns"
+      bulletItems.get(2).text mustBe "ensure your group’s Pillar 2 Top-up Taxes account accurately reflects their records."
+    }
+
+    "have paragraph for filing member obligations warning" in {
+      view.getElementsByClass("govuk-body").get(3).text mustBe
+        "If you fail to meet your obligations as a filing member, you may be liable for penalties."
+    }
+
+    "have an H2 heading for what happens next" in {
+      view.getElementsByTag("h2").get(1).text mustBe "What happens next"
+    }
+
+    "have a paragraph with link" in {
+      val paragraph = view.getElementsByClass("govuk-body").get(4)
+      paragraph.text mustBe "You can now report and manage your group's Pillar 2 Top-up Taxes on behalf of your group."
+      val link = paragraph.getElementsByTag("a")
+      link.text mustBe "report and manage your group's Pillar 2 Top-up Taxes"
+      link.attr("href") mustBe controllers.routes.DashboardController.onPageLoad.url
+    }
+
+    "have a bullet list with download and print links" in {
+      val bulletItems: Elements = view.getElementsByClass("govuk-list--bullet").select("li")
+
+      bulletItems.get(3).text mustBe "Print this page"
+      bulletItems.get(4).text mustBe "Download as PDF"
+    }
+  }
+}

--- a/test/views/rfm/RfmContactByTelephoneViewSpec.scala
+++ b/test/views/rfm/RfmContactByTelephoneViewSpec.scala
@@ -22,6 +22,9 @@ import models.NormalMode
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
+import play.api.mvc.{AnyContent, Request}
+import play.api.test.CSRFTokenHelper.CSRFRequest
+import play.api.test.FakeRequest
 import views.html.rfm.RfmContactByTelephoneView
 
 class RfmContactByTelephoneViewSpec extends ViewSpecBase {
@@ -29,7 +32,9 @@ class RfmContactByTelephoneViewSpec extends ViewSpecBase {
   lazy val formProvider = new RfmContactByTelephoneFormProvider
   lazy val page:     RfmContactByTelephoneView = inject[RfmContactByTelephoneView]
   lazy val username: String                    = "John Doe"
-  lazy val view:      Document = Jsoup.parse(page(formProvider(username), NormalMode, username)(request, appConfig, messages).toString())
+  lazy val rfmRequest: Request[AnyContent] =
+    FakeRequest("GET", controllers.rfm.routes.RfmContactByTelephoneController.onPageLoad(NormalMode).url).withCSRFToken
+  lazy val view:      Document = Jsoup.parse(page(formProvider(username), NormalMode, username)(rfmRequest, appConfig, messages).toString())
   lazy val pageTitle: String   = "Can we contact by phone"
 
   "Rfm Contact By Telephone View" should {
@@ -37,6 +42,12 @@ class RfmContactByTelephoneViewSpec extends ViewSpecBase {
     "have a title" in {
       view.getElementsByTag("title").text must include("Can we contact by phone?")
       view.title() mustBe s"$pageTitle? - Report Pillar 2 Top-up Taxes - GOV.UK"
+    }
+
+    "have a non-clickable banner" in {
+      val serviceName = view.getElementsByClass("govuk-header__service-name").first()
+      serviceName.text mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.getElementsByTag("a") mustBe empty
     }
 
     "have a caption" in {

--- a/test/views/rfm/RfmContactCheckYourAnswersViewSpec.scala
+++ b/test/views/rfm/RfmContactCheckYourAnswersViewSpec.scala
@@ -27,6 +27,9 @@ import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
 import org.mockito.Mockito.when
 import pages._
+import play.api.mvc.{AnyContent, Request}
+import play.api.test.CSRFTokenHelper.CSRFRequest
+import play.api.test.FakeRequest
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryList
 import viewmodels.checkAnswers._
 import viewmodels.govuk.summarylist._
@@ -100,9 +103,11 @@ class RfmContactCheckYourAnswersViewSpec extends ViewSpecBase {
     rows = Seq(RfmContactAddressSummary.row(userAnswers, mockCountryOptions)).flatten
   )
 
+  lazy val rfmRequest: Request[AnyContent] =
+    FakeRequest("GET", controllers.rfm.routes.RfmContactCheckYourAnswersController.onPageLoad.url).withCSRFToken
   lazy val page: RfmContactCheckYourAnswersView = inject[RfmContactCheckYourAnswersView]
   lazy val view: Document = Jsoup.parse(
-    page(rfmCorporatePositionSummaryList, rfmPrimaryContactList, rfmSecondaryContactList, address)(request, appConfig, messages).toString()
+    page(rfmCorporatePositionSummaryList, rfmPrimaryContactList, rfmSecondaryContactList, address)(rfmRequest, appConfig, messages).toString()
   )
   lazy val pageTitle:  String   = "Check your answers before submitting"
   lazy val h2Elements: Elements = view.getElementsByTag("h2")
@@ -111,6 +116,12 @@ class RfmContactCheckYourAnswersViewSpec extends ViewSpecBase {
 
     "have a title" in {
       view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+    }
+
+    "have a non-clickable banner" in {
+      val serviceName = view.getElementsByClass("govuk-header__service-name").first()
+      serviceName.text mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.getElementsByTag("a") mustBe empty
     }
 
     "have a caption" in {

--- a/test/views/rfm/RfmContactCheckYourAnswersViewSpec.scala
+++ b/test/views/rfm/RfmContactCheckYourAnswersViewSpec.scala
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.rfm
+
+import base.ViewSpecBase
+import models.grs.GrsRegistrationResult
+import models.grs.RegistrationStatus.Registered
+import models.registration.{CompanyProfile, IncorporatedEntityAddress, IncorporatedEntityRegistrationData}
+import models.rfm.CorporatePosition.Upe
+import models.{NonUKAddress, UserAnswers}
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.select.Elements
+import org.mockito.Mockito.when
+import pages._
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryList
+import viewmodels.checkAnswers._
+import viewmodels.govuk.summarylist._
+import views.html.rfm.RfmContactCheckYourAnswersView
+
+class RfmContactCheckYourAnswersViewSpec extends ViewSpecBase {
+
+  lazy val countryCode: String = "GB"
+  lazy val country:     String = "United Kingdom"
+  lazy val incorporatedEntityRegistrationData: IncorporatedEntityRegistrationData = IncorporatedEntityRegistrationData(
+    CompanyProfile("companyName", "companyNumber", None, IncorporatedEntityAddress(None, None, None, None, None, None, None, None)),
+    "ctutr",
+    identifiersMatch = false,
+    None,
+    GrsRegistrationResult(Registered, None, None)
+  )
+  lazy val contactAddress: NonUKAddress = NonUKAddress(
+    addressLine1 = "RFM Address Line 1",
+    addressLine2 = None,
+    addressLine3 = "RFM City",
+    addressLine4 = None,
+    postalCode = Some("EH5 5WY"),
+    countryCode = "GB"
+  )
+
+  lazy val userAnswers: UserAnswers = emptyUserAnswers
+    .setOrException(RfmCorporatePositionPage, Upe)
+    .setOrException(RfmPrimaryContactNamePage, "RFM test contact")
+    .setOrException(RfmPrimaryContactEmailPage, "rfm@email.com")
+    .setOrException(RfmContactByTelephonePage, false)
+    .setOrException(RfmAddSecondaryContactPage, false)
+    .setOrException(RfmContactAddressPage, contactAddress)
+
+  when(mockCountryOptions.getCountryNameFromCode(countryCode)).thenReturn(country)
+
+  val rfmCorporatePositionSummaryList: SummaryList =
+    SummaryListViewModel(
+      rows = Seq(
+        RfmCorporatePositionSummary.row(userAnswers),
+        RfmNameRegistrationSummary.row(userAnswers),
+        RfmRegisteredAddressSummary.row(userAnswers, mockCountryOptions),
+        EntityTypeIncorporatedCompanyNameRfmSummary.row(userAnswers),
+        EntityTypeIncorporatedCompanyRegRfmSummary.row(userAnswers),
+        EntityTypeIncorporatedCompanyUtrRfmSummary.row(userAnswers),
+        EntityTypePartnershipCompanyNameRfmSummary.row(userAnswers),
+        EntityTypePartnershipCompanyRegRfmSummary.row(userAnswers),
+        EntityTypePartnershipCompanyUtrRfmSummary.row(userAnswers)
+      ).flatten
+    )
+
+  val rfmPrimaryContactList: SummaryList = SummaryListViewModel(
+    rows = Seq(
+      RfmPrimaryContactNameSummary.row(userAnswers),
+      RfmPrimaryContactEmailSummary.row(userAnswers),
+      RfmContactByTelephoneSummary.row(userAnswers),
+      RfmCapturePrimaryTelephoneSummary.row(userAnswers)
+    ).flatten
+  )
+
+  val rfmSecondaryContactList: SummaryList = SummaryListViewModel(
+    rows = Seq(
+      RfmAddSecondaryContactSummary.row(userAnswers),
+      RfmSecondaryContactNameSummary.row(userAnswers),
+      RfmSecondaryContactEmailSummary.row(userAnswers),
+      RfmSecondaryTelephonePreferenceSummary.row(userAnswers),
+      RfmSecondaryTelephoneSummary.row(userAnswers)
+    ).flatten
+  )
+
+  val address: SummaryList = SummaryListViewModel(
+    rows = Seq(RfmContactAddressSummary.row(userAnswers, mockCountryOptions)).flatten
+  )
+
+  lazy val page: RfmContactCheckYourAnswersView = inject[RfmContactCheckYourAnswersView]
+  lazy val view: Document = Jsoup.parse(
+    page(rfmCorporatePositionSummaryList, rfmPrimaryContactList, rfmSecondaryContactList, address)(request, appConfig, messages).toString()
+  )
+  lazy val pageTitle:  String   = "Check your answers before submitting"
+  lazy val h2Elements: Elements = view.getElementsByTag("h2")
+
+  "Rfm Contact Check Your Answers View" should {
+
+    "have a title" in {
+      view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+    }
+
+    "have a caption" in {
+      view.getElementsByClass("govuk-caption-l").text mustBe "Review and submit"
+    }
+
+    "have a unique H1 heading" in {
+      val h1Elements: Elements = view.getElementsByTag("h1")
+      h1Elements.size mustBe 1
+      h1Elements.text mustBe pageTitle
+    }
+
+    "have filing member details section" must {
+      "have h2 heading" in {
+        h2Elements.get(1).text mustBe "Filing member details"
+      }
+
+      "have a summary list key" in {
+        view.getElementsByClass("govuk-summary-list__key").get(0).text mustBe "Position in the group’s corporate structure"
+      }
+
+      "have a summary list item" in {
+        view.getElementsByClass("govuk-summary-list__value").get(0).text mustBe "Ultimate Parent Entity (UPE)"
+      }
+
+      "have a summary list links" in {
+        view.getElementsByClass("govuk-summary-list__actions").get(0).text mustBe "Change the position in the group’s corporate structure"
+      }
+    }
+
+    "have primary contact section" must {
+      "have h2 heading" in {
+        h2Elements.get(2).text mustBe "Primary contact"
+      }
+
+      "have a summary list key" in {
+        val summaryListKeys: Elements = view.getElementsByClass("govuk-summary-list__key")
+        summaryListKeys.get(1).text mustBe "Contact name"
+        summaryListKeys.get(2).text mustBe "Email address"
+        summaryListKeys.get(3).text mustBe "Can we contact the primary contact by phone?"
+      }
+
+      "have a summary list item" in {
+        val summaryListItems = view.getElementsByClass("govuk-summary-list__value")
+        summaryListItems.get(1).text mustBe "RFM test contact"
+        summaryListItems.get(2).text mustBe "rfm@email.com"
+        summaryListItems.get(3).text mustBe "No"
+      }
+
+      "have a summary list links" in {
+        val summaryListLinks = view.getElementsByClass("govuk-summary-list__actions")
+        summaryListLinks.get(1).text mustBe "Change the primary contact name"
+        summaryListLinks.get(2).text mustBe "Change the primary contact email address"
+        summaryListLinks.get(3).text mustBe "Change can we contact the primary contact by phone"
+      }
+    }
+
+    "have a secondary contact section" must {
+      "have h2 heading" in {
+        h2Elements.get(3).text mustBe "Secondary contact"
+      }
+
+      "have a summary list key" in {
+        view.getElementsByClass("govuk-summary-list__key").get(4).text mustBe "Do you have a secondary contact?"
+      }
+
+      "have a summary list item" in {
+        view.getElementsByClass("govuk-summary-list__value").get(4).text mustBe "No"
+      }
+
+      "have a summary list links" in {
+        view.getElementsByClass("govuk-summary-list__actions").get(4).text mustBe "Change do you have a secondary contact"
+      }
+    }
+
+    "have a contact address section" must {
+      "have h2 heading" in {
+        h2Elements.get(4).text mustBe "Contact address"
+      }
+
+      "have a summary list key" in {
+        view.getElementsByClass("govuk-summary-list__key").get(5).text mustBe "Address"
+      }
+
+      "have a summary list item" in {
+        view.getElementsByClass("govuk-summary-list__value").get(5).text mustBe "RFM Address Line 1 RFM City EH5 5WY United Kingdom"
+      }
+
+      "have a summary list links" in {
+        view.getElementsByClass("govuk-summary-list__actions").get(5).text mustBe "Change the contact address"
+      }
+    }
+
+    "have a keep a record of your answers section" must {
+      "have h2 heading" in {
+        h2Elements.get(5).text mustBe "Do you need to keep a record of your answers?"
+      }
+
+      "have a paragraph" in {
+        view.getElementsByClass("govuk-body").get(0).text mustBe "If you need to keep a record of your answers, you can:"
+      }
+
+      "have bullet items" in {
+        val bulletItems: Elements = view.getElementsByClass("govuk-list--bullet").select("li")
+
+        bulletItems.get(0).text mustBe "Print this page"
+        bulletItems.get(1).text mustBe "Download as PDF"
+      }
+    }
+
+    "have a submission section" must {
+      "have h2 heading" in {
+        h2Elements.get(6).text mustBe "Now submit your details to replace the current filing member"
+      }
+
+      "have a paragraph" in {
+        view
+          .getElementsByClass("govuk-body")
+          .get(1)
+          .text mustBe "By submitting these details, you are confirming that you are able to act as a new filing member for your group and the information is correct and complete to the best of your knowledge."
+      }
+    }
+
+    "have a button" in {
+      view.getElementsByClass("govuk-button").text mustBe "Confirm and submit"
+    }
+  }
+}

--- a/test/views/rfm/RfmContactCheckYourAnswersViewSpec.scala
+++ b/test/views/rfm/RfmContactCheckYourAnswersViewSpec.scala
@@ -21,7 +21,7 @@ import models.grs.GrsRegistrationResult
 import models.grs.RegistrationStatus.Registered
 import models.registration.{CompanyProfile, IncorporatedEntityAddress, IncorporatedEntityRegistrationData}
 import models.rfm.CorporatePosition.Upe
-import models.{NonUKAddress, UserAnswers}
+import models.{CheckMode, NonUKAddress, UserAnswers}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
@@ -149,6 +149,8 @@ class RfmContactCheckYourAnswersViewSpec extends ViewSpecBase {
 
       "have a summary list links" in {
         view.getElementsByClass("govuk-summary-list__actions").get(0).text mustBe "Change the position in the group’s corporate structure"
+        view.getElementsByClass("govuk-summary-list__actions").get(0).getElementsByTag("a").attr("href") mustBe
+          controllers.rfm.routes.CorporatePositionController.onPageLoad(CheckMode).url
       }
     }
 
@@ -174,8 +176,17 @@ class RfmContactCheckYourAnswersViewSpec extends ViewSpecBase {
       "have a summary list links" in {
         val summaryListLinks = view.getElementsByClass("govuk-summary-list__actions")
         summaryListLinks.get(1).text mustBe "Change the primary contact name"
+        summaryListLinks.get(1).getElementsByTag("a").attr("href") mustBe controllers.rfm.routes.RfmPrimaryContactNameController
+          .onPageLoad(CheckMode)
+          .url
         summaryListLinks.get(2).text mustBe "Change the primary contact email address"
+        summaryListLinks.get(2).getElementsByTag("a").attr("href") mustBe controllers.rfm.routes.RfmPrimaryContactEmailController
+          .onPageLoad(CheckMode)
+          .url
         summaryListLinks.get(3).text mustBe "Change can we contact the primary contact by phone"
+        summaryListLinks.get(3).getElementsByTag("a").attr("href") mustBe controllers.rfm.routes.RfmContactByTelephoneController
+          .onPageLoad(CheckMode)
+          .url
       }
     }
 
@@ -194,6 +205,8 @@ class RfmContactCheckYourAnswersViewSpec extends ViewSpecBase {
 
       "have a summary list links" in {
         view.getElementsByClass("govuk-summary-list__actions").get(4).text mustBe "Change do you have a secondary contact"
+        view.getElementsByClass("govuk-summary-list__actions").get(4).getElementsByTag("a").attr("href") mustBe
+          controllers.rfm.routes.RfmAddSecondaryContactController.onPageLoad(CheckMode).url
       }
     }
 
@@ -212,6 +225,8 @@ class RfmContactCheckYourAnswersViewSpec extends ViewSpecBase {
 
       "have a summary list links" in {
         view.getElementsByClass("govuk-summary-list__actions").get(5).text mustBe "Change the contact address"
+        view.getElementsByClass("govuk-summary-list__actions").get(5).getElementsByTag("a").attr("href") mustBe
+          controllers.rfm.routes.RfmContactAddressController.onPageLoad(CheckMode).url
       }
     }
 

--- a/test/views/rfm/RfmContactDetailsRegistrationViewSpec.scala
+++ b/test/views/rfm/RfmContactDetailsRegistrationViewSpec.scala
@@ -17,27 +17,24 @@
 package views.rfm
 
 import base.ViewSpecBase
-import forms.RfmSecurityCheckFormProvider
-import models.NormalMode
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
 import play.api.mvc.{AnyContent, Request}
 import play.api.test.CSRFTokenHelper.CSRFRequest
 import play.api.test.FakeRequest
-import views.html.rfm.SecurityCheckView
+import views.html.rfm.RfmContactDetailsRegistrationView
 
-class SecurityCheckViewSpec extends ViewSpecBase {
-
-  lazy val formProvider: RfmSecurityCheckFormProvider = new RfmSecurityCheckFormProvider
+class RfmContactDetailsRegistrationViewSpec extends ViewSpecBase {
+  lazy val page:      RfmContactDetailsRegistrationView = inject[RfmContactDetailsRegistrationView]
+  lazy val pageTitle: String                            = "We need contact details for your Pillar 2 Top-up Taxes account"
   lazy val rfmRequest: Request[AnyContent] =
-    FakeRequest("GET", controllers.rfm.routes.SecurityCheckController.onPageLoad(NormalMode).url).withCSRFToken
-  lazy val page:      SecurityCheckView = inject[SecurityCheckView]
-  lazy val view:      Document          = Jsoup.parse(page(formProvider(), NormalMode)(rfmRequest, appConfig, messages).toString())
-  lazy val pageTitle: String            = "Enter the group’s Pillar 2 Top-up Taxes ID"
+    FakeRequest("GET", controllers.rfm.routes.RfmContactDetailsRegistrationController.onPageLoad.url).withCSRFToken
 
-  "Security Check View" should {
+  lazy val view: Document =
+    Jsoup.parse(page()(rfmRequest, appConfig, messages).toString())
 
+  "Rfm Contact Details Registration View" should {
     "have a title" in {
       view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
     }
@@ -49,19 +46,19 @@ class SecurityCheckViewSpec extends ViewSpecBase {
     }
 
     "have a caption" in {
-      view.getElementsByClass("govuk-caption-l").text mustBe "Replace filing member"
+      view.getElementsByClass("govuk-caption-l").text mustBe "Contact details"
     }
 
-    "have a unique H1 heading" in {
+    "have a panel with a unique H1 heading" in {
       val h1Elements: Elements = view.getElementsByTag("h1")
       h1Elements.size() mustBe 1
       h1Elements.text() mustBe pageTitle
+      h1Elements.hasClass("govuk-heading-l") mustBe true
     }
 
-    "have a hint description" in {
-      view.getElementsByClass("govuk-hint").get(0).text mustBe
-        "This is 15 characters, for example, " +
-        "XMPLR0123456789. The current filing member can find it within their Pillar 2 Top-up Taxes account."
+    "have a paragraph" in {
+      view.getElementsByClass("govuk-body").get(0).text mustBe
+        "We need information about the filing member of this group so we can contact the right person or team when reviewing your Pillar 2 Top-up Taxes compliance."
     }
 
     "have a button" in {

--- a/test/views/rfm/RfmWaitingRoomViewSpec.scala
+++ b/test/views/rfm/RfmWaitingRoomViewSpec.scala
@@ -21,12 +21,17 @@ import models.rfm.RfmStatus.SuccessfullyCompleted
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
+import play.api.mvc.{AnyContent, Request}
+import play.api.test.CSRFTokenHelper.CSRFRequest
+import play.api.test.FakeRequest
 import views.html.rfm.RfmWaitingRoomView
 
 class RfmWaitingRoomViewSpec extends ViewSpecBase {
 
+  lazy val rfmRequest: Request[AnyContent] =
+    FakeRequest("GET", controllers.rfm.routes.RfmWaitingRoomController.onPageLoad().url).withCSRFToken
   lazy val page:      RfmWaitingRoomView = inject[RfmWaitingRoomView]
-  lazy val view:      Document           = Jsoup.parse(page(Some(SuccessfullyCompleted))(request, appConfig, messages).toString())
+  lazy val view:      Document           = Jsoup.parse(page(Some(SuccessfullyCompleted))(rfmRequest, appConfig, messages).toString())
   lazy val pageTitle: String             = "Submitting..."
 
   "Rfm Waiting Room View" should {
@@ -36,9 +41,9 @@ class RfmWaitingRoomViewSpec extends ViewSpecBase {
     }
 
     "have a non-clickable banner" in {
-      val headerContent = view.getElementsByClass("govuk-header__content").get(0)
-      headerContent.text mustBe "Report Pillar 2 Top-up Taxes"
-      headerContent.getElementsByTag("a") mustBe empty
+      val serviceName = view.getElementsByClass("govuk-header__service-name").first()
+      serviceName.text mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.getElementsByTag("a") mustBe empty
     }
 
     "have a unique H1 heading" in {

--- a/test/views/rfm/RfmWaitingRoomViewSpec.scala
+++ b/test/views/rfm/RfmWaitingRoomViewSpec.scala
@@ -35,6 +35,12 @@ class RfmWaitingRoomViewSpec extends ViewSpecBase {
       view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
     }
 
+    "have a non-clickable banner" in {
+      val headerContent = view.getElementsByClass("govuk-header__content").get(0)
+      headerContent.text mustBe "Report Pillar 2 Top-up Taxes"
+      headerContent.getElementsByTag("a") mustBe empty
+    }
+
     "have a unique H1 heading" in {
       val h1Elements: Elements = view.getElementsByTag("h1")
       h1Elements.size() mustBe 1

--- a/test/views/rfm/SecurityQuestionsCheckYourAnswersViewSpec.scala
+++ b/test/views/rfm/SecurityQuestionsCheckYourAnswersViewSpec.scala
@@ -22,6 +22,9 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
 import pages.{RfmPillar2ReferencePage, RfmRegistrationDatePage}
+import play.api.mvc.{AnyContent, Request}
+import play.api.test.CSRFTokenHelper.CSRFRequest
+import play.api.test.FakeRequest
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryList
 import utils.ViewHelpers
 import viewmodels.checkAnswers.{RfmRegistrationDateSummary, RfmSecurityCheckSummary}
@@ -43,14 +46,22 @@ class SecurityQuestionsCheckYourAnswersViewSpec extends ViewSpecBase {
     ).flatten
   )
 
+  lazy val rfmRequest: Request[AnyContent] =
+    FakeRequest("GET", controllers.rfm.routes.SecurityQuestionsCheckYourAnswersController.onPageLoad(NormalMode).url).withCSRFToken
   lazy val page:      SecurityQuestionsCheckYourAnswersView = inject[SecurityQuestionsCheckYourAnswersView]
-  lazy val view:      Document                              = Jsoup.parse(page(NormalMode, list)(request, appConfig, messages).toString())
+  lazy val view:      Document                              = Jsoup.parse(page(NormalMode, list)(rfmRequest, appConfig, messages).toString())
   lazy val pageTitle: String                                = "Check your answers"
 
   "Security Questions Check Your Answers View" should {
 
     "have a title" in {
       view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+    }
+
+    "have a non-clickable banner" in {
+      val serviceName = view.getElementsByClass("govuk-header__service-name").first()
+      serviceName.text mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.getElementsByTag("a") mustBe empty
     }
 
     "have a caption" in {


### PR DESCRIPTION
Moving content tests from acceptance tests to unit tests for the following feature files:
RFMnfmNoIDFlow
RFMSecurity&ErrorValidations
RFMStartPage&KBValidations
SubscriptionAndErrorValidations
UPEAndNFMGRSFlowPages
UPENoIDFLowPage