### PR TITLE
PIL-2228: Update from microservice name to service name

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -160,7 +160,7 @@ enrolment {
 host = "http://localhost:10050"
 
 accessibility-statement {
-  service-path = "/pillar2-frontend"
+  service-path = "/pillar2"
 }
 
 tracking-consent-frontend {

--- a/test/config/FrontendAppConfigSpec.scala
+++ b/test/config/FrontendAppConfigSpec.scala
@@ -64,7 +64,7 @@ class FrontendAppConfigSpec extends SpecBase {
 
     ".accessibilityStatementPath" must {
       "return correct accessibility statement path" in {
-        config.accessibilityStatementPath mustBe "/accessibility-statement/pillar2-frontend"
+        config.accessibilityStatementPath mustBe "/accessibility-statement/pillar2"
       }
     }
 

--- a/test/connectors/IncorporatedEntityIdentificationFrontendConnectorSpec.scala
+++ b/test/connectors/IncorporatedEntityIdentificationFrontendConnectorSpec.scala
@@ -70,7 +70,7 @@ class IncorporatedEntityIdentificationFrontendConnectorSpec extends MockitoStubU
           optServiceName = Some(serviceName.en.optServiceName),
           deskProServiceId = "pillar2-frontend",
           signOutUrl = "http://localhost:9553/bas-gateway/sign-out-without-state",
-          accessibilityUrl = "/accessibility-statement/pillar2-frontend",
+          accessibilityUrl = "/accessibility-statement/pillar2",
           labels = serviceName
         )
 

--- a/test/connectors/IncorporatedEntityIdentificationFrontendConnectorSpec.scala
+++ b/test/connectors/IncorporatedEntityIdentificationFrontendConnectorSpec.scala
@@ -48,7 +48,7 @@ class IncorporatedEntityIdentificationFrontendConnectorSpec extends MockitoStubU
           optServiceName = Some(serviceName.en.optServiceName),
           deskProServiceId = "pillar2-frontend",
           signOutUrl = "http://localhost:9553/bas-gateway/sign-out-without-state",
-          accessibilityUrl = "/accessibility-statement/pillar2-frontend",
+          accessibilityUrl = "/accessibility-statement/pillar2",
           labels = serviceName
         )
 

--- a/test/connectors/PartnershipEntityIdentificationFrontendConnectorSpec.scala
+++ b/test/connectors/PartnershipEntityIdentificationFrontendConnectorSpec.scala
@@ -49,7 +49,7 @@ class PartnershipEntityIdentificationFrontendConnectorSpec extends MockitoStubUt
           optServiceName = Some(serviceName.en.optServiceName),
           deskProServiceId = "pillar2-frontend",
           signOutUrl = "http://localhost:9553/bas-gateway/sign-out-without-state",
-          accessibilityUrl = "/accessibility-statement/pillar2-frontend",
+          accessibilityUrl = "/accessibility-statement/pillar2",
           labels = serviceName
         )
 

--- a/test/connectors/PartnershipEntityIdentificationFrontendConnectorSpec.scala
+++ b/test/connectors/PartnershipEntityIdentificationFrontendConnectorSpec.scala
@@ -71,7 +71,7 @@ class PartnershipEntityIdentificationFrontendConnectorSpec extends MockitoStubUt
           optServiceName = Some(serviceName.en.optServiceName),
           deskProServiceId = "pillar2-frontend",
           signOutUrl = "http://localhost:9553/bas-gateway/sign-out-without-state",
-          accessibilityUrl = "/accessibility-statement/pillar2-frontend",
+          accessibilityUrl = "/accessibility-statement/pillar2",
           labels = serviceName
         )
 


### PR DESCRIPTION
Changes the path from `/pillar2-frontend` to `/pillar2`. The should be the only place that needs updating - https://catalogue.tax.service.gov.uk/service/pillar2-frontend/config#accessibility-statement.service-path