### PR TITLE
[PIL-2440] - add outstanding payments tag

### DIFF
--- a/app/controllers/DashboardController.scala
+++ b/app/controllers/DashboardController.scala
@@ -103,8 +103,8 @@ class DashboardController @Inject() (
       sessionRepository.get(request.userId).flatMap { maybeUserAnswers =>
         maybeUserAnswers.getOrElse(UserAnswers(request.userId))
         for {
-          obligationsResponse <- osService.handleData(plrReference, LocalDate.now().minusYears(7), LocalDate.now())
-          financialData       <- opService.retrieveData(plrReference, LocalDate.now(), LocalDate.now().minusYears(SUBMISSION_ACCOUNTING_PERIODS))
+          obligationsResponse <- osService.handleData(plrReference, LocalDate.now().minusYears(SUBMISSION_ACCOUNTING_PERIODS), LocalDate.now())
+          financialData       <- opService.retrieveData(plrReference, LocalDate.now().minusYears(SUBMISSION_ACCOUNTING_PERIODS), LocalDate.now())
         } yield Ok(
           homepageView(
             subscriptionData.upeDetails.organisationName,

--- a/app/controllers/DashboardController.scala
+++ b/app/controllers/DashboardController.scala
@@ -31,12 +31,12 @@ import play.api.Logging
 import play.api.i18n.I18nSupport
 import play.api.mvc._
 import repositories.SessionRepository
-import services.{ObligationsAndSubmissionsService, OutstandingPaymentsService, ReferenceNumberService, SubscriptionService}
+import services._
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.Constants.RECEIVED_PERIOD_IN_DAYS
-import views.html.{DashboardView, HomepageView}
 import utils.Constants.SUBMISSION_ACCOUNTING_PERIODS
+import views.html.{DashboardView, HomepageView}
 
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter

--- a/app/models/OutstandingPaymentBannerScenario.scala
+++ b/app/models/OutstandingPaymentBannerScenario.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+sealed trait OutstandingPaymentBannerScenario
+
+case object Outstanding extends OutstandingPaymentBannerScenario
+
+object OutstandingPaymentBannerScenario {
+  implicit val ordering: Ordering[OutstandingPaymentBannerScenario] =
+    Ordering.by { case Outstanding =>
+      1
+    }
+}

--- a/app/views/HomepageView.scala.html
+++ b/app/views/HomepageView.scala.html
@@ -25,7 +25,7 @@
 
 @this(layout: Layout, heading: heading, paragraphBody: paragraphBody, link: link, card: HomepageCard, govukNotificationBanner : GovukNotificationBanner)
 
-@(organisationName: String, registrationDate: String, btnActive: Boolean, maybeUktrBannerScenario: Option[String], plrReference: String, isAgent: Boolean)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(organisationName: String, registrationDate: String, btnActive: Boolean, maybeUktrBannerScenario: Option[String], maybePaymentBannerScenario: Option[String], plrReference: String, isAgent: Boolean)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @maybeAgentKey = @{if(isAgent) ".agent" else ""}
 
@@ -118,14 +118,47 @@
     )
    }
 
-   @card(
-    title = messages("homepage.payments.title"),
-    links = Seq(
-     (messages("homepage.payments.transactionHistory.linkText"), controllers.routes.TransactionHistoryController.onPageLoadTransactionHistory(None).url, None),
-     (messages("homepage.payments.outstandingPayments.linkText"), controllers.payments.routes.OutstandingPaymentsController.onPageLoad.url, None),
-     (messages("homepage.payments.repayments.linkText"), controllers.repayments.routes.RequestRepaymentBeforeStartController.onPageLoad.url, None),
-    )
-   )
+ @if(maybePaymentBannerScenario.isDefined) {
+     <div class="card-half-width">
+         <div class="govuk-summary-card__title-wrapper card-with-tag">
+             <h2 class="govuk-heading-m govuk-!-margin-0">@messages("homepage.payments.title")</h2>
+             @maybePaymentBannerScenario.map { scenario =>
+                 <span class="govuk-tag @{
+                     scenario match {
+                         case "Outstanding" => "govuk-tag--red"
+                     }
+                 }" aria-label="@{
+                     scenario
+                 } payments" title="@{
+                     scenario
+                 } payments">@scenario</span>
+             }
+         </div>
+         <div class="card-content">
+             <ul class="govuk-list">
+                 <li class="card-links">
+                     <a href="@controllers.routes.TransactionHistoryController.onPageLoadTransactionHistory(None).url" class="govuk-link">@messages("homepage.payments.transactionHistory.linkText")</a>
+                 </li>
+                 <li class="card-links">
+                     <a href="@controllers.payments.routes.OutstandingPaymentsController.onPageLoad.url" class="govuk-link">@messages("homepage.payments.outstandingPayments.linkText")</a>
+                 </li>
+                 <li class="card-links">
+                     <a href="@controllers.repayments.routes.RequestRepaymentBeforeStartController.onPageLoad.url" class="govuk-link">@messages("homepage.payments.repayments.linkText")</a>
+                 </li>
+             </ul>
+         </div>
+     </div>
+ } else {
+     @card(
+         title = messages("homepage.payments.title"),
+         links = Seq(
+             (messages("homepage.payments.transactionHistory.linkText"), controllers.routes.TransactionHistoryController.onPageLoadTransactionHistory(None).url, None),
+             (messages("homepage.payments.outstandingPayments.linkText"), controllers.payments.routes.OutstandingPaymentsController.onPageLoad.url, None),
+             (messages("homepage.payments.repayments.linkText"), controllers.repayments.routes.RequestRepaymentBeforeStartController.onPageLoad.url, None),
+         )
+     )
+ }
+
 
    @{
     val registrationContent = Html(

--- a/test/controllers/DashboardControllerSpec.scala
+++ b/test/controllers/DashboardControllerSpec.scala
@@ -17,8 +17,11 @@
 package controllers
 
 import base.SpecBase
+import connectors.FinancialDataConnector
 import controllers.actions.TestAuthRetrievals.Ops
+import controllers.payments.OutstandingPaymentsControllerSpec.samplePaymentsDataWithNoTag
 import generators.ModelGenerators
+import helpers.FinancialDataHelper.Pillar2UktrName
 import models._
 import models.obligationsandsubmissions.ObligationStatus
 import models.subscription._
@@ -28,7 +31,7 @@ import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import repositories.SessionRepository
-import services.{ObligationsAndSubmissionsService, SubscriptionService}
+import services.{ObligationsAndSubmissionsService, OutstandingPaymentsService, SubscriptionService}
 import uk.gov.hmrc.auth.core.AffinityGroup.Agent
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.{Credentials, ~}
@@ -77,7 +80,9 @@ class DashboardControllerSpec extends SpecBase with ModelGenerators {
             .overrides(
               bind[SessionRepository].toInstance(mockSessionRepository),
               bind[SubscriptionService].toInstance(mockSubscriptionService),
-              bind[ObligationsAndSubmissionsService].toInstance(mockObligationsAndSubmissionsService)
+              bind[ObligationsAndSubmissionsService].toInstance(mockObligationsAndSubmissionsService),
+              bind[OutstandingPaymentsService].toInstance(mockOutstandingPaymentsService),
+              bind[FinancialDataConnector].toInstance(mockFinancialDataConnector)
             )
             .build()
 
@@ -91,6 +96,8 @@ class DashboardControllerSpec extends SpecBase with ModelGenerators {
           when(mockSubscriptionService.cacheSubscription(any())(any())).thenReturn(Future.successful(subscriptionData))
           when(mockObligationsAndSubmissionsService.handleData(any(), any(), any())(any[HeaderCarrier]))
             .thenReturn(Future.successful(obligationsAndSubmissionsSuccessResponse(ObligationStatus.Fulfilled)))
+          when(mockOutstandingPaymentsService.retrieveData(any(), any(), any())(any[HeaderCarrier]))
+            .thenReturn(Future.successful(samplePaymentsDataWithNoTag))
 
           val result = route(application, request).value
           val view   = application.injector.instanceOf[HomepageView]
@@ -100,6 +107,7 @@ class DashboardControllerSpec extends SpecBase with ModelGenerators {
             subscriptionData.upeDetails.organisationName,
             subscriptionData.upeDetails.registrationDate.format(DateTimeFormatter.ofPattern("d MMMM yyyy")),
             btnActive = false,
+            None,
             None,
             "12345678",
             isAgent = false
@@ -1014,6 +1022,58 @@ class DashboardControllerSpec extends SpecBase with ModelGenerators {
         val result = controller.getDueOrOverdueReturnsStatus(obligationsAndSubmissions)
 
         result mustBe Some(Received)
+      }
+    }
+
+  }
+
+  "getOutstandingPaymentsStatus" should {
+
+    "return Outstanding when there is an outstanding payment that has exceeded the due date to be made" in {
+      val application = applicationBuilder(userAnswers = None, enrolments).build()
+      running(application) {
+        val controller = application.injector.instanceOf[DashboardController]
+
+        val pastDueDate = LocalDate.now.minusDays(7)
+        val transactions = Seq(
+          TransactionSummary(
+            name = Pillar2UktrName,
+            outstandingAmount = 100,
+            dueDate = pastDueDate
+          )
+        )
+        val financialSummary = FinancialSummary(
+          accountingPeriod = AccountingPeriod(LocalDate.now.minusMonths(12), LocalDate.now),
+          transactions = transactions
+        )
+
+        val result = controller.getOutstandingPaymentsStatus(Seq(financialSummary))
+
+        result mustBe Some(Outstanding)
+      }
+    }
+
+    "return None when there is an outstanding payment that has not exceeded the due date to be made" in {
+      val application = applicationBuilder(userAnswers = None, enrolments).build()
+      running(application) {
+        val controller = application.injector.instanceOf[DashboardController]
+
+        val futureDueDate = LocalDate.now.plusDays(7)
+        val transactions = Seq(
+          TransactionSummary(
+            name = Pillar2UktrName,
+            outstandingAmount = 100,
+            dueDate = futureDueDate
+          )
+        )
+        val financialSummary = FinancialSummary(
+          accountingPeriod = AccountingPeriod(LocalDate.now.minusMonths(12), LocalDate.now),
+          transactions = transactions
+        )
+
+        val result = controller.getOutstandingPaymentsStatus(Seq(financialSummary))
+
+        result mustBe None
       }
     }
   }

--- a/test/controllers/DashboardControllerSpec.scala
+++ b/test/controllers/DashboardControllerSpec.scala
@@ -1047,7 +1047,7 @@ class DashboardControllerSpec extends SpecBase with ModelGenerators {
           transactions = transactions
         )
 
-        val result = controller.getOutstandingPaymentsStatus(Seq(financialSummary))
+        val result = controller.getOutstandingPaymentsStatus(Some(Seq(financialSummary)))
 
         result mustBe Some(Outstanding)
       }
@@ -1071,7 +1071,7 @@ class DashboardControllerSpec extends SpecBase with ModelGenerators {
           transactions = transactions
         )
 
-        val result = controller.getOutstandingPaymentsStatus(Seq(financialSummary))
+        val result = controller.getOutstandingPaymentsStatus(Some(Seq(financialSummary)))
 
         result mustBe None
       }

--- a/test/controllers/payments/OutstandingPaymentsControllerSpec.scala
+++ b/test/controllers/payments/OutstandingPaymentsControllerSpec.scala
@@ -134,5 +134,12 @@ object OutstandingPaymentsControllerSpec {
     )
   )
 
+  val samplePaymentsDataWithNoTag: Seq[FinancialSummary] = Seq(
+    FinancialSummary(
+      AccountingPeriod(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31)),
+      Seq(TransactionSummary(Pillar2UktrName, BigDecimal(0), LocalDate.now.plusDays(7)))
+    )
+  )
+
   val amountDue: BigDecimal = samplePaymentsData.flatMap(_.transactions.map(_.outstandingAmount)).sum.max(0)
 }

--- a/test/views/HomepageViewSpec.scala
+++ b/test/views/HomepageViewSpec.scala
@@ -35,12 +35,12 @@ class HomepageViewSpec extends ViewSpecBase {
 
   lazy val organisationView: Document =
     Jsoup.parse(
-      page(organisationName, date, btnActive = false, None, plrRef, isAgent = false)(request, appConfig, messages).toString()
+      page(organisationName, date, btnActive = false, None, None, plrRef, isAgent = false)(request, appConfig, messages).toString()
     )
 
   lazy val agentView: Document =
     Jsoup.parse(
-      page(organisationName, date, btnActive = false, None, plrRef, isAgent = true)(request, appConfig, messages).toString()
+      page(organisationName, date, btnActive = false, None, None, plrRef, isAgent = true)(request, appConfig, messages).toString()
     )
 
   "HomepageView for a group" should {
@@ -141,7 +141,7 @@ class HomepageViewSpec extends ViewSpecBase {
     "display notification banner" in {
       val accountInactiveOrgView: Document =
         Jsoup.parse(
-          page(organisationName, date, btnActive = true, None, plrRef, isAgent = false)(request, appConfig, messages).toString()
+          page(organisationName, date, btnActive = true, None, None, plrRef, isAgent = false)(request, appConfig, messages).toString()
         )
 
       val bannerContent: Element = accountInactiveOrgView.getElementsByClass("govuk-notification-banner").first()
@@ -157,7 +157,7 @@ class HomepageViewSpec extends ViewSpecBase {
     "show clean Returns card with no tag when Due scenario is provided" in {
       val organisationViewWithDueScenario: Document =
         Jsoup.parse(
-          page(organisationName, date, btnActive = false, Some("Due"), plrRef, isAgent = false)(request, appConfig, messages)
+          page(organisationName, date, btnActive = false, Some("Due"), None, plrRef, isAgent = false)(request, appConfig, messages)
             .toString()
         )
       val returnsCard:      Element  = organisationViewWithDueScenario.getElementsByClass("card-half-width").first()
@@ -180,7 +180,7 @@ class HomepageViewSpec extends ViewSpecBase {
     "display UKTR Overdue status tag with red style when Overdue scenario is provided" in {
       val organisationViewWithOverdueScenario: Document =
         Jsoup.parse(
-          page(organisationName, date, btnActive = false, Some("Overdue"), plrRef, isAgent = false)(request, appConfig, messages)
+          page(organisationName, date, btnActive = false, Some("Overdue"), None, plrRef, isAgent = false)(request, appConfig, messages)
             .toString()
         )
       val returnsCard:      Element  = organisationViewWithOverdueScenario.getElementsByClass("card-half-width").first()
@@ -208,7 +208,7 @@ class HomepageViewSpec extends ViewSpecBase {
     "display UKTR Incomplete status tag with purple style when Incomplete scenario is provided" in {
       val organisationViewWithIncompleteScenario: Document =
         Jsoup.parse(
-          page(organisationName, date, btnActive = false, Some("Incomplete"), plrRef, isAgent = false)(request, appConfig, messages)
+          page(organisationName, date, btnActive = false, Some("Incomplete"), None, plrRef, isAgent = false)(request, appConfig, messages)
             .toString()
         )
       val returnsCard:      Element  = organisationViewWithIncompleteScenario.getElementsByClass("card-half-width").first()
@@ -236,7 +236,7 @@ class HomepageViewSpec extends ViewSpecBase {
     "display UKTR Received status tag with green style when Received scenario is provided" in {
       val organisationViewWithOverdueScenario: Document =
         Jsoup.parse(
-          page(organisationName, date, btnActive = false, Some("Received"), plrRef, isAgent = false)(request, appConfig, messages)
+          page(organisationName, date, btnActive = false, Some("Received"), None, plrRef, isAgent = false)(request, appConfig, messages)
             .toString()
         )
       val returnsCard: Element  = organisationViewWithOverdueScenario.getElementsByClass("card-half-width").first()
@@ -250,6 +250,50 @@ class HomepageViewSpec extends ViewSpecBase {
       receivedStatusTag.text() mustBe "Received"
       receivedStatusTag.attr("aria-label") mustBe "Received returns"
       receivedStatusTag.attr("title") mustBe "Received returns"
+    }
+
+    "show clean Payments card with no tag when no scenario is provided" in {
+      val organisationViewWithOutstandingScenario: Document =
+        Jsoup.parse(
+          page(organisationName, date, btnActive = false, None, None, plrRef, isAgent = false)(request, appConfig, messages)
+            .toString()
+        )
+      val returnsCard:       Element  = organisationViewWithOutstandingScenario.getElementsByClass("card-half-width").get(1)
+      val paymentsCardLinks: Elements = returnsCard.getElementsByTag("a")
+
+      val statusTags: Elements = returnsCard.getElementsByClass("govuk-tag")
+      statusTags.size() mustBe 0
+
+      returnsCard.getElementsByTag("h2").first().ownText() mustBe "Payments"
+
+      paymentsCardLinks.get(0).text() mustBe "View transaction history"
+      paymentsCardLinks.get(0).attr("href") mustBe
+        controllers.routes.TransactionHistoryController.onPageLoadTransactionHistory(None).url
+
+      paymentsCardLinks.get(1).text() mustBe "View outstanding payments"
+      paymentsCardLinks.get(1).attr("href") mustBe
+        controllers.payments.routes.OutstandingPaymentsController.onPageLoad.url
+
+      paymentsCardLinks.get(2).text() mustBe "Request a repayment"
+      paymentsCardLinks.get(2).attr("href") mustBe
+        controllers.repayments.routes.RequestRepaymentBeforeStartController.onPageLoad.url
+    }
+
+    "display Payments Outstanding tag with red style when Outstanding scenario is provided" in {
+      val organisationViewWithOutstandingScenario: Document =
+        Jsoup.parse(
+          page(organisationName, date, btnActive = false, None, Some("Outstanding"), plrRef, isAgent = false)(request, appConfig, messages)
+            .toString()
+        )
+      val returnsCard: Element  = organisationViewWithOutstandingScenario.getElementsByClass("card-half-width").get(1)
+      val statusTags:  Elements = returnsCard.getElementsByClass("govuk-tag--red")
+
+      returnsCard.getElementsByTag("h2").first().ownText() mustBe "Payments"
+
+      val outstandingTag: Element = statusTags.first()
+      outstandingTag.text() mustBe "Outstanding"
+      outstandingTag.attr("aria-label") mustBe "Outstanding payments"
+      outstandingTag.attr("title") mustBe "Outstanding payments"
     }
   }
 
@@ -348,7 +392,7 @@ class HomepageViewSpec extends ViewSpecBase {
     "display notification banner" in {
       val accountInactiveAgentView: Document =
         Jsoup.parse(
-          page(organisationName, date, btnActive = true, None, plrRef, isAgent = true)(request, appConfig, messages).toString()
+          page(organisationName, date, btnActive = true, None, None, plrRef, isAgent = true)(request, appConfig, messages).toString()
         )
 
       val bannerContent = accountInactiveAgentView.getElementsByClass("govuk-notification-banner").first()


### PR DESCRIPTION
New business requirements mean we will have to display an outstanding flag on the Payments home page card when the pillar id has a payment to be made and it has also gone past the due date.

Key Changes:
- Add method to determine outstanding logic
- Add class to deal with ordering for future flags
- Add unit tests for the Dashboard Controller
- Use for comprehension to get financial data on the home page
- Modify UI and add tag when necessary using same styling as returns card
- Unit tests for the UI on the home page