### PR TITLE
[PIL-2353] - add new received flag

### DIFF
--- a/app/models/DueAndOverdueReturnBannerScenario.scala
+++ b/app/models/DueAndOverdueReturnBannerScenario.scala
@@ -21,12 +21,14 @@ sealed trait DueAndOverdueReturnBannerScenario
 case object Due extends DueAndOverdueReturnBannerScenario
 case object Overdue extends DueAndOverdueReturnBannerScenario
 case object Incomplete extends DueAndOverdueReturnBannerScenario
+case object Received extends DueAndOverdueReturnBannerScenario
 
 object DueAndOverdueReturnBannerScenario {
   implicit val ordering: Ordering[DueAndOverdueReturnBannerScenario] =
     Ordering.by {
-      case Overdue    => 3
-      case Incomplete => 2
-      case Due        => 1
+      case Overdue    => 4
+      case Incomplete => 3
+      case Due        => 2
+      case Received   => 1
     }
 }

--- a/app/views/HomepageView.scala.html
+++ b/app/views/HomepageView.scala.html
@@ -67,6 +67,7 @@
   </p>
 
  @maybeUktrBannerScenario.map { scenario =>
+ @if(!maybeUktrBannerScenario.contains("Received")) {
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
   <h2 class="govuk-heading-m">@messages(s"homepage.uktrBanner$maybeAgentKey.$scenario.title")</h2>
   <p class="govuk-body">@messages(s"homepage.uktrBanner$maybeAgentKey.$scenario.body")</p>
@@ -79,6 +80,7 @@
   </p>
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
  }
+ }
 
  <div class="card-group">
       @if(maybeUktrBannerScenario.isDefined) {
@@ -86,11 +88,12 @@
         <div class="govuk-summary-card__title-wrapper card-with-tag">
           <h2 class="govuk-heading-m govuk-!-margin-0">@messages("homepage.returns.title")</h2>
           @maybeUktrBannerScenario.map { scenario =>
-              @if(scenario == "Overdue" || scenario == "Incomplete") {
+              @if(scenario == "Overdue" || scenario == "Incomplete" || scenario == "Received") {
                 <span class="govuk-tag @{
                   scenario match {
                     case "Overdue" => "govuk-tag--red"
                     case "Incomplete" => "govuk-tag--purple"
+                    case "Received" => "govuk-tag--green"
                   }
                 }" aria-label="@{scenario} returns" title="@{scenario} returns">@scenario</span>
               }

--- a/test/controllers/DashboardControllerSpec.scala
+++ b/test/controllers/DashboardControllerSpec.scala
@@ -19,10 +19,9 @@ package controllers
 import base.SpecBase
 import controllers.actions.TestAuthRetrievals.Ops
 import generators.ModelGenerators
-import models.UserAnswers
+import models._
 import models.obligationsandsubmissions.ObligationStatus
 import models.subscription._
-import models.{Due, Incomplete, Overdue}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import play.api.inject.bind
@@ -785,6 +784,236 @@ class DashboardControllerSpec extends SpecBase with ModelGenerators {
         val result = controller.getDueOrOverdueReturnsStatus(obligationsAndSubmissions)
 
         result mustBe Some(Overdue)
+      }
+    }
+
+    "return Received when UKTR and GIR obligations are both fulfilled and within 60 day period" in {
+      val application = applicationBuilder(userAnswers = None, enrolments).build()
+      running(application) {
+        val controller = application.injector.instanceOf[DashboardController]
+
+        val pastDueDate          = LocalDate.now().minusDays(7)
+        val recentSubmissionDate = java.time.ZonedDateTime.now().minusDays(30)
+        val obligations = Seq(
+          models.obligationsandsubmissions.Obligation(
+            obligationType = models.obligationsandsubmissions.ObligationType.UKTR,
+            status = ObligationStatus.Fulfilled,
+            canAmend = false,
+            submissions = Seq(
+              models.obligationsandsubmissions.Submission(
+                submissionType = models.obligationsandsubmissions.SubmissionType.UKTR_CREATE,
+                receivedDate = recentSubmissionDate,
+                country = None
+              )
+            )
+          ),
+          models.obligationsandsubmissions.Obligation(
+            obligationType = models.obligationsandsubmissions.ObligationType.GIR,
+            status = ObligationStatus.Fulfilled,
+            canAmend = false,
+            submissions = Seq(
+              models.obligationsandsubmissions.Submission(
+                submissionType = models.obligationsandsubmissions.SubmissionType.GIR,
+                receivedDate = recentSubmissionDate,
+                country = None
+              )
+            )
+          )
+        )
+        val accountingPeriod = models.obligationsandsubmissions.AccountingPeriodDetails(
+          startDate = LocalDate.now().minusMonths(12),
+          endDate = LocalDate.now(),
+          dueDate = pastDueDate,
+          underEnquiry = false,
+          obligations = obligations
+        )
+        val obligationsAndSubmissions = models.obligationsandsubmissions.ObligationsAndSubmissionsSuccess(
+          processingDate = java.time.ZonedDateTime.now(),
+          accountingPeriodDetails = Seq(accountingPeriod)
+        )
+
+        val result = controller.getDueOrOverdueReturnsStatus(obligationsAndSubmissions)
+
+        result mustBe Some(Received)
+      }
+    }
+
+    "return None when UKTR and GIR obligations are both fulfilled and outside 60 day period" in {
+      val application = applicationBuilder(userAnswers = None, enrolments).build()
+      running(application) {
+        val controller = application.injector.instanceOf[DashboardController]
+
+        val recentSubmissionDate = java.time.ZonedDateTime.now().minusDays(70)
+        val obligations = Seq(
+          models.obligationsandsubmissions.Obligation(
+            obligationType = models.obligationsandsubmissions.ObligationType.UKTR,
+            status = ObligationStatus.Fulfilled,
+            canAmend = false,
+            submissions = Seq(
+              models.obligationsandsubmissions.Submission(
+                submissionType = models.obligationsandsubmissions.SubmissionType.UKTR_CREATE,
+                receivedDate = recentSubmissionDate,
+                country = None
+              )
+            )
+          ),
+          models.obligationsandsubmissions.Obligation(
+            obligationType = models.obligationsandsubmissions.ObligationType.GIR,
+            status = ObligationStatus.Fulfilled,
+            canAmend = false,
+            submissions = Seq(
+              models.obligationsandsubmissions.Submission(
+                submissionType = models.obligationsandsubmissions.SubmissionType.GIR,
+                receivedDate = recentSubmissionDate,
+                country = None
+              )
+            )
+          )
+        )
+        val accountingPeriod = models.obligationsandsubmissions.AccountingPeriodDetails(
+          startDate = LocalDate.now().minusMonths(12),
+          endDate = LocalDate.now(),
+          dueDate = pastDueDate,
+          underEnquiry = false,
+          obligations = obligations
+        )
+        val obligationsAndSubmissions = models.obligationsandsubmissions.ObligationsAndSubmissionsSuccess(
+          processingDate = java.time.ZonedDateTime.now(),
+          accountingPeriodDetails = Seq(accountingPeriod)
+        )
+
+        val result = controller.getDueOrOverdueReturnsStatus(obligationsAndSubmissions)
+
+        result mustBe None
+      }
+    }
+
+    "return None when only UKTR is fulfilled and within 60 day period" in {
+      val application = applicationBuilder(userAnswers = None, enrolments).build()
+      running(application) {
+        val controller = application.injector.instanceOf[DashboardController]
+
+        val recentSubmissionDate = java.time.ZonedDateTime.now().minusDays(30)
+        val obligations = Seq(
+          models.obligationsandsubmissions.Obligation(
+            obligationType = models.obligationsandsubmissions.ObligationType.UKTR,
+            status = ObligationStatus.Fulfilled,
+            canAmend = false,
+            submissions = Seq(
+              models.obligationsandsubmissions.Submission(
+                submissionType = models.obligationsandsubmissions.SubmissionType.UKTR_CREATE,
+                receivedDate = recentSubmissionDate,
+                country = None
+              )
+            )
+          )
+        )
+        val accountingPeriod = models.obligationsandsubmissions.AccountingPeriodDetails(
+          startDate = LocalDate.now().minusMonths(12),
+          endDate = LocalDate.now(),
+          dueDate = pastDueDate,
+          underEnquiry = false,
+          obligations = obligations
+        )
+        val obligationsAndSubmissions = models.obligationsandsubmissions.ObligationsAndSubmissionsSuccess(
+          processingDate = java.time.ZonedDateTime.now(),
+          accountingPeriodDetails = Seq(accountingPeriod)
+        )
+
+        val result = controller.getDueOrOverdueReturnsStatus(obligationsAndSubmissions)
+
+        result mustBe None
+      }
+    }
+
+    "return None when only GIR is fulfilled and within 60 day period" in {
+      val application = applicationBuilder(userAnswers = None, enrolments).build()
+      running(application) {
+        val controller = application.injector.instanceOf[DashboardController]
+
+        val recentSubmissionDate = java.time.ZonedDateTime.now().minusDays(30)
+        val obligations = Seq(
+          models.obligationsandsubmissions.Obligation(
+            obligationType = models.obligationsandsubmissions.ObligationType.GIR,
+            status = ObligationStatus.Fulfilled,
+            canAmend = false,
+            submissions = Seq(
+              models.obligationsandsubmissions.Submission(
+                submissionType = models.obligationsandsubmissions.SubmissionType.GIR,
+                receivedDate = recentSubmissionDate,
+                country = None
+              )
+            )
+          )
+        )
+        val accountingPeriod = models.obligationsandsubmissions.AccountingPeriodDetails(
+          startDate = LocalDate.now().minusMonths(12),
+          endDate = LocalDate.now(),
+          dueDate = pastDueDate,
+          underEnquiry = false,
+          obligations = obligations
+        )
+        val obligationsAndSubmissions = models.obligationsandsubmissions.ObligationsAndSubmissionsSuccess(
+          processingDate = java.time.ZonedDateTime.now(),
+          accountingPeriodDetails = Seq(accountingPeriod)
+        )
+
+        val result = controller.getDueOrOverdueReturnsStatus(obligationsAndSubmissions)
+
+        result mustBe None
+      }
+    }
+
+    "return Received when multiple submissions exist and most recent for both obligations is within 60 days" in {
+      val application = applicationBuilder(userAnswers = None, enrolments).build()
+      running(application) {
+        val controller = application.injector.instanceOf[DashboardController]
+
+        val pastDueDate          = LocalDate.now().minusDays(7)
+        val oldSubmissionDate    = java.time.ZonedDateTime.now().minusDays(70)
+        val recentSubmissionDate = java.time.ZonedDateTime.now().minusDays(5)
+
+        val obligations = Seq(
+          models.obligationsandsubmissions.Obligation(
+            obligationType = models.obligationsandsubmissions.ObligationType.UKTR,
+            status = ObligationStatus.Fulfilled,
+            canAmend = false,
+            submissions = Seq(
+              models.obligationsandsubmissions.Submission(
+                submissionType = models.obligationsandsubmissions.SubmissionType.UKTR_CREATE,
+                receivedDate = oldSubmissionDate,
+                country = None
+              )
+            )
+          ),
+          models.obligationsandsubmissions.Obligation(
+            obligationType = models.obligationsandsubmissions.ObligationType.GIR,
+            status = ObligationStatus.Fulfilled,
+            canAmend = false,
+            submissions = Seq(
+              models.obligationsandsubmissions.Submission(
+                submissionType = models.obligationsandsubmissions.SubmissionType.GIR,
+                receivedDate = recentSubmissionDate,
+                country = None
+              )
+            )
+          )
+        )
+        val accountingPeriod = models.obligationsandsubmissions.AccountingPeriodDetails(
+          startDate = LocalDate.now().minusMonths(12),
+          endDate = LocalDate.now(),
+          dueDate = pastDueDate,
+          underEnquiry = false,
+          obligations = obligations
+        )
+        val obligationsAndSubmissions = models.obligationsandsubmissions.ObligationsAndSubmissionsSuccess(
+          processingDate = java.time.ZonedDateTime.now(),
+          accountingPeriodDetails = Seq(accountingPeriod)
+        )
+
+        val result = controller.getDueOrOverdueReturnsStatus(obligationsAndSubmissions)
+
+        result mustBe Some(Received)
       }
     }
   }

--- a/test/views/HomepageViewSpec.scala
+++ b/test/views/HomepageViewSpec.scala
@@ -238,7 +238,7 @@ class HomepageViewSpec extends ViewSpecBase {
         controllers.submissionhistory.routes.SubmissionHistoryController.onPageLoad.url
     }
 
-    "display UKTR Received status tag with red style when Received scenario is provided" in {
+    "display UKTR Received status tag with green style when Received scenario is provided" in {
       val organisationViewWithOverdueScenario: Document =
         Jsoup.parse(
           page(organisationName, date, None, Some("Received"), plrRef, isAgent = false)(request, appConfig, messages)

--- a/test/views/HomepageViewSpec.scala
+++ b/test/views/HomepageViewSpec.scala
@@ -237,6 +237,25 @@ class HomepageViewSpec extends ViewSpecBase {
       returnsCardLinks.get(1).attr("href") mustBe
         controllers.submissionhistory.routes.SubmissionHistoryController.onPageLoad.url
     }
+
+    "display UKTR Received status tag with red style when Received scenario is provided" in {
+      val organisationViewWithOverdueScenario: Document =
+        Jsoup.parse(
+          page(organisationName, date, None, Some("Received"), plrRef, isAgent = false)(request, appConfig, messages)
+            .toString()
+        )
+      val returnsCard: Element  = organisationViewWithOverdueScenario.getElementsByClass("card-half-width").first()
+      val statusTags:  Elements = returnsCard.getElementsByClass("govuk-tag--green")
+
+      returnsCard.getElementsByTag("h2").first().ownText() mustBe "Returns"
+
+      statusTags.size() mustBe 1
+
+      val receivedStatusTag: Element = statusTags.first()
+      receivedStatusTag.text() mustBe "Received"
+      receivedStatusTag.attr("aria-label") mustBe "Received returns"
+      receivedStatusTag.attr("title") mustBe "Received returns"
+    }
   }
 
   "HomepageView for an agent" should {


### PR DESCRIPTION
A new received flag that will show when both UKTR and GIR obligations have **both** been fulfilled. The flag should last 60 days from the most recent submission.

Key changes:

- Add logic to show received on the home page when both obligations have been fulfilled.
- Add unit tests to test the code
- Add logic in the view that will not show any text when received flag is shown
- Add unit tests for the homepage view