### PR TITLE
PIL-2373: RfmSecondaryContactName page max length discrepancy

### DIFF
--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1107,7 +1107,7 @@ rfm.secondaryContactName.heading = What is the name of the alternative person or
 rfm.secondaryContactName.checkYourAnswersLabel = Second contact name
 rfm.secondaryContactName.hint = For example, ‘Tax team’ or ‘Ashley Smith’.
 rfm.secondaryContactName.error.required = Enter name of the person or team we should contact
-rfm.secondaryContactName.error.length = Name of the contact person or team should be 105 characters or less
+rfm.secondaryContactName.error.length = Name of the contact person or team should be 160 characters or less
 rfm.secondaryContactName.error.invalid = The name of the contact person or team must only include letters a to z, numbers 0 to 9, ampersands (&), apostrophes, commas, forward slashes, full stops, hyphens, round brackets and spaces
 
 rfm.secondaryContactEmail.title = What is the email address?

--- a/test/views/rfm/RfmSecondaryContactNameViewSpec.scala
+++ b/test/views/rfm/RfmSecondaryContactNameViewSpec.scala
@@ -128,13 +128,13 @@ class RfmSecondaryContactNameViewSpec extends ViewSpecBase with StringGenerators
 
       errorsList
         .get(0)
-        .text() mustBe "Name of the contact person or team should be 105 characters or less"
+        .text() mustBe "Name of the contact person or team should be 160 characters or less"
     }
 
     "show field-specific errors" in {
       val fieldErrors: Elements = errorView.getElementsByClass("govuk-error-message")
 
-      fieldErrors.get(0).text() mustBe "Error: Name of the contact person or team should be 105 characters or less"
+      fieldErrors.get(0).text() mustBe "Error: Name of the contact person or team should be 160 characters or less"
     }
   }
 


### PR DESCRIPTION
Corrected RfmSecondaryContactName max length error message to state 160 characters is the max