### PR TITLE
PIL-2480 Introduce text wrapping for all headings

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,7 +9,7 @@
 .js-enabled .js-visible {
   display: inline-block !important;
 }
-.long-word, .govuk-error-summary, .govuk-error-message {
+.govuk-error-summary, .govuk-error-message {
   word-wrap: break-word;
 }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,7 @@
-@import "autocomplete";
-@import "hods-loading-spinner";
+@use "autocomplete";
+@use "hods-loading-spinner";
+@use "partials/heading";
+@use "partials/legend";
 
 .js-visible {
   display: none !important;

--- a/app/assets/stylesheets/partials/_heading.scss
+++ b/app/assets/stylesheets/partials/_heading.scss
@@ -1,0 +1,3 @@
+h1 {
+  word-wrap: break-word;
+}

--- a/app/assets/stylesheets/partials/_legend.scss
+++ b/app/assets/stylesheets/partials/_legend.scss
@@ -1,0 +1,4 @@
+// govuk-frontend has legends with 'display: table', meaning they don't respect parent tag widths.
+legend {
+  display: block !important;
+}

--- a/app/views/fmview/NfmEmailAddressView.scala.html
+++ b/app/views/fmview/NfmEmailAddressView.scala.html
@@ -45,7 +45,6 @@
             InputViewModel(
                 field = form("emailAddress"),
                 label = LabelViewModel(messages("nfmEmailAddress.heading", UserName)).asPageHeading(Large)
-                .withCssClass("long-word")
             )
             .withHint(Hint(content = Text(messages("nfmEmailAddress.hint"))))
             .withWidth(TwoThirds)

--- a/app/views/fmview/NfmRegisteredAddressView.scala.html
+++ b/app/views/fmview/NfmRegisteredAddressView.scala.html
@@ -46,7 +46,7 @@
 
         @sectionHeader(messages("nfmRegisteredAddress.heading.caption"))
 
-        @heading(messages("nfmRegisteredAddress.heading", UserName), "govuk-heading-l long-word")
+        @heading(messages("nfmRegisteredAddress.heading", UserName), "govuk-heading-l")
         @govukWarningText(WarningText(
         iconFallbackText = Some(messages("site.warning")),
         content = HtmlContent(messages("address.warning"))

--- a/app/views/registrationview/UpeContactEmailView.scala.html
+++ b/app/views/registrationview/UpeContactEmailView.scala.html
@@ -44,7 +44,6 @@
             InputViewModel(
                 field = form("emailAddress"),
                 label = LabelViewModel(messages("upe-input-business-email.heading", UserName)).asPageHeading(Large)
-                .withCssClass("long-word")
 
             )
             .withHint(Hint(content = Text(messages("upe-input-business-email.hint"))))

--- a/app/views/registrationview/UpeRegisteredAddressView.scala.html
+++ b/app/views/registrationview/UpeRegisteredAddressView.scala.html
@@ -47,7 +47,7 @@
 
         @sectionHeader(messages("upeRegisteredAddress.heading.caption"))
 
-        @heading(messages("upeRegisteredAddress.heading", UserName), "govuk-heading-l long-word")
+        @heading(messages("upeRegisteredAddress.heading", UserName), "govuk-heading-l")
         @govukWarningText(WarningText(
         iconFallbackText = Some(messages("site.warning")),
         content = HtmlContent(messages("address.warning"))

--- a/app/views/rfm/RfmContactAddressView.scala.html
+++ b/app/views/rfm/RfmContactAddressView.scala.html
@@ -44,7 +44,7 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
         @sectionHeader(messages("rfmContactAddress.heading.caption"))
-        @heading(messages("rfmContactAddress.heading"), "govuk-heading-l long-word")
+        @heading(messages("rfmContactAddress.heading"), "govuk-heading-l")
 
         @govukInput(
             InputViewModel(

--- a/app/views/rfm/RfmPrimaryContactEmailView.scala.html
+++ b/app/views/rfm/RfmPrimaryContactEmailView.scala.html
@@ -41,8 +41,6 @@
             InputViewModel(
                 field = form("emailAddress"),
                 label = LabelViewModel(messages("rfm-input-business-email.heading", UserName)).asPageHeading(Large)
-                .withCssClass("long-word")
-
             )
             .withHint(Hint(content = Text(messages("rfm-input-business-email.hint"))))
             .withWidth(TwoThirds)

--- a/app/views/rfm/RfmRegisteredAddressView.scala.html
+++ b/app/views/rfm/RfmRegisteredAddressView.scala.html
@@ -46,7 +46,7 @@
 
         @sectionHeader(messages("rfm.registration.heading.caption"))
 
-        @heading(messages("rfm.registeredAddress.heading", UserName), "govuk-heading-l long-word")
+        @heading(messages("rfm.registeredAddress.heading", UserName), "govuk-heading-l")
 
         @govukWarningText(WarningText(
             iconFallbackText = Some(messages("site.warning")),

--- a/app/views/rfm/RfmSecondaryContactEmailView.scala.html
+++ b/app/views/rfm/RfmSecondaryContactEmailView.scala.html
@@ -46,7 +46,6 @@
             InputViewModel(
                 field = form("emailAddress"),
                 label = LabelViewModel(messages("rfm.secondaryContactEmail.heading", secondaryContactName)).asPageHeading(Large)
-                .withCssClass("long-word")
             )
             .withHint(Hint(content = Text(messages("rfm.secondaryContactEmail.hint"))))
             .withWidth(TwoThirds)

--- a/app/views/subscriptionview/CaptureSubscriptionAddressView.scala.html
+++ b/app/views/subscriptionview/CaptureSubscriptionAddressView.scala.html
@@ -45,7 +45,7 @@
 
         @sectionHeader(messages("subscriptionAddress.heading.caption"))
 
-        @heading(messages("subscriptionAddress.heading"), "govuk-heading-l long-word")
+        @heading(messages("subscriptionAddress.heading"), "govuk-heading-l")
 
         @govukInput(
             InputViewModel(

--- a/app/views/subscriptionview/ContactEmailAddressView.scala.html
+++ b/app/views/subscriptionview/ContactEmailAddressView.scala.html
@@ -45,7 +45,6 @@
             InputViewModel(
                 field = form("emailAddress"),
                 label = LabelViewModel(messages("contactEmailAddress.heading", UserName)).asPageHeading(Large)
-                .withCssClass("long-word")
             )
             .withHint(Hint(content = Text(messages("contactEmailAddress.hint"))))
             .withWidth(TwoThirds)

--- a/app/views/subscriptionview/SecondaryContactEmailView.scala.html
+++ b/app/views/subscriptionview/SecondaryContactEmailView.scala.html
@@ -46,7 +46,6 @@
             InputViewModel(
                 field = form("emailAddress"),
                 label = LabelViewModel(messages("secondaryContactEmail.heading", secondaryContactName)).asPageHeading(Large)
-                .withCssClass("long-word")
             )
             .withHint(Hint(content = Text(messages("secondaryContactEmail.hint"))))
             .withWidth(TwoThirds)

--- a/app/views/subscriptionview/manageAccount/CaptureSubscriptionAddressView.scala.html
+++ b/app/views/subscriptionview/manageAccount/CaptureSubscriptionAddressView.scala.html
@@ -50,7 +50,7 @@
             @sectionHeader(messages("subscriptionAddress.heading.caption"))
         }
 
-        @heading(messages("subscriptionAddress.heading"), "govuk-heading-l long-word")
+        @heading(messages("subscriptionAddress.heading"), "govuk-heading-l")
 
         @govukInput(
             InputViewModel(

--- a/app/views/subscriptionview/manageAccount/ContactEmailAddressView.scala.html
+++ b/app/views/subscriptionview/manageAccount/ContactEmailAddressView.scala.html
@@ -49,7 +49,6 @@
             InputViewModel(
                 field = form("emailAddress"),
                 label = LabelViewModel(messages("contactEmailAddress.heading", UserName)).asPageHeading(Large)
-                .withCssClass("long-word")
             )
             .withHint(Hint(content = Text(messages("contactEmailAddress.hint"))))
             .withWidth(TwoThirds)

--- a/app/views/subscriptionview/manageAccount/SecondaryContactEmailView.scala.html
+++ b/app/views/subscriptionview/manageAccount/SecondaryContactEmailView.scala.html
@@ -49,7 +49,6 @@
             InputViewModel(
                 field = form("emailAddress"),
                 label = LabelViewModel(messages("secondaryContactEmail.heading", secondaryContactName)).asPageHeading(Large)
-                .withCssClass("long-word")
             )
             .withHint(Hint(content = Text(messages("secondaryContactEmail.hint"))))
             .withWidth(TwoThirds)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.3")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.1")
 
-addSbtPlugin("io.github.irundaia" % "sbt-sassify" % "1.5.2")
+addSbtPlugin("uk.gov.hmrc" % "sbt-sass-compiler" % "0.12.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-concat" % "1.0.0")
 


### PR DESCRIPTION
A number of screens were identified where user-inputted values are used in the page heading and text wrapping was not in place to handle long values. This PR styles all h1 elements to wrap when the content is too long, and removes the long-word class previously used. It was only applied on h1 elements, so this is a safe change.

https://jira.tools.tax.service.gov.uk/browse/PIL-2480