### PR TITLE
PIL-2452 Add 'accruing interest' notification on outstanding payment

### DIFF
--- a/app/controllers/DashboardController.scala
+++ b/app/controllers/DashboardController.scala
@@ -20,6 +20,7 @@ import cats.data.OptionT
 import config.FrontendAppConfig
 import connectors.UserAnswersConnectors
 import controllers.actions.{DataRetrievalAction, IdentifierAction}
+import models.DueAndOverdueReturnBannerScenario._
 import models._
 import models.obligationsandsubmissions.ObligationType.{GIR, UKTR}
 import models.obligationsandsubmissions.SubmissionType.UKTR_CREATE

--- a/app/controllers/DashboardController.scala
+++ b/app/controllers/DashboardController.scala
@@ -115,8 +115,8 @@ class DashboardController @Inject() (
               subscriptionData.upeDetails.organisationName,
               subscriptionData.upeDetails.registrationDate.format(DateTimeFormatter.ofPattern("d MMMM yyyy")),
               subscriptionData.accountStatus.exists(_.inactive),
-              getDueOrOverdueReturnsStatus(obligationsResponse).map(_.toString),
-              getOutstandingPaymentsStatus(financialData).map(_.toString),
+              getDueOrOverdueReturnsStatus(obligationsResponse),
+              getOutstandingPaymentsStatus(financialData),
               plrReference,
               isAgent = request.isAgent,
               hasReturnsUnderEnquiry = hasReturnsUnderEnquiry

--- a/app/controllers/DashboardController.scala
+++ b/app/controllers/DashboardController.scala
@@ -201,20 +201,10 @@ class DashboardController @Inject() (
 
   def getOutstandingPaymentsStatus(financialSummaries: Option[Seq[FinancialSummary]]): Option[OutstandingPaymentBannerScenario] = {
 
-    def summaryStatus(summary: FinancialSummary): Option[OutstandingPaymentBannerScenario] = {
-      val transactions = summary.transactions
-
-      if (transactions.isEmpty) {
-        None
-      } else {
-        val hasOutstandingPayment = transactions.exists(t => t.outstandingAmount > 0 && t.dueDate.isBefore(LocalDate.now))
-
-        hasOutstandingPayment match {
-          case true => Some(Outstanding)
-          case _    => None
-        }
-      }
-    }
+    def summaryStatus(summary: FinancialSummary): Option[OutstandingPaymentBannerScenario] =
+      summary.transactions
+        .find(t => t.outstandingAmount > 0 && t.dueDate.isBefore(LocalDate.now))
+        .map(transaction => Outstanding(amountOutstanding = transaction.outstandingAmount))
 
     financialSummaries
       .getOrElse(Seq.empty)

--- a/app/models/DueAndOverdueReturnBannerScenario.scala
+++ b/app/models/DueAndOverdueReturnBannerScenario.scala
@@ -16,14 +16,17 @@
 
 package models
 
-sealed trait DueAndOverdueReturnBannerScenario
+import enumeratum.{Enum, EnumEntry}
 
-case object Due extends DueAndOverdueReturnBannerScenario
-case object Overdue extends DueAndOverdueReturnBannerScenario
-case object Incomplete extends DueAndOverdueReturnBannerScenario
-case object Received extends DueAndOverdueReturnBannerScenario
+sealed trait DueAndOverdueReturnBannerScenario extends EnumEntry
 
-object DueAndOverdueReturnBannerScenario {
+object DueAndOverdueReturnBannerScenario extends Enum[DueAndOverdueReturnBannerScenario] {
+
+  case object Due extends DueAndOverdueReturnBannerScenario
+  case object Overdue extends DueAndOverdueReturnBannerScenario
+  case object Incomplete extends DueAndOverdueReturnBannerScenario
+  case object Received extends DueAndOverdueReturnBannerScenario
+
   implicit val ordering: Ordering[DueAndOverdueReturnBannerScenario] =
     Ordering.by {
       case Overdue    => 4
@@ -31,4 +34,6 @@ object DueAndOverdueReturnBannerScenario {
       case Due        => 2
       case Received   => 1
     }
+
+  val values = findValues
 }

--- a/app/models/OutstandingPaymentBannerScenario.scala
+++ b/app/models/OutstandingPaymentBannerScenario.scala
@@ -18,11 +18,11 @@ package models
 
 sealed trait OutstandingPaymentBannerScenario
 
-case object Outstanding extends OutstandingPaymentBannerScenario
+case class Outstanding(amountOutstanding: BigDecimal) extends OutstandingPaymentBannerScenario
 
 object OutstandingPaymentBannerScenario {
   implicit val ordering: Ordering[OutstandingPaymentBannerScenario] =
-    Ordering.by { case Outstanding =>
+    Ordering.by { case Outstanding(_) =>
       1
     }
 }

--- a/app/views/DynamicNotificationArea.scala.html
+++ b/app/views/DynamicNotificationArea.scala.html
@@ -71,14 +71,14 @@
       }
     ){ scenarioKey => @insideSectionBreaks {
         <h2 class="govuk-heading-m" id="return-expected-notification-subheading">
-            @messages(s"homepage.uktrBanner$maybeAgentKey.$scenarioKey.title")
+            @messages(s"homepage.dna.returnExpected$maybeAgentKey.$scenarioKey.title")
         </h2>
         <p class="govuk-body" id="return-expected-notification-body">
-            @messages(s"homepage.uktrBanner$maybeAgentKey.$scenarioKey.body")
+            @messages(s"homepage.dna.returnExpected$maybeAgentKey.$scenarioKey.body")
         </p>
         <p class="govuk-body">
             @link(
-                text = messages("homepage.uktrBanner.linkText"),
+                text = messages("homepage.dna.returnExpected.linkText"),
                 call = Call("GET", dueAndOverdueReturnsUrl),
                 id = Some("return-expected-notification-submission-link")
             )

--- a/app/views/DynamicNotificationArea.scala.html
+++ b/app/views/DynamicNotificationArea.scala.html
@@ -14,7 +14,7 @@
  * limitations under the License.
  *@
 
-@import models.DueAndOverdueReturnBannerScenario.Received
+@import models.DueAndOverdueReturnBannerScenario.{Overdue, Received}
 @import views.html.components.gds._
 
 @this(
@@ -33,20 +33,56 @@
     controllers.dueandoverduereturns.routes.DueAndOverdueReturnsController.onPageLoad.url
 }
 
-@maybeUktrBannerScenario.map { scenario =>
-    @if(!maybeUktrBannerScenario.contains(Received)) {
-        @defining(scenario.toString) { scenario =>
-            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" id="notifications-break-begin">
-            <h2 class="govuk-heading-m" id="notifications-subheading">@messages(s"homepage.uktrBanner$maybeAgentKey.$scenario.title")</h2>
-            <p class="govuk-body" id="notifications-body">@messages(s"homepage.uktrBanner$maybeAgentKey.$scenario.body")</p>
-            <p class="govuk-body">
+@viewOutstandingPaymentsUrl = @{
+    controllers.payments.routes.OutstandingPaymentsController.onPageLoad.url
+}
+
+@insideSectionBreaks(content: Html) = {
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" id="notifications-break-begin">
+    @content
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" id="notifications-break-end">
+}
+
+@(maybeUktrBannerScenario, maybePaymentBannerScenario) match {
+  case (None | Some(Received), _) => {}
+  case (Some(Overdue), Some(Outstanding(amountOutstanding))) => {
+      @insideSectionBreaks {
+          <h2 class="govuk-heading-m" id="accruing-interest-notification-subheading">
+              @messages(s"homepage.dna.accruingInterest$maybeAgentKey.title", formatAmount(amountOutstanding))
+          </h2>
+          <p class="govuk-body" id="accruing-interest-notification-body">
+              @messages(s"homepage.dna.accruingInterest$maybeAgentKey.body")
+          </p>
+          <p class="govuk-body">
+          @link(
+              text = messages("homepage.dna.accruingInterest.outstandingPayments.linkText"),
+              call = Call("GET", viewOutstandingPaymentsUrl),
+              id = Some("accruing-interest-notification-outstanding-payments-link")
+          )
+          </p>
+      }
+  }
+  case (Some(scenario), _) => {
+    @defining(
+      scenario match {
+          case DueAndOverdueReturnBannerScenario.Due => "Due"
+          case DueAndOverdueReturnBannerScenario.Overdue => "Overdue"
+          case DueAndOverdueReturnBannerScenario.Incomplete => "Incomplete"
+      }
+    ){ scenarioKey => @insideSectionBreaks {
+        <h2 class="govuk-heading-m" id="return-expected-notification-subheading">
+            @messages(s"homepage.uktrBanner$maybeAgentKey.$scenarioKey.title")
+        </h2>
+        <p class="govuk-body" id="return-expected-notification-body">
+            @messages(s"homepage.uktrBanner$maybeAgentKey.$scenarioKey.body")
+        </p>
+        <p class="govuk-body">
             @link(
                 text = messages("homepage.uktrBanner.linkText"),
                 call = Call("GET", dueAndOverdueReturnsUrl),
-                id = Some("submission-link")
+                id = Some("return-expected-notification-submission-link")
             )
-            </p>
-            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" id="notifications-break-end">
-        }
-    }
+        </p>
+    }}
+  }
 }

--- a/app/views/DynamicNotificationArea.scala.html
+++ b/app/views/DynamicNotificationArea.scala.html
@@ -14,6 +14,7 @@
  * limitations under the License.
  *@
 
+@import models.DueAndOverdueReturnBannerScenario.Received
 @import views.html.components.gds._
 
 @this(

--- a/app/views/DynamicNotificationArea.scala.html
+++ b/app/views/DynamicNotificationArea.scala.html
@@ -1,0 +1,50 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import views.html.components.gds._
+
+@this(
+    link: link,
+)
+
+@(
+    maybeUktrBannerScenario: Option[DueAndOverdueReturnBannerScenario],
+    isAgent: Boolean
+)(implicit messages: Messages)
+
+@maybeAgentKey = @{if(isAgent) ".agent" else ""}
+
+@dueAndOverdueReturnsUrl = @{
+    controllers.dueandoverduereturns.routes.DueAndOverdueReturnsController.onPageLoad.url
+}
+
+@maybeUktrBannerScenario.map { scenario =>
+    @if(!maybeUktrBannerScenario.contains(Received)) {
+        @defining(scenario.toString) { scenario =>
+            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" id="notifications-break-begin">
+            <h2 class="govuk-heading-m" id="notifications-subheading">@messages(s"homepage.uktrBanner$maybeAgentKey.$scenario.title")</h2>
+            <p class="govuk-body" id="notifications-body">@messages(s"homepage.uktrBanner$maybeAgentKey.$scenario.body")</p>
+            <p class="govuk-body">
+            @link(
+                text = messages("homepage.uktrBanner.linkText"),
+                call = Call("GET", dueAndOverdueReturnsUrl),
+                id = Some("submission-link")
+            )
+            </p>
+            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" id="notifications-break-end">
+        }
+    }
+}

--- a/app/views/DynamicNotificationArea.scala.html
+++ b/app/views/DynamicNotificationArea.scala.html
@@ -44,8 +44,7 @@
 }
 
 @(maybeUktrBannerScenario, maybePaymentBannerScenario) match {
-  case (None | Some(Received), _) => {}
-  case (Some(Overdue), Some(Outstanding(amountOutstanding))) => {
+  case (_, Some(Outstanding(amountOutstanding))) => {
       @insideSectionBreaks {
           <h2 class="govuk-heading-m" id="accruing-interest-notification-subheading">
               @messages(s"homepage.dna.accruingInterest$maybeAgentKey.title", formatAmount(amountOutstanding))
@@ -62,6 +61,7 @@
           </p>
       }
   }
+  case (None | Some(Received), _) => {}
   case (Some(scenario), _) => {
     @defining(
       scenario match {

--- a/app/views/DynamicNotificationArea.scala.html
+++ b/app/views/DynamicNotificationArea.scala.html
@@ -23,6 +23,7 @@
 
 @(
     maybeUktrBannerScenario: Option[DueAndOverdueReturnBannerScenario],
+    maybePaymentBannerScenario: Option[OutstandingPaymentBannerScenario],
     isAgent: Boolean
 )(implicit messages: Messages)
 

--- a/app/views/HomepageView.scala.html
+++ b/app/views/HomepageView.scala.html
@@ -15,13 +15,12 @@
  *@
 
 @import config.FrontendAppConfig
+@import models.DueAndOverdueReturnBannerScenario._
 @import uk.gov.hmrc.govukfrontend.views.html.components._
-@import views.html.components.gds._
-@import views.html.templates.Layout
 
-@import java.time.LocalDate
-@import java.time.format.DateTimeFormatter
+@import views.html.components.gds._
 @import views.html.DynamicNotificationArea
+@import views.html.templates.Layout
 
 @this(
     layout: Layout,

--- a/app/views/HomepageView.scala.html
+++ b/app/views/HomepageView.scala.html
@@ -25,7 +25,16 @@
 
 @this(layout: Layout, heading: heading, paragraphBody: paragraphBody, link: link, card: HomepageCard, govukNotificationBanner : GovukNotificationBanner)
 
-@(organisationName: String, registrationDate: String, btnActive: Boolean, maybeUktrBannerScenario: Option[String], maybePaymentBannerScenario: Option[String], plrReference: String, isAgent: Boolean, hasReturnsUnderEnquiry: Boolean)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(
+    organisationName: String,
+    registrationDate: String,
+    btnActive: Boolean,
+    maybeUktrBannerScenario: Option[DueAndOverdueReturnBannerScenario],
+    maybePaymentBannerScenario: Option[OutstandingPaymentBannerScenario],
+    plrReference: String,
+    isAgent: Boolean,
+    hasReturnsUnderEnquiry: Boolean
+)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @maybeAgentKey = @{if(isAgent) ".agent" else ""}
 
@@ -66,98 +75,109 @@
    <span><strong>@{messages("homepage.id")}:</strong> @plrReference</span>
   </p>
 
- @maybeUktrBannerScenario.map { scenario =>
-  @if(!maybeUktrBannerScenario.contains("Received")) {
-   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-   <h2 class="govuk-heading-m">@messages(s"homepage.uktrBanner$maybeAgentKey.$scenario.title")</h2>
-   <p class="govuk-body">@messages(s"homepage.uktrBanner$maybeAgentKey.$scenario.body")</p>
-   <p class="govuk-body">
-     @link(
-       text = messages("homepage.uktrBanner.linkText"),
-       call = Call("GET", dueAndOverdueReturnsUrl),
-       id = Some("submission-link")
-     )
-   </p>
-   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-  }
- }
+@maybeUktrBannerScenario.map { scenario =>
+    @if(!maybeUktrBannerScenario.contains(Received)) {
+        @defining(scenario.toString) { scenario =>
+            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+            <h2 class="govuk-heading-m">@messages(s"homepage.uktrBanner$maybeAgentKey.$scenario.title")</h2>
+            <p class="govuk-body">@messages(s"homepage.uktrBanner$maybeAgentKey.$scenario.body")</p>
+            <p class="govuk-body">
+              @link(
+                text = messages("homepage.uktrBanner.linkText"),
+                call = Call("GET", dueAndOverdueReturnsUrl),
+                id = Some("submission-link")
+              )
+            </p>
+            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+        }
+    }
+}
 
  <div class="card-group">
-      @if(maybeUktrBannerScenario.isDefined) {
-    <div class="card-half-width">
-        <div class="govuk-summary-card__title-wrapper card-with-tag">
-          <h2 class="govuk-heading-m govuk-!-margin-0">@messages("homepage.returns.title")</h2>
-            @maybeUktrBannerScenario.filter(Set("Overdue", "Incomplete", "Received").contains).map { scenario =>
-                <span class="govuk-tag @{
-                    scenario match {
-                        case "Overdue" => "govuk-tag--red"
-                        case "Incomplete" => "govuk-tag--purple"
-                        case "Received" => "govuk-tag--green"
+    @maybeUktrBannerScenario match {
+        case Some(returnScenario) => {
+            <div class="card-half-width">
+                <div class="govuk-summary-card__title-wrapper card-with-tag">
+                    <h2 class="govuk-heading-m govuk-!-margin-0">@messages("homepage.returns.title")</h2>
+                    @returnScenario match {
+                        case scenario @ (Overdue | Incomplete | Received) => {@defining(scenario.toString) { scenarioString =>
+                            <span class="govuk-tag @{
+                                scenario match {
+                                    case Overdue => "govuk-tag--red"
+                                    case Incomplete => "govuk-tag--purple"
+                                    case Received => "govuk-tag--green"
+                                }
+                            }" aria-label="@{scenarioString} returns" title="@{scenarioString} returns">@scenarioString</span>
+                        }}
+                        case Due => {}
                     }
-                }" aria-label="@{scenario} returns" title="@{scenario} returns">@scenario</span>
+                </div>
+                <div class="card-content">
+                    @if(hasReturnsUnderEnquiry) {
+                        <p class="govuk-body govuk-!-margin-bottom-4">
+                        @messages(s"homepage.returns.underEnquiry$maybeAgentKey.message")
+                        </p>
+                    }
+                    <ul class="govuk-list">
+                        <li class="card-links">
+                            <a href="@dueAndOverdueReturnsUrl" class="govuk-link">@messages("homepage.returns.dueOverdueReturns.linkText")</a>
+                        </li>
+                        <li class="card-links">
+                            <a href="@submissionHistoryUrl" class="govuk-link">@messages("homepage.returns.submissionHistory.linkText")</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        }
+        case None => {
+            @if(hasReturnsUnderEnquiry) {
+                <div class="card-half-width">
+                    <div class="govuk-summary-card__title-wrapper">
+                        <h2 class="govuk-heading-m govuk-!-margin-0">@messages("homepage.returns.title")</h2>
+                    </div>
+                    <div class="card-content">
+                        <p class="govuk-body govuk-!-margin-bottom-4">
+                        @messages(s"homepage.returns.underEnquiry$maybeAgentKey.message")
+                        </p>
+                        <ul class="govuk-list">
+                            <li class="card-links">
+                                <a href="@dueAndOverdueReturnsUrl" class="govuk-link">@messages("homepage.returns.dueOverdueReturns.linkText")</a>
+                            </li>
+                            <li class="card-links">
+                                <a href="@submissionHistoryUrl" class="govuk-link">@messages("homepage.returns.submissionHistory.linkText")</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            } else {
+                @card(
+                    title = messages("homepage.returns.title"),
+                    links = Seq(
+                        (messages("homepage.returns.dueOverdueReturns.linkText"), dueAndOverdueReturnsUrl, None),
+                        (messages("homepage.returns.submissionHistory.linkText"), submissionHistoryUrl, None),
+                    )
+                )
             }
-        </div>
-      <div class="card-content">
-              @if(hasReturnsUnderEnquiry) {
-               <p class="govuk-body govuk-!-margin-bottom-4">
-                @messages(s"homepage.returns.underEnquiry$maybeAgentKey.message")
-               </p>
-              }
-       <ul class="govuk-list">
-        <li class="card-links">
-         <a href="@dueAndOverdueReturnsUrl" class="govuk-link">@messages("homepage.returns.dueOverdueReturns.linkText")</a>
-        </li>
-        <li class="card-links">
-         <a href="@submissionHistoryUrl" class="govuk-link">@messages("homepage.returns.submissionHistory.linkText")</a>
-        </li>
-       </ul>
-      </div>
-     </div>
-   } else {
-    @if(hasReturnsUnderEnquiry) {
-     <div class="card-half-width">
-        <div class="govuk-summary-card__title-wrapper">
-          <h2 class="govuk-heading-m govuk-!-margin-0">@messages("homepage.returns.title")</h2>
-        </div>
-               <div class="card-content">
-                <p class="govuk-body govuk-!-margin-bottom-4">
-                 @messages(s"homepage.returns.underEnquiry$maybeAgentKey.message")
-                </p>
-         <ul class="govuk-list">
-          <li class="card-links">
-           <a href="@dueAndOverdueReturnsUrl" class="govuk-link">@messages("homepage.returns.dueOverdueReturns.linkText")</a>
-          </li>
-          <li class="card-links">
-           <a href="@submissionHistoryUrl" class="govuk-link">@messages("homepage.returns.submissionHistory.linkText")</a>
-          </li>
-         </ul>
-        </div>
-       </div>
-    } else {
-     @card(
-      title = messages("homepage.returns.title"),
-      links = Seq(
-       (messages("homepage.returns.dueOverdueReturns.linkText"), dueAndOverdueReturnsUrl, None),
-       (messages("homepage.returns.submissionHistory.linkText"), submissionHistoryUrl, None),
-      )
-     )
+        }
     }
-   }
 
  @if(maybePaymentBannerScenario.isDefined) {
      <div class="card-half-width">
          <div class="govuk-summary-card__title-wrapper card-with-tag">
              <h2 class="govuk-heading-m govuk-!-margin-0">@messages("homepage.payments.title")</h2>
-             @maybePaymentBannerScenario.map { scenario =>
-                 <span class="govuk-tag @{
-                     scenario match {
-                         case "Outstanding" => "govuk-tag--red"
-                     }
-                 }" aria-label="@{
-                     scenario
-                 } payments" title="@{
-                     scenario
-                 } payments">@scenario</span>
+             @maybePaymentBannerScenario.map { paymentScenario =>
+                 @defining(paymentScenario.toString) { paymentScenarioString =>
+                     <span class="govuk-tag @{
+                         paymentScenario match {
+                             case Outstanding => "govuk-tag--red"
+                             case _ => ""
+                         }
+                     }" aria-label="@{
+                         paymentScenarioString
+                     } payments" title="@{
+                         paymentScenarioString
+                     } payments">@paymentScenarioString</span>
+                 }
              }
          </div>
          <div class="card-content">

--- a/app/views/HomepageView.scala.html
+++ b/app/views/HomepageView.scala.html
@@ -156,17 +156,14 @@
      <div class="card-half-width">
          <div class="govuk-summary-card__title-wrapper card-with-tag">
              <h2 class="govuk-heading-m govuk-!-margin-0">@messages("homepage.payments.title")</h2>
-             @maybePaymentBannerScenario.map { paymentScenario =>
-                 @defining(paymentScenario.toString) { paymentScenarioString =>
-                     <span class="govuk-tag @{
-                         paymentScenario match {
-                             case Outstanding => "govuk-tag--red"
-                         }
-                     }" aria-label="@{
-                         paymentScenarioString
-                     } payments" title="@{
-                         paymentScenarioString
-                     } payments">@paymentScenarioString</span>
+             @maybePaymentBannerScenario.map {
+                 case Outstanding(_) => {
+                     <span
+                        class="govuk-tag govuk-tag--red"
+                        aria-label="Outstanding payments"
+                        title="Outstanding payments">
+                       @messages("homepage.payments.tags.outstanding")
+                     </span>
                  }
              }
          </div>

--- a/app/views/HomepageView.scala.html
+++ b/app/views/HomepageView.scala.html
@@ -21,9 +21,17 @@
 
 @import java.time.LocalDate
 @import java.time.format.DateTimeFormatter
+@import views.html.DynamicNotificationArea
 
-
-@this(layout: Layout, heading: heading, paragraphBody: paragraphBody, link: link, card: HomepageCard, govukNotificationBanner : GovukNotificationBanner)
+@this(
+    layout: Layout,
+    heading: heading,
+    paragraphBody: paragraphBody,
+    link: link,
+    card: HomepageCard,
+    govukNotificationBanner: GovukNotificationBanner,
+    dynamicNotificationArea: DynamicNotificationArea
+)
 
 @(
     organisationName: String,
@@ -75,23 +83,7 @@
    <span><strong>@{messages("homepage.id")}:</strong> @plrReference</span>
   </p>
 
-@maybeUktrBannerScenario.map { scenario =>
-    @if(!maybeUktrBannerScenario.contains(Received)) {
-        @defining(scenario.toString) { scenario =>
-            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-            <h2 class="govuk-heading-m">@messages(s"homepage.uktrBanner$maybeAgentKey.$scenario.title")</h2>
-            <p class="govuk-body">@messages(s"homepage.uktrBanner$maybeAgentKey.$scenario.body")</p>
-            <p class="govuk-body">
-              @link(
-                text = messages("homepage.uktrBanner.linkText"),
-                call = Call("GET", dueAndOverdueReturnsUrl),
-                id = Some("submission-link")
-              )
-            </p>
-            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-        }
-    }
-}
+@dynamicNotificationArea(maybeUktrBannerScenario, isAgent)
 
  <div class="card-group">
     @maybeUktrBannerScenario match {
@@ -170,7 +162,6 @@
                      <span class="govuk-tag @{
                          paymentScenario match {
                              case Outstanding => "govuk-tag--red"
-                             case _ => ""
                          }
                      }" aria-label="@{
                          paymentScenarioString

--- a/app/views/HomepageView.scala.html
+++ b/app/views/HomepageView.scala.html
@@ -82,7 +82,7 @@
    <span><strong>@{messages("homepage.id")}:</strong> @plrReference</span>
   </p>
 
-@dynamicNotificationArea(maybeUktrBannerScenario, isAgent)
+@dynamicNotificationArea(maybeUktrBannerScenario, maybePaymentBannerScenario, isAgent)
 
  <div class="card-group">
     @maybeUktrBannerScenario match {

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -854,6 +854,7 @@ homepage.returns.underEnquiry.agent.message = Your client has one or more return
 homepage.payments.title = Payments
 homepage.payments.transactionHistory.linkText = View transaction history
 homepage.payments.outstandingPayments.linkText = View outstanding payments
+homepage.payments.tags.outstanding = Outstanding
 homepage.payments.repayments.linkText = Request a repayment
 
 homepage.manageAccount.title = Manage account
@@ -892,6 +893,13 @@ homepage.uktrBanner.agent.Incomplete.title = Overdue or incomplete returns
 homepage.uktrBanner.agent.Incomplete.body = Submit or complete these returns as soon as possible.
 
 homepage.uktrBanner.linkText = View all due and overdue returns
+
+homepage.dna.accruingInterest.title = You owe £{0}
+homepage.dna.accruingInterest.agent.title = Your client owes £{0}
+homepage.dna.accruingInterest.body = Your overdue payment is now subject to daily interest.
+homepage.dna.accruingInterest.agent.body = This payment is overdue, and is now subject to daily interest.
+homepage.dna.accruingInterest.outstandingPayments.linkText = View outstanding payments
+
 ###############################################
 #
 # Dashboard

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -877,28 +877,28 @@ homepage.btnActiveBanner.body = You have told us you do not need to submit a UK 
 homepage.btnActiveBanner.agent.body = You or your client have told us the group does not need to submit a UK Tax Return. You or your client must submit a UK Tax Return if they meet the Pillar 2 Top-up Taxes criteria in the future.
 homepage.btnActiveBanner.linkText = Find out more about Below-Threshold Notification
 
-homepage.uktrBanner.Due.title = You have one or more returns due
-homepage.uktrBanner.Due.body = Submit your returns before the due date to avoid penalties.
-homepage.uktrBanner.agent.Due.title = One or more returns are now due
-homepage.uktrBanner.agent.Due.body = Submit returns before the due date to avoid penalties.
-
-homepage.uktrBanner.Overdue.title = You have overdue or incomplete returns
-homepage.uktrBanner.Overdue.body = You must submit or complete these returns as soon as possible.
-homepage.uktrBanner.agent.Overdue.title = Overdue or incomplete returns
-homepage.uktrBanner.agent.Overdue.body = Submit or complete these returns as soon as possible.
-
-homepage.uktrBanner.Incomplete.title = You have overdue or incomplete returns
-homepage.uktrBanner.Incomplete.body = You must submit or complete these returns as soon as possible.
-homepage.uktrBanner.agent.Incomplete.title = Overdue or incomplete returns
-homepage.uktrBanner.agent.Incomplete.body = Submit or complete these returns as soon as possible.
-
-homepage.uktrBanner.linkText = View all due and overdue returns
-
 homepage.dna.accruingInterest.title = You owe £{0}
 homepage.dna.accruingInterest.agent.title = Your client owes £{0}
 homepage.dna.accruingInterest.body = Your overdue payment is now subject to daily interest.
 homepage.dna.accruingInterest.agent.body = This payment is overdue, and is now subject to daily interest.
 homepage.dna.accruingInterest.outstandingPayments.linkText = View outstanding payments
+
+homepage.dna.returnExpected.Due.title = You have one or more returns due
+homepage.dna.returnExpected.Due.body = Submit your returns before the due date to avoid penalties.
+homepage.dna.returnExpected.agent.Due.title = One or more returns are now due
+homepage.dna.returnExpected.agent.Due.body = Submit returns before the due date to avoid penalties.
+
+homepage.dna.returnExpected.Overdue.title = You have overdue or incomplete returns
+homepage.dna.returnExpected.Overdue.body = You must submit or complete these returns as soon as possible.
+homepage.dna.returnExpected.agent.Overdue.title = Overdue or incomplete returns
+homepage.dna.returnExpected.agent.Overdue.body = Submit or complete these returns as soon as possible.
+
+homepage.dna.returnExpected.Incomplete.title = You have overdue or incomplete returns
+homepage.dna.returnExpected.Incomplete.body = You must submit or complete these returns as soon as possible.
+homepage.dna.returnExpected.agent.Incomplete.title = Overdue or incomplete returns
+homepage.dna.returnExpected.agent.Incomplete.body = Submit or complete these returns as soon as possible.
+
+homepage.dna.returnExpected.linkText = View all due and overdue returns
 
 ###############################################
 #

--- a/test/controllers/DashboardControllerSpec.scala
+++ b/test/controllers/DashboardControllerSpec.scala
@@ -22,6 +22,7 @@ import controllers.actions.TestAuthRetrievals.Ops
 import controllers.payments.OutstandingPaymentsControllerSpec.samplePaymentsDataWithNoTag
 import generators.ModelGenerators
 import helpers.FinancialDataHelper.Pillar2UktrName
+import models.DueAndOverdueReturnBannerScenario._
 import models._
 import models.obligationsandsubmissions.ObligationStatus
 import models.subscription._

--- a/test/controllers/DashboardControllerSpec.scala
+++ b/test/controllers/DashboardControllerSpec.scala
@@ -1034,13 +1034,14 @@ class DashboardControllerSpec extends SpecBase with ModelGenerators {
     "return Outstanding when there is an outstanding payment that has exceeded the due date to be made" in {
       val application = applicationBuilder(userAnswers = None, enrolments).build()
       running(application) {
-        val controller = application.injector.instanceOf[DashboardController]
+        val amountOutstanding = 100
+        val controller        = application.injector.instanceOf[DashboardController]
 
         val pastDueDate = LocalDate.now.minusDays(7)
         val transactions = Seq(
           TransactionSummary(
             name = Pillar2UktrName,
-            outstandingAmount = 100,
+            outstandingAmount = amountOutstanding,
             dueDate = pastDueDate
           )
         )
@@ -1051,7 +1052,7 @@ class DashboardControllerSpec extends SpecBase with ModelGenerators {
 
         val result = controller.getOutstandingPaymentsStatus(Some(Seq(financialSummary)))
 
-        result mustBe Some(Outstanding)
+        result mustBe Some(Outstanding(amountOutstanding))
       }
     }
 

--- a/test/views/DynamicNotificationAreaSpec.scala
+++ b/test/views/DynamicNotificationAreaSpec.scala
@@ -17,7 +17,8 @@
 package views
 
 import base.ViewSpecBase
-import models.{Due, DueAndOverdueReturnBannerScenario, Incomplete, Overdue, Received}
+import models.DueAndOverdueReturnBannerScenario
+import models.DueAndOverdueReturnBannerScenario._
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalacheck.Gen
@@ -43,7 +44,9 @@ class DynamicNotificationAreaSpec extends ViewSpecBase with ScalaCheckPropertyCh
 
   "Dynamic notification area" should {
     "not render anything" when {
-      "return is nonexistent or already received" in forAll(anyNotificationArea, Gen.oneOf(Some(Received), None)) { (template, uktr) =>
+      val doNotRenderScenarios = Gen.oneOf(Set(None, Some(Received)))
+
+      "return is nonexistent or already received" in forAll(anyNotificationArea, doNotRenderScenarios) { (template, uktr) =>
         val page = template(uktr)
         Option(page.getElementById(firstSectionBreakId)) must not be defined
         Option(page.getElementById(lastSectionBreakId))  must not be defined
@@ -54,7 +57,9 @@ class DynamicNotificationAreaSpec extends ViewSpecBase with ScalaCheckPropertyCh
     }
 
     "render a uktr notification" which {
-      val scenariosWhichRenderNotification = Gen.oneOf(Set(Due, Overdue, Incomplete).map(Some.apply))
+      val scenariosWhichRenderNotification = Gen.oneOf(
+        DueAndOverdueReturnBannerScenario.values.filter(_ != Received).map(Some.apply)
+      )
 
       "includes the section breaks" in forAll(anyNotificationArea, scenariosWhichRenderNotification) { (template, uktrScenario) =>
         val page = template(uktrScenario)

--- a/test/views/DynamicNotificationAreaSpec.scala
+++ b/test/views/DynamicNotificationAreaSpec.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import base.ViewSpecBase
+import models.{Due, DueAndOverdueReturnBannerScenario, Incomplete, Overdue, Received}
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.scalacheck.Gen
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import views.html.DynamicNotificationArea
+
+class DynamicNotificationAreaSpec extends ViewSpecBase with ScalaCheckPropertyChecks {
+
+  lazy val component: DynamicNotificationArea = inject[DynamicNotificationArea]
+
+  lazy val organisationNotificationArea: Option[DueAndOverdueReturnBannerScenario] => Document = uktrScenario =>
+    Jsoup.parse(component(uktrScenario, isAgent = false).toString())
+  lazy val agentNotificationArea: Option[DueAndOverdueReturnBannerScenario] => Document = uktrScenario =>
+    Jsoup.parse(component(uktrScenario, isAgent = true).toString())
+  lazy val anyNotificationArea: Gen[Option[DueAndOverdueReturnBannerScenario] => Document] =
+    Gen.oneOf(organisationNotificationArea, agentNotificationArea)
+
+  lazy val firstSectionBreakId = "notifications-break-begin"
+  lazy val lastSectionBreakId  = "notifications-break-end"
+  lazy val subheadingId        = "notifications-subheading"
+  lazy val messageId           = "notifications-body"
+  lazy val trSubmissionLinkId  = "submission-link"
+
+  "Dynamic notification area" should {
+    "not render anything" when {
+      "return is nonexistent or already received" in forAll(anyNotificationArea, Gen.oneOf(Some(Received), None)) { (template, uktr) =>
+        val page = template(uktr)
+        Option(page.getElementById(firstSectionBreakId)) must not be defined
+        Option(page.getElementById(lastSectionBreakId))  must not be defined
+        Option(page.getElementById(subheadingId))        must not be defined
+        Option(page.getElementById(messageId))           must not be defined
+        Option(page.getElementById(trSubmissionLinkId))  must not be defined
+      }
+    }
+
+    "render a uktr notification" which {
+      val scenariosWhichRenderNotification = Gen.oneOf(Set(Due, Overdue, Incomplete).map(Some.apply))
+
+      "includes the section breaks" in forAll(anyNotificationArea, scenariosWhichRenderNotification) { (template, uktrScenario) =>
+        val page = template(uktrScenario)
+        Option(page.getElementById(firstSectionBreakId)) mustBe defined
+        Option(page.getElementById(lastSectionBreakId)) mustBe defined
+      }
+
+      "has the proper link" in forAll(anyNotificationArea, scenariosWhichRenderNotification) { (template, uktrScenario) =>
+        val page = template(uktrScenario)
+        val link = page.getElementById(trSubmissionLinkId)
+        link.text() mustBe "View all due and overdue returns"
+        link.attr("href") mustBe controllers.dueandoverduereturns.routes.DueAndOverdueReturnsController.onPageLoad.url
+      }
+
+      "has the proper heading and message" when {
+
+        val orgExpectations = Table(
+          ("Return scenario", "subhead", "message"),
+          (Due, "You have one or more returns due", "Submit your returns before the due date to avoid penalties."),
+          (Overdue, "You have overdue or incomplete returns", "You must submit or complete these returns as soon as possible."),
+          (Incomplete, "You have overdue or incomplete returns", "You must submit or complete these returns as soon as possible.")
+        )
+
+        "user is an organisation" in forAll(orgExpectations) { case (scenario, expSubhead, expMessage) =>
+          val page    = organisationNotificationArea(Some(scenario))
+          val subhead = page.getElementById(subheadingId)
+          val message = page.getElementById(messageId)
+
+          subhead.text() mustBe expSubhead
+          message.text() mustBe expMessage
+        }
+
+        val agentExpectations = Table(
+          ("Return scenario", "subhead", "message"),
+          (Due, "One or more returns are now due", "Submit returns before the due date to avoid penalties."),
+          (Overdue, "Overdue or incomplete returns", "Submit or complete these returns as soon as possible."),
+          (Incomplete, "Overdue or incomplete returns", "Submit or complete these returns as soon as possible.")
+        )
+
+        "user is an agent" in forAll(agentExpectations) { case (scenario, expSubhead, expMessage) =>
+          val page    = agentNotificationArea(Some(scenario))
+          val subhead = page.getElementById(subheadingId)
+          val message = page.getElementById(messageId)
+
+          subhead.text() mustBe expSubhead
+          message.text() mustBe expMessage
+        }
+      }
+    }
+  }
+}

--- a/test/views/HomepageViewSpec.scala
+++ b/test/views/HomepageViewSpec.scala
@@ -18,7 +18,8 @@ package views
 
 import base.ViewSpecBase
 import controllers.routes
-import models.{Due, Incomplete, Outstanding, Overdue, Received}
+import models.DueAndOverdueReturnBannerScenario._
+import models.Outstanding
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements

--- a/test/views/HomepageViewSpec.scala
+++ b/test/views/HomepageViewSpec.scala
@@ -304,7 +304,7 @@ class HomepageViewSpec extends ViewSpecBase {
     "display enquiry message with status tag when both enquiry and status scenario are present" in {
       val organisationViewWithEnquiryAndOverdue: Document =
         Jsoup.parse(
-          page(organisationName, date, btnActive = false, Some("Overdue"), None, plrRef, isAgent = false, hasReturnsUnderEnquiry = true)(
+          page(organisationName, date, btnActive = false, Some(Overdue), None, plrRef, isAgent = false, hasReturnsUnderEnquiry = true)(
             request,
             appConfig,
             messages
@@ -353,7 +353,16 @@ class HomepageViewSpec extends ViewSpecBase {
       val amountOutstanding = 100000.00
       val organisationViewWithOutstandingScenario: Document =
         Jsoup.parse(
-          page(organisationName, date, btnActive = false, None, Some(Outstanding(amountOutstanding)), plrRef, isAgent = false, hasReturnsUnderEnquiry = false)(
+          page(
+            organisationName,
+            date,
+            btnActive = false,
+            None,
+            Some(Outstanding(amountOutstanding)),
+            plrRef,
+            isAgent = false,
+            hasReturnsUnderEnquiry = false
+          )(
             request,
             appConfig,
             messages

--- a/test/views/HomepageViewSpec.scala
+++ b/test/views/HomepageViewSpec.scala
@@ -350,14 +350,14 @@ class HomepageViewSpec extends ViewSpecBase {
     }
 
     "display Payments Outstanding tag with red style when Outstanding scenario is provided" in {
+      val amountOutstanding = 100000.00
       val organisationViewWithOutstandingScenario: Document =
         Jsoup.parse(
-          page(organisationName, date, btnActive = false, None, Some(Outstanding), plrRef, isAgent = false, hasReturnsUnderEnquiry = false)(
+          page(organisationName, date, btnActive = false, None, Some(Outstanding(amountOutstanding)), plrRef, isAgent = false, hasReturnsUnderEnquiry = false)(
             request,
             appConfig,
             messages
-          )
-            .toString()
+          ).toString()
         )
       val returnsCard: Element  = organisationViewWithOutstandingScenario.getElementsByClass("card-half-width").get(1)
       val statusTags:  Elements = returnsCard.getElementsByClass("govuk-tag--red")

--- a/test/views/HomepageViewSpec.scala
+++ b/test/views/HomepageViewSpec.scala
@@ -18,6 +18,7 @@ package views
 
 import base.ViewSpecBase
 import controllers.routes
+import models.{Due, Incomplete, Outstanding, Overdue, Received}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
@@ -172,7 +173,7 @@ class HomepageViewSpec extends ViewSpecBase {
     "show clean Returns card with no tag when Due scenario is provided" in {
       val organisationViewWithDueScenario: Document =
         Jsoup.parse(
-          page(organisationName, date, btnActive = false, Some("Due"), None, plrRef, isAgent = false, hasReturnsUnderEnquiry = false)(
+          page(organisationName, date, btnActive = false, Some(Due), None, plrRef, isAgent = false, hasReturnsUnderEnquiry = false)(
             request,
             appConfig,
             messages
@@ -199,7 +200,7 @@ class HomepageViewSpec extends ViewSpecBase {
     "display UKTR Overdue status tag with red style when Overdue scenario is provided" in {
       val organisationViewWithOverdueScenario: Document =
         Jsoup.parse(
-          page(organisationName, date, btnActive = false, Some("Overdue"), None, plrRef, isAgent = false, hasReturnsUnderEnquiry = false)(
+          page(organisationName, date, btnActive = false, Some(Overdue), None, plrRef, isAgent = false, hasReturnsUnderEnquiry = false)(
             request,
             appConfig,
             messages
@@ -231,7 +232,7 @@ class HomepageViewSpec extends ViewSpecBase {
     "display UKTR Incomplete status tag with purple style when Incomplete scenario is provided" in {
       val organisationViewWithIncompleteScenario: Document =
         Jsoup.parse(
-          page(organisationName, date, btnActive = false, Some("Incomplete"), None, plrRef, isAgent = false, hasReturnsUnderEnquiry = false)(
+          page(organisationName, date, btnActive = false, Some(Incomplete), None, plrRef, isAgent = false, hasReturnsUnderEnquiry = false)(
             request,
             appConfig,
             messages
@@ -263,7 +264,7 @@ class HomepageViewSpec extends ViewSpecBase {
     "display UKTR Received status tag with green style when Received scenario is provided" in {
       val organisationViewWithOverdueScenario: Document =
         Jsoup.parse(
-          page(organisationName, date, btnActive = false, Some("Received"), None, plrRef, isAgent = false, hasReturnsUnderEnquiry = false)(
+          page(organisationName, date, btnActive = false, Some(Received), None, plrRef, isAgent = false, hasReturnsUnderEnquiry = false)(
             request,
             appConfig,
             messages
@@ -350,7 +351,7 @@ class HomepageViewSpec extends ViewSpecBase {
     "display Payments Outstanding tag with red style when Outstanding scenario is provided" in {
       val organisationViewWithOutstandingScenario: Document =
         Jsoup.parse(
-          page(organisationName, date, btnActive = false, None, Some("Outstanding"), plrRef, isAgent = false, hasReturnsUnderEnquiry = false)(
+          page(organisationName, date, btnActive = false, None, Some(Outstanding), plrRef, isAgent = false, hasReturnsUnderEnquiry = false)(
             request,
             appConfig,
             messages


### PR DESCRIPTION
In the scenario where a user has an outstanding payment, interest begins to accrue against the total. This PR adds a banner to inform users of this, piggybacking off of the existing logic used to determine the overdue tag on the payment card.

Since it appears there are plans for other additions to the "dynamic notification area," I extracted it to a new template to keep things separated. I also updated the homepage template to take typed scenarios, so we can avoid matching on strings and leverage the existing model.

https://jira.tools.tax.service.gov.uk/browse/PIL-2452