### PR TITLE
NOJIRA: Fix account activity API to use dateFrom/dateTo parameters in…

### DIFF
--- a/app/connectors/AccountActivityConnector.scala
+++ b/app/connectors/AccountActivityConnector.scala
@@ -38,7 +38,7 @@ class AccountActivityConnector @Inject() (val config: FrontendAppConfig, val htt
     hc: HeaderCarrier
   ): Future[AccountActivityResponse] =
     http
-      .get(url"${config.pillar2BaseUrl}/report-pillar2-top-up-taxes/account-activity?fromDate=${dateFrom.toString}&toDate=${dateTo.toString}")
+      .get(url"${config.pillar2BaseUrl}/report-pillar2-top-up-taxes/account-activity?dateFrom=${dateFrom.toString}&dateTo=${dateTo.toString}")
       .setHeader("X-Pillar2-Id" -> plrReference)
       .execute[HttpResponse]
       .flatMap {

--- a/test/connectors/AccountActivityConnectorSpec.scala
+++ b/test/connectors/AccountActivityConnectorSpec.scala
@@ -38,7 +38,7 @@ class AccountActivityConnectorSpec extends SpecBase with WireMockServerHandler {
 
   override val toDate: LocalDate = LocalDate.now.plusYears(1)
 
-  val accountActivityUrl: String = s"/report-pillar2-top-up-taxes/account-activity?fromDate=${fromDate.toString}&toDate=${toDate.toString}"
+  val accountActivityUrl: String = s"/report-pillar2-top-up-taxes/account-activity?dateFrom=${fromDate.toString}&dateTo=${toDate.toString}"
 
   val accountActivityResponse: AccountActivityResponse =
     AccountActivityResponse(


### PR DESCRIPTION
Fixes the "Missing parameter: dateFrom" error when using the account activity API.

The backend expects `dateFrom`/`dateTo` query parameters, but the frontend was sending `fromDate`/`toDate`. Updated `AccountActivityConnector` and its test to use the correct parameter names.