### PR TITLE
PIL-2796: Implemented Stoodover Charges page and content behind account activity toggle

### DIFF
--- a/app/config/GuiceModule.scala
+++ b/app/config/GuiceModule.scala
@@ -44,6 +44,7 @@ class GuiceModule(
     bind(classOf[SessionDataRetrievalAction]).to(classOf[SessionDataRetrievalActionImpl]).asEagerSingleton()
     bind(classOf[SessionDataRequiredAction]).to(classOf[SessionDataRequiredActionImpl]).asEagerSingleton()
     bind(classOf[AmendMultipleAccountingPeriodScreensAction]).to(classOf[AmendMultipleAccountingPeriodScreensActionImpl]).asEagerSingleton()
+    bind(classOf[AccountActivityScreensAction]).to(classOf[AccountActivityScreensActionImpl]).asEagerSingleton()
 
     // For session based storage instead of cred based, change to SessionIdentifierAction
     bind(classOf[IdentifierAction]).to(classOf[AuthenticatedIdentifierAction]).asEagerSingleton()

--- a/app/controllers/HomepageController.scala
+++ b/app/controllers/HomepageController.scala
@@ -189,7 +189,8 @@ class HomepageController @Inject() (
             notificationArea,
             plrReference,
             request.isAgent,
-            hasReturnsUnderEnquiry
+            hasReturnsUnderEnquiry,
+            appConfig.useAccountActivityApi
           )
         )
       }

--- a/app/controllers/actions/AccountActivityScreensAction.scala
+++ b/app/controllers/actions/AccountActivityScreensAction.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import config.FrontendAppConfig
+import models.requests.IdentifierRequest
+import play.api.mvc.{ActionRefiner, Result, Results}
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class AccountActivityScreensActionImpl @Inject() (
+  config: FrontendAppConfig
+)(using val executionContext: ExecutionContext)
+    extends AccountActivityScreensAction {
+
+  override protected def refine[A](request: IdentifierRequest[A]): Future[Either[Result, IdentifierRequest[A]]] =
+    if config.useAccountActivityApi then {
+      Future.successful(Right(request))
+    } else {
+      Future.successful(Left(Results.Redirect(controllers.routes.HomepageController.onPageLoad())))
+    }
+}
+
+trait AccountActivityScreensAction extends ActionRefiner[IdentifierRequest, IdentifierRequest]

--- a/app/controllers/payments/OutstandingPaymentsController.scala
+++ b/app/controllers/payments/OutstandingPaymentsController.scala
@@ -85,7 +85,7 @@ class OutstandingPaymentsController @Inject() (
     financialSummaries.map { summary =>
       OutstandingPaymentsTable(
         accountingPeriod = summary.accountingPeriod,
-        rows = summary.transactions.map(tx => OutstandingPaymentsRow(tx.description, tx.outstandingAmount, tx.dueDate))
+        rows = summary.transactions.map(tx => OutstandingPaymentsRow(tx.description, tx.outstandingAmount, tx.dueDate, None))
       )
     }
 
@@ -93,7 +93,7 @@ class OutstandingPaymentsController @Inject() (
     accountActivitySummaries.map { summary =>
       OutstandingPaymentsTable(
         accountingPeriod = summary.accountingPeriod,
-        rows = summary.items.map(item => OutstandingPaymentsRow(item.description, item.outstandingAmount, item.dueDate))
+        rows = summary.items.map(item => OutstandingPaymentsRow(item.description, item.outstandingAmount, item.dueDate, item.appealFlag))
       )
     }
 

--- a/app/controllers/payments/StoodoverChargesController.scala
+++ b/app/controllers/payments/StoodoverChargesController.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.payments
+
+import cats.data.OptionT
+import config.FrontendAppConfig
+import connectors.AccountActivityConnector
+import controllers.actions.*
+import models.*
+import pages.AgentClientPillar2ReferencePage
+import play.api.Logging
+import play.api.i18n.I18nSupport
+import play.api.mvc.*
+import repositories.SessionRepository
+import services.{ReferenceNumberService, SubscriptionService}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import utils.Constants.SubmissionAccountingPeriods
+import views.html.stoodoverCharges.StoodoverChargesView
+
+import java.time.LocalDate.now
+import java.time.{LocalDate, LocalDateTime}
+import javax.inject.{Inject, Named}
+import scala.concurrent.{ExecutionContext, Future}
+
+class StoodoverChargesController @Inject() (
+  @Named("EnrolmentIdentifier") identify: IdentifierAction,
+  val controllerComponents:               MessagesControllerComponents,
+  sessionRepository:                      SessionRepository,
+  accountActivityConnector:               AccountActivityConnector,
+  referenceNumberService:                 ReferenceNumberService,
+  subscriptionService:                    SubscriptionService,
+  getData:                                DataRetrievalAction,
+  requireData:                            DataRequiredAction,
+  view:                                   StoodoverChargesView
+)(using appConfig: FrontendAppConfig, ec: ExecutionContext)
+    extends FrontendBaseController
+    with I18nSupport
+    with Logging {
+
+  private def retrieveStoodoverCharges(plrReference: String, dateFrom: LocalDate, dateTo: LocalDate)(using
+    hc: HeaderCarrier
+  ): Future[AccountActivityResponse] =
+    accountActivityConnector
+      .retrieveAccountActivity(plrReference, dateFrom, dateTo)
+      .recover { case NoResultFound => AccountActivityResponse(LocalDateTime.now, Seq.empty) }
+
+  private def toTablesFromAccountActivity(accountActivitySummaries: Seq[StoodoverChargeSummary]): Seq[StoodoverChargesTable] =
+    accountActivitySummaries.map { summary =>
+      StoodoverChargesTable(
+        accountingPeriod = summary.accountingPeriod,
+        rows = summary.items.map(item => StoodoverChargesRow(item.description, item.stoodoverAmount))
+      )
+    }
+
+  def onPageLoad: Action[AnyContent] =
+    (identify andThen getData andThen requireData).async { request =>
+      given Request[AnyContent] = request
+
+      given isAgent: Boolean = request.isAgent
+
+      (for {
+        maybeUserAnswer <- OptionT.liftF(sessionRepository.get(request.userId))
+        userAnswers = maybeUserAnswer.getOrElse(UserAnswers(request.userId))
+        plrRef <- OptionT
+                    .fromOption[Future](userAnswers.get(AgentClientPillar2ReferencePage))
+                    .orElse(OptionT.fromOption[Future](referenceNumberService.get(Some(userAnswers), request.enrolments)))
+        subscriptionData       <- OptionT.liftF(subscriptionService.readSubscription(plrRef))
+        standoverChargesResult <-
+          OptionT.liftF(
+            retrieveStoodoverCharges(plrRef, LocalDate.now.minusYears(SubmissionAccountingPeriods), now())
+          )
+      } yield {
+        val tables    = toTablesFromAccountActivity(standoverChargesResult.toStoodoverCharges)
+        val amountDue = tables.flatMap(_.rows.map(_.stoodoverAmount)).sum.max(0)
+        Ok(view(plrReference = plrRef, data = tables, stoodoverTotal = amountDue, organisationName = subscriptionData.upeDetails.organisationName))
+      }).getOrElse {
+        Redirect(controllers.routes.JourneyRecoveryController.onPageLoad())
+      }.recover {
+        case _ => Redirect(controllers.routes.JourneyRecoveryController.onPageLoad())
+      }
+    }
+}

--- a/app/controllers/payments/StoodoverChargesController.scala
+++ b/app/controllers/payments/StoodoverChargesController.scala
@@ -90,8 +90,8 @@ class StoodoverChargesController @Inject() (
         Ok(view(plrReference = plrRef, data = tables, stoodoverTotal = amountDue, organisationName = subscriptionData.upeDetails.organisationName))
       }).getOrElse {
         Redirect(controllers.routes.JourneyRecoveryController.onPageLoad())
-      }.recover {
-        case _ => Redirect(controllers.routes.JourneyRecoveryController.onPageLoad())
+      }.recover { case _ =>
+        Redirect(controllers.routes.JourneyRecoveryController.onPageLoad())
       }
     }
 }

--- a/app/controllers/payments/StoodoverChargesController.scala
+++ b/app/controllers/payments/StoodoverChargesController.scala
@@ -44,6 +44,7 @@ class StoodoverChargesController @Inject() (
   accountActivityConnector:               AccountActivityConnector,
   referenceNumberService:                 ReferenceNumberService,
   subscriptionService:                    SubscriptionService,
+  checkAccountActivityScreens:            AccountActivityScreensAction,
   getData:                                DataRetrievalAction,
   requireData:                            DataRequiredAction,
   view:                                   StoodoverChargesView
@@ -68,7 +69,7 @@ class StoodoverChargesController @Inject() (
     }
 
   def onPageLoad: Action[AnyContent] =
-    (identify andThen getData andThen requireData).async { request =>
+    (identify andThen checkAccountActivityScreens andThen getData andThen requireData).async { request =>
       given Request[AnyContent] = request
 
       given isAgent: Boolean = request.isAgent

--- a/app/models/AccountActivityResponse.scala
+++ b/app/models/AccountActivityResponse.scala
@@ -113,7 +113,8 @@ case class AccountActivityResponse(processingDate: LocalDateTime, transactionDet
               OutstandingPaymentItem(
                 description = if t.accruedInterest.exists(_ > 0) then uiDescription + " accruing interest" else uiDescription,
                 outstandingAmount = t.outstandingAmount.get,
-                dueDate = t.dueDate.getOrElse(t.transactionDate)
+                dueDate = t.dueDate.getOrElse(t.transactionDate),
+                appealFlag = t.appealFlag
               )
             }
             .sortBy(_.dueDate)(Ordering[LocalDate].reverse) // Sort by dueDate descending

--- a/app/models/AccountActivityResponse.scala
+++ b/app/models/AccountActivityResponse.scala
@@ -134,6 +134,42 @@ case class AccountActivityResponse(processingDate: LocalDateTime, transactionDet
       )
       .flatMap(_.accruedInterest)
       .sum
+
+  def toStoodoverCharges: Seq[StoodoverChargeSummary] = {
+    val stoodoverCharges = transactionDetails.filter { t =>
+      t.standOverAmount.exists(_ > 0) &&
+      (t.startDate.isDefined || t.endDate.isDefined)
+    }
+
+    if stoodoverCharges.isEmpty then Seq.empty
+    else {
+      val itemsByPeriod = stoodoverCharges
+        .groupBy { t =>
+          val start = t.startDate.getOrElse(t.transactionDate)
+          val end   = t.endDate.getOrElse(t.transactionDate)
+          AccountingPeriod(start, end)
+        }
+        .map { case (accountingPeriod, transactions) =>
+          val items = transactions
+            .map { t =>
+              val uiDescription = TransactionDescription
+                .fromString(t.transactionDesc)
+                .map(_.toUiDescription)
+                .getOrElse(t.transactionDesc)
+
+              StoodoverChargeItem(
+                description = uiDescription,
+                stoodoverAmount = t.standOverAmount.get
+              )
+            }
+
+          StoodoverChargeSummary(accountingPeriod, items)
+        }
+        .toSeq
+
+      itemsByPeriod.sortBy(_.accountingPeriod.endDate)(Ordering[LocalDate].reverse)
+    }
+  }
 }
 
 sealed trait TransactionType

--- a/app/models/OutstandingPaymentSummary.scala
+++ b/app/models/OutstandingPaymentSummary.scala
@@ -22,4 +22,4 @@ import java.time.LocalDate
 
 case class OutstandingPaymentSummary(accountingPeriod: AccountingPeriod, items: Seq[OutstandingPaymentItem])
 
-case class OutstandingPaymentItem(description: String, outstandingAmount: BigDecimal, dueDate: LocalDate)
+case class OutstandingPaymentItem(description: String, outstandingAmount: BigDecimal, dueDate: LocalDate, appealFlag: Option[Boolean])

--- a/app/models/OutstandingPaymentsTable.scala
+++ b/app/models/OutstandingPaymentsTable.scala
@@ -22,4 +22,4 @@ import java.time.LocalDate
 
 final case class OutstandingPaymentsTable(accountingPeriod: AccountingPeriod, rows: Seq[OutstandingPaymentsRow])
 
-final case class OutstandingPaymentsRow(description: String, outstandingAmount: BigDecimal, dueDate: LocalDate)
+final case class OutstandingPaymentsRow(description: String, outstandingAmount: BigDecimal, dueDate: LocalDate, appealFlag: Option[Boolean])

--- a/app/models/StoodoverChargeSummary.scala
+++ b/app/models/StoodoverChargeSummary.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import models.subscription.AccountingPeriod
+
+case class StoodoverChargeSummary(accountingPeriod: AccountingPeriod, items: Seq[StoodoverChargeItem])
+
+case class StoodoverChargeItem(description: String, stoodoverAmount: BigDecimal)

--- a/app/models/StoodoverChargesTable.scala
+++ b/app/models/StoodoverChargesTable.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import models.subscription.AccountingPeriod
+
+final case class StoodoverChargesTable(accountingPeriod: AccountingPeriod, rows: Seq[StoodoverChargesRow])
+
+final case class StoodoverChargesRow(description: String, stoodoverAmount: BigDecimal)

--- a/app/views/HomepageView.scala.html
+++ b/app/views/HomepageView.scala.html
@@ -193,6 +193,9 @@
                      <a href="@controllers.payments.routes.OutstandingPaymentsController.onPageLoad.url" class="govuk-link">@messages("homepage.payments.outstandingPayments.linkText")</a>
                  </li>
                  <li class="card-links">
+                     <a href="@controllers.payments.routes.StoodoverChargesController.onPageLoad.url" class="govuk-link">@messages("homepage.payments.stoodoverCharges.linkText")</a>
+                 </li>
+                 <li class="card-links">
                      <a href="@controllers.repayments.routes.RequestRepaymentBeforeStartController.onPageLoad().url" class="govuk-link">@messages("homepage.payments.repayments.linkText")</a>
                  </li>
              </ul>
@@ -204,7 +207,8 @@
          links = Seq(
              (messages("homepage.payments.transactionHistory.linkText"), controllers.routes.TransactionHistoryController.onPageLoadTransactionHistory(None).url, None),
              (messages("homepage.payments.outstandingPayments.linkText"), controllers.payments.routes.OutstandingPaymentsController.onPageLoad.url, None),
-             (messages("homepage.payments.repayments.linkText"), controllers.repayments.routes.RequestRepaymentBeforeStartController.onPageLoad().url, None),
+             (messages("homepage.payments.stoodoverCharges.linkText"), controllers.payments.routes.StoodoverChargesController.onPageLoad.url, None),
+             (messages("homepage.payments.repayments.linkText"), controllers.repayments.routes.RequestRepaymentBeforeStartController.onPageLoad().url, None)
          )
      )
  }

--- a/app/views/HomepageView.scala.html
+++ b/app/views/HomepageView.scala.html
@@ -43,7 +43,8 @@
     dynamicNotificationAreaState: DynamicNotificationAreaState,
     plrReference: String,
     isAgent: Boolean,
-    hasReturnsUnderEnquiry: Boolean
+    hasReturnsUnderEnquiry: Boolean,
+    useAccountActivity: Boolean = false
 )(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @maybeAgentKey = @{if(isAgent) ".agent" else ""}
@@ -192,9 +193,11 @@
                  <li class="card-links">
                      <a href="@controllers.payments.routes.OutstandingPaymentsController.onPageLoad.url" class="govuk-link">@messages("homepage.payments.outstandingPayments.linkText")</a>
                  </li>
-                 <li class="card-links">
-                     <a href="@controllers.payments.routes.StoodoverChargesController.onPageLoad.url" class="govuk-link">@messages("homepage.payments.stoodoverCharges.linkText")</a>
-                 </li>
+                 @if(useAccountActivity) {
+                     <li class="card-links">
+                         <a href="@controllers.payments.routes.StoodoverChargesController.onPageLoad.url" class="govuk-link">@messages("homepage.payments.stoodoverCharges.linkText")</a>
+                     </li>
+                 }
                  <li class="card-links">
                      <a href="@controllers.repayments.routes.RequestRepaymentBeforeStartController.onPageLoad().url" class="govuk-link">@messages("homepage.payments.repayments.linkText")</a>
                  </li>
@@ -204,12 +207,21 @@
  } else {
      @card(
          title = messages("homepage.payments.title"),
-         links = Seq(
-             (messages("homepage.payments.transactionHistory.linkText"), controllers.routes.TransactionHistoryController.onPageLoadTransactionHistory(None).url, None),
-             (messages("homepage.payments.outstandingPayments.linkText"), controllers.payments.routes.OutstandingPaymentsController.onPageLoad.url, None),
-             (messages("homepage.payments.stoodoverCharges.linkText"), controllers.payments.routes.StoodoverChargesController.onPageLoad.url, None),
-             (messages("homepage.payments.repayments.linkText"), controllers.repayments.routes.RequestRepaymentBeforeStartController.onPageLoad().url, None)
-         )
+         links =
+             if(useAccountActivity) {
+                 Seq(
+                     (messages("homepage.payments.transactionHistory.linkText"), controllers.routes.TransactionHistoryController.onPageLoadTransactionHistory(None).url, None),
+                     (messages("homepage.payments.outstandingPayments.linkText"), controllers.payments.routes.OutstandingPaymentsController.onPageLoad.url, None),
+                     (messages("homepage.payments.stoodoverCharges.linkText"), controllers.payments.routes.StoodoverChargesController.onPageLoad.url, None),
+                     (messages("homepage.payments.repayments.linkText"), controllers.repayments.routes.RequestRepaymentBeforeStartController.onPageLoad().url, None)
+                 )
+             } else {
+                 Seq(
+                    (messages("homepage.payments.transactionHistory.linkText"), controllers.routes.TransactionHistoryController.onPageLoadTransactionHistory(None).url, None),
+                    (messages("homepage.payments.outstandingPayments.linkText"), controllers.payments.routes.OutstandingPaymentsController.onPageLoad.url, None),
+                    (messages("homepage.payments.repayments.linkText"), controllers.repayments.routes.RequestRepaymentBeforeStartController.onPageLoad().url, None)
+                )
+            }
      )
  }
 

--- a/app/views/outstandingpayments/OutstandingPaymentsView.scala.html
+++ b/app/views/outstandingpayments/OutstandingPaymentsView.scala.html
@@ -138,7 +138,11 @@
                     ),
                     rows =  summary.rows.map { row =>
                         Seq(
-                            TableRow(content = Text(row.description)),
+                            TableRow(content = if(useAccountActivity && row.appealFlag.contains(true)) {
+                                                   HtmlContent(s"""${row.description} <br> <strong class="govuk-tag govuk-tag--red">Appealed</strong>""")
+                                               } else {
+                                                   Text(row.description)
+                                               }),
                             TableRow(content = Text(formatCurrencyAmount(row.outstandingAmount)), format = Some("numeric")),
                             TableRow(content = Text(row.dueDate.toDateFormat))
                         )

--- a/app/views/outstandingpayments/OutstandingPaymentsView.scala.html
+++ b/app/views/outstandingpayments/OutstandingPaymentsView.scala.html
@@ -106,6 +106,15 @@
 
     @h2(messages("payments.outstanding.details.heading"), size = "m")
     @paragraphBody(messages("payments.outstanding.details.p1"))
+
+    @if(useAccountActivity) {
+        @paragraphBody(messages("payments.outstanding.details.p2"))
+        @paragraphMessageWithLink(
+            linkMessage = messages("payments.outstanding.stoodoverCharges.linkText"),
+            linkUrl = payments.routes.StoodoverChargesController.onPageLoad.url
+        )
+    }
+
     @details(Details(
         summary = messages("payments.outstanding.abbreviation.heading"),
         content = HtmlContent(Html(
@@ -156,9 +165,17 @@
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
+            @if(useAccountActivity) {
+                @h2(messages("payments.stoodoverCharges.title"), size = "m")
+                @paragraphBody(messages("payments.outstanding.stoodoverCharges.p1"))
+                @paragraphMessageWithLink(
+                    linkMessage = messages("payments.outstanding.stoodoverCharges.linkText"),
+                    linkUrl = payments.routes.StoodoverChargesController.onPageLoad.url
+                )
+            }
+
             @h2(messages("transactionHistory.title"), size = "m")
             @paragraphBody(messages("payments.outstanding.transactionHistory.p1"))
-            @paragraphBody(messages("payments.outstanding.transactionHistory.p2"))
             @paragraphMessageWithLink(
                 linkMessage = messages("homepage.payments.transactionHistory.linkText"),
                 linkUrl = routes.TransactionHistoryController.onPageLoadTransactionHistory(None).url

--- a/app/views/stoodoverCharges/StoodoverChargesView.scala.html
+++ b/app/views/stoodoverCharges/StoodoverChargesView.scala.html
@@ -1,0 +1,109 @@
+@*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.FrontendAppConfig
+@import utils.DateTimeUtils._
+@import views.ViewUtils._
+@import views.html.components.gds._
+@import views.html.templates.Layout
+
+@this(
+        layout: Layout,
+        govukBackLink: GovukBackLink,
+        govukTable: GovukTable,
+        govukWarningText: GovukWarningText,
+        h1: heading,
+        h2: HeadingH2,
+        paragraphBody: paragraphBody,
+        paragraphMessageWithLink: ParagraphMessageWithLink,
+        details: GovukDetails
+)
+@(plrReference: String, data: Seq[StoodoverChargesTable], stoodoverTotal: BigDecimal, organisationName: String)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages, isAgent: Boolean)
+
+@layout(pageTitle = titleNoForm(messages("payments.stoodoverCharges.title")), twoThirdsPagelayout = false, bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
+
+    @if(isAgent) {
+        <span class="govuk-caption-m"><strong>Group:</strong> @organisationName <strong>ID:</strong> @plrReference</span>
+    }
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            @h1(messages("payments.stoodoverCharges.title"), classes = "govuk-heading-l")
+            @h2(messages("payments.stoodoverCharges.stoodoverTotal", formatAmount(stoodoverTotal)), size = "m")
+            @h2(messages("payments.stoodoverCharges.details.heading"), size = "m")
+            @paragraphBody(messages("payments.stoodoverCharges.p1"))
+        </div>
+    </div>
+
+    @details(Details(
+        summary = messages("payments.stoodoverCharges.abbreviation.heading"),
+        content = HtmlContent(Html(
+            s"""
+            |<ul class="govuk-list">
+            |  <li>${messages("payments.stoodoverCharges.abbreviation.uktr")}</li>
+            |  <li>${messages("payments.stoodoverCharges.abbreviation.dtt")}</li>
+            |  <li>${messages("payments.stoodoverCharges.abbreviation.mtt")}</li>
+            |  <li>${messages("payments.stoodoverCharges.abbreviation.iir")}</li>
+            |  <li>${messages("payments.stoodoverCharges.abbreviation.utpr")}</li>
+            |  <li>${messages("payments.stoodoverCharges.abbreviation.orngir")}</li>
+            |</ul>
+            """.stripMargin
+        ))
+    ))
+
+    @{
+        if(stoodoverTotal <= 0 || data.isEmpty) {
+            paragraphBody(messages("payments.stoodoverCharges.details.noStoodoverCharges"), classes = "govuk-body govuk-!-margin-bottom-8 govuk-!-margin-top-7")
+        } else {
+            data.map { summary =>
+                govukTable(Table(
+                    head = Some(
+                        Seq(
+                            HeadCell(Text("Description"), classes = "govuk-table__header govuk-!-width-one-half"),
+                            HeadCell(Text("Stoodover amount"), format = Some("numeric"), classes = "govuk-table__header govuk-table__header--numeric"),
+                        )
+                    ),
+                    rows =  summary.rows.map { row =>
+                        Seq(
+                            TableRow(content = Text(row.description)),
+                            TableRow(content = Text(formatCurrencyAmount(row.stoodoverAmount)), format = Some("numeric"))
+                        )
+                    },
+                    caption = Some(s"Accounting period: ${summary.accountingPeriod.startDate.toDateFormat} to ${summary.accountingPeriod.endDate.toDateFormat}"),
+                    captionClasses = "govuk-table__caption govuk-table__caption--m"
+                ))
+            }
+        }
+    }
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            @h2(messages("payments.outstanding.title"), size = "m")
+            @paragraphBody(messages("payments.stoodoverCharges.outstandingPayments.p1"))
+            @paragraphMessageWithLink(
+                linkMessage = messages("homepage.payments.outstandingPayments.linkText"),
+                linkUrl = payments.routes.OutstandingPaymentsController.onPageLoad.url
+            )
+
+            @h2(messages("transactionHistory.title"), size = "m")
+            @paragraphBody(messages("payments.stoodoverCharges.transactionHistory.p1"))
+            @paragraphMessageWithLink(
+                linkMessage = messages("homepage.payments.transactionHistory.linkText"),
+                linkUrl = routes.TransactionHistoryController.onPageLoadTransactionHistory(None).url
+            )
+        </div>
+    </div>
+}

--- a/app/views/subscriptionview/manageAccount/NewAccountingPeriodView.scala.html
+++ b/app/views/subscriptionview/manageAccount/NewAccountingPeriodView.scala.html
@@ -45,7 +45,7 @@
         }
 
         @if(isAgent && organisationName.isDefined) {
-            <h2 class="govuk-caption-m hmrc-caption-m"><span id="section-header"><strong>Group:</strong> @organisationName <strong>ID:</strong> @plrReference</span></h2>
+            <span class="govuk-caption-m"><strong>Group:</strong> @organisationName <strong>ID:</strong> @plrReference</span>
         }
 
         @heading(messages("newAccountingPeriod.heading"), "govuk-heading-l")

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -539,6 +539,7 @@ GET        /payment/history                                                     
 GET        /payment/history-empty                                                                   controllers.TransactionHistoryController.onPageLoadNoTransactionHistory()
 GET        /repayment/error/payment-history                                                         controllers.TransactionHistoryController.onPageLoadError()
 GET        /payment/outstanding                                                                     controllers.payments.OutstandingPaymentsController.onPageLoad
+GET        /payment/stoodover-charges                                                               controllers.payments.StoodoverChargesController.onPageLoad
 
 GET        /manage-contact-details/cannot-return                                                    controllers.subscription.manageAccount.ManageContactCannotReturnAfterConfirmationController.onPageLoad
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1823,7 +1823,8 @@ payments.outstanding.otherWaysToPay.agent.p2 = You’ll need to use this referen
 payments.outstanding.otherWaysToPay.linkText = Find out more about ways to pay (opens in a new page)
 
 payments.outstanding.details.heading = Details of outstanding payments
-payments.outstanding.details.p1 = We have separated any payments due by accounting period.
+payments.outstanding.details.p1 = We have separated any payments due by the associated accounting period where there is one.
+payments.outstanding.details.p2 = An appealed charge is still part of the amount due until it is partly or completely stoodover.
 payments.outstanding.details.nothingDue = No payments due.
 
 payments.outstanding.abbreviation.heading = Outstanding payments abbreviations
@@ -1835,8 +1836,10 @@ payments.outstanding.abbreviation.utpr = UTPR - Undertaxed Profit Rule
 payments.outstanding.abbreviation.orngir = ORN/GIR - Overseas Return Notification or GloBE Information Return
 payments.outstanding.abbreviation.gaar = GAAR - General Anti Abuse Rule penalty
 
-payments.outstanding.transactionHistory.p1 = Find details on payments and repayments.
-payments.outstanding.transactionHistory.p2 = Payments will appear in the transaction history page within 3-5 working days.
+payments.outstanding.stoodoverCharges.p1 = Details of appealed charges and other standover payments.
+payments.outstanding.stoodoverCharges.linkText = View stoodover charges
+
+payments.outstanding.transactionHistory.p1 = Find details on payments and refunds. It may take up to 5 working days for transactions to appear.
 
 payments.outstanding.penaltiesAndCharges.heading = Penalties and interest charges
 payments.outstanding.penaltiesAndCharges.p1 = Find out how HMRC may charge your group penalties and interest.

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -909,6 +909,7 @@ homepage.payments.title = Payments
 homepage.payments.transactionHistory.linkText = View transaction history
 homepage.payments.outstandingPayments.linkText = View outstanding payments
 homepage.payments.tags.outstanding = Outstanding
+homepage.payments.stoodoverCharges.linkText = Stoodover charges
 homepage.payments.repayments.linkText = Request a repayment
 homepage.payments.tags.paid = Paid
 
@@ -1847,6 +1848,31 @@ payments.noOutstanding.heading = Outstanding payments
 payments.noOutstanding.group.p1 = You have no outstanding payments.
 payments.noOutstanding.agent.p1 = Your client has no outstanding payments.
 payments.noOutstanding.linkText = Return to your account homepage
+
+
+###############################################
+#
+# Stoodover charges
+#
+###############################################
+payments.stoodoverCharges.title = Stoodover charges
+payments.stoodoverCharges.stoodoverTotal = Stoodover total: £{0}
+
+payments.stoodoverCharges.details.heading = Details of stoodover charges
+payments.stoodoverCharges.p1 = We have separated the charges by accounting period.
+payments.stoodoverCharges.details.noStoodoverCharges = No stoodover charges.
+
+payments.stoodoverCharges.abbreviation.heading = Charge description abbreviations
+payments.stoodoverCharges.abbreviation.uktr = UKTR - UK Tax Return
+payments.stoodoverCharges.abbreviation.dtt = DTT - Domestic Top-up Tax
+payments.stoodoverCharges.abbreviation.mtt = MTT - Multinational Top-up Tax
+payments.stoodoverCharges.abbreviation.iir = IIR - Income Inclusion Rule
+payments.stoodoverCharges.abbreviation.utpr = UTPR - Undertaxed Profit Rule
+payments.stoodoverCharges.abbreviation.orngir = ORN/GIR - Overseas Return Notification or GloBE Information Return
+
+payments.stoodoverCharges.outstandingPayments.p1 = Find full details of any payments due, including penalties and interest.
+payments.stoodoverCharges.transactionHistory.p1 = Find details on payments and refunds. It may take up to 5 working days for transactions to appear.
+
 
 # ---------------------------------------------
 # Pillar 2 Research

--- a/test/controllers/actions/AccountActivityScreensActionSpec.scala
+++ b/test/controllers/actions/AccountActivityScreensActionSpec.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import base.SpecBase
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import play.api.test.FakeRequest
+import play.api.test.Helpers.*
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+
+import scala.concurrent.Future
+
+class AccountActivityScreensActionSpec extends SpecBase {
+
+  class TestController(
+    identify:                    IdentifierAction,
+    checkAccountActivityScreens: AccountActivityScreensAction,
+    val controllerComponents:    MessagesControllerComponents
+  ) extends FrontendBaseController {
+
+    def testAction(): Action[AnyContent] =
+      (identify andThen checkAccountActivityScreens).async { _ =>
+        Future.successful(Ok("Success"))
+      }
+  }
+
+  "AccountActivityScreensAction" when {
+    "useAccountActivityApi is true" should {
+      "allow the request to continue" in {
+        val application = applicationBuilder()
+          .configure("features.useAccountActivityApi" -> true)
+          .build()
+
+        running(application) {
+          val identify                    = application.injector.instanceOf[IdentifierAction]
+          val checkAccountActivityScreens = application.injector.instanceOf[AccountActivityScreensAction]
+          val controllerComponents        = application.injector.instanceOf[MessagesControllerComponents]
+
+          val controller = new TestController(identify, checkAccountActivityScreens, controllerComponents)
+
+          val request = FakeRequest("GET", "/test")
+          val result  = controller.testAction()(request)
+
+          status(result) mustEqual OK
+          contentAsString(result) mustEqual "Success"
+        }
+      }
+    }
+
+    "useAccountActivityApi is false" should {
+      "redirect to homepage" in {
+        val application = applicationBuilder()
+          .configure("features.useAccountActivityApi" -> false)
+          .build()
+
+        running(application) {
+          val identify                    = application.injector.instanceOf[IdentifierAction]
+          val checkAccountActivityScreens = application.injector.instanceOf[AccountActivityScreensAction]
+          val controllerComponents        = application.injector.instanceOf[MessagesControllerComponents]
+
+          val controller = new TestController(identify, checkAccountActivityScreens, controllerComponents)
+
+          val request = FakeRequest("GET", "/test")
+          val result  = controller.testAction()(request)
+
+          status(result) mustEqual SEE_OTHER
+          redirectLocation(result) mustEqual Some(controllers.routes.HomepageController.onPageLoad().url)
+        }
+      }
+    }
+  }
+}

--- a/test/controllers/payments/OutstandingPaymentsControllerSpec.scala
+++ b/test/controllers/payments/OutstandingPaymentsControllerSpec.scala
@@ -422,7 +422,12 @@ object OutstandingPaymentsControllerSpec {
     OutstandingPaymentsTable(
       accountingPeriod = AccountingPeriod(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31)),
       rows = Seq(
-        OutstandingPaymentsRow(description = "UKTR - DTT", outstandingAmount = BigDecimal(1000.00), dueDate = LocalDate.of(2024, 12, 31))
+        OutstandingPaymentsRow(
+          description = "UKTR - DTT",
+          outstandingAmount = BigDecimal(1000.00),
+          dueDate = LocalDate.of(2024, 12, 31),
+          appealFlag = None
+        )
       )
     )
   )
@@ -431,7 +436,12 @@ object OutstandingPaymentsControllerSpec {
     OutstandingPaymentsTable(
       accountingPeriod = AccountingPeriod(LocalDate.of(2020, 1, 1), LocalDate.of(2020, 12, 31)),
       rows = Seq(
-        OutstandingPaymentsRow(description = "UKTR - DTT", outstandingAmount = BigDecimal(1000.00), dueDate = LocalDate.of(2020, 12, 31))
+        OutstandingPaymentsRow(
+          description = "UKTR - DTT",
+          outstandingAmount = BigDecimal(1000.00),
+          dueDate = LocalDate.of(2020, 12, 31),
+          appealFlag = None
+        )
       )
     )
   )

--- a/test/controllers/payments/StoodoverChargesControllerSpec.scala
+++ b/test/controllers/payments/StoodoverChargesControllerSpec.scala
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.payments
+
+import base.SpecBase
+import connectors.AccountActivityConnector
+import controllers.payments.OutstandingPaymentsControllerSpec.*
+import models.*
+import models.subscription.AccountingPeriod
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import play.api.inject.bind
+import play.api.test.FakeRequest
+import play.api.test.Helpers.*
+import repositories.SessionRepository
+import services.SubscriptionService
+import uk.gov.hmrc.http.HeaderCarrier
+import views.html.stoodoverCharges.StoodoverChargesView
+
+import java.time.{LocalDate, LocalDateTime}
+import scala.concurrent.Future
+
+class StoodoverChargesControllerSpec extends SpecBase {
+
+  val plrReference: String = "XMPLR0123456789"
+
+  val accountActivityEmptyResponse: AccountActivityResponse = AccountActivityResponse(
+    processingDate = LocalDateTime.now(),
+    transactionDetails = Seq.empty
+  )
+
+  val accountActivityResponse: AccountActivityResponse = AccountActivityResponse(
+    processingDate = LocalDateTime.now(),
+    transactionDetails = Seq(
+      AccountActivityTransaction(
+        transactionType = TransactionType.Debit,
+        transactionDesc = "UKTR - DTT",
+        startDate = Some(LocalDate.of(2025, 1, 1)),
+        endDate = Some(LocalDate.of(2025, 12, 31)),
+        accruedInterest = None,
+        chargeRefNo = Some("X123456789012"),
+        transactionDate = LocalDate.of(2025, 2, 15),
+        dueDate = Some(LocalDate.of(2025, 12, 31)),
+        originalAmount = BigDecimal(2000),
+        outstandingAmount = Some(BigDecimal(1000)),
+        clearedAmount = Some(BigDecimal(1000)),
+        standOverAmount = Some(BigDecimal(1000)),
+        appealFlag = None,
+        clearingDetails = None
+      )
+    )
+  )
+
+  "StoodoverChargesController" should {
+    "return OK and display the correct view for a GET with no stoodover charges" in {
+
+      val application = applicationBuilder(
+        userAnswers = Some(emptyUserAnswers),
+        enrolments = enrolments
+      )
+        .overrides(
+          bind[SessionRepository].toInstance(mockSessionRepository),
+          bind[SubscriptionService].toInstance(mockSubscriptionService),
+          bind[AccountActivityConnector].toInstance(mockAccountActivityConnector)
+        )
+        .build()
+
+      running(application) {
+        when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(emptyUserAnswers)))
+        when(mockSubscriptionService.readSubscription(any())(using any[HeaderCarrier]))
+          .thenReturn(Future.successful(subscriptionData))
+        when(mockAccountActivityConnector.retrieveAccountActivity(any(), any(), any())(using any[HeaderCarrier]))
+          .thenReturn(Future.successful(accountActivityEmptyResponse))
+
+        val request = FakeRequest(GET, controllers.payments.routes.StoodoverChargesController.onPageLoad.url)
+        val result  = route(application, request).value
+        val view    = application.injector.instanceOf[StoodoverChargesView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual
+          view(plrReference, Seq.empty, 0, "orgName")(
+            request,
+            applicationConfig,
+            messages(application),
+            isAgent = false
+          ).toString
+      }
+    }
+
+    "return OK and display the correct view for a GET with stoodover charges" in {
+
+      val accountingPeriod: AccountingPeriod = AccountingPeriod(startDate = LocalDate.of(2025, 1, 1), endDate = LocalDate.of(2025, 12, 31))
+      val row: StoodoverChargesRow = StoodoverChargesRow(description = "UKTR - DTT", stoodoverAmount = BigDecimal(1000))
+      val table: StoodoverChargesTable = StoodoverChargesTable(accountingPeriod = accountingPeriod, rows = Seq(row))
+      val data: Seq[StoodoverChargesTable] = Seq(table)
+
+      val application = applicationBuilder(
+        userAnswers = Some(emptyUserAnswers),
+        enrolments = enrolments
+      )
+        .overrides(
+          bind[SessionRepository].toInstance(mockSessionRepository),
+          bind[SubscriptionService].toInstance(mockSubscriptionService),
+          bind[AccountActivityConnector].toInstance(mockAccountActivityConnector)
+        )
+        .build()
+
+      running(application) {
+        when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(emptyUserAnswers)))
+        when(mockSubscriptionService.readSubscription(any())(using any[HeaderCarrier]))
+          .thenReturn(Future.successful(subscriptionData))
+        when(mockAccountActivityConnector.retrieveAccountActivity(any(), any(), any())(using any[HeaderCarrier]))
+          .thenReturn(Future.successful(accountActivityResponse))
+
+        val request = FakeRequest(GET, controllers.payments.routes.StoodoverChargesController.onPageLoad.url)
+        val result = route(application, request).value
+        val view = application.injector.instanceOf[StoodoverChargesView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual
+          view(plrReference, data, BigDecimal(1000), "orgName")(
+            request,
+            applicationConfig,
+            messages(application),
+            isAgent = false
+          ).toString
+      }
+    }
+
+    "redirect to journey recovery when there is no plrReference" in {
+
+      val application = applicationBuilder(
+        userAnswers = None,
+        enrolments = enrolments
+      )
+        .overrides(
+          bind[SessionRepository].toInstance(mockSessionRepository),
+          bind[SubscriptionService].toInstance(mockSubscriptionService),
+          bind[AccountActivityConnector].toInstance(mockAccountActivityConnector)
+        )
+        .build()
+
+      running(application) {
+        when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(emptyUserAnswers)))
+        when(mockSubscriptionService.readSubscription(any())(using any[HeaderCarrier]))
+          .thenReturn(Future.successful(subscriptionData))
+        when(mockAccountActivityConnector.retrieveAccountActivity(any(), any(), any())(using any[HeaderCarrier]))
+          .thenReturn(Future.successful(accountActivityResponse))
+
+        val request = FakeRequest(GET, controllers.payments.routes.StoodoverChargesController.onPageLoad.url)
+        val result  = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "redirect to journey recovery when the subscription service call fails" in {
+
+      val application = applicationBuilder(
+        userAnswers = Some(emptyUserAnswers),
+        enrolments = enrolments
+      )
+        .overrides(
+          bind[SessionRepository].toInstance(mockSessionRepository),
+          bind[SubscriptionService].toInstance(mockSubscriptionService),
+          bind[AccountActivityConnector].toInstance(mockAccountActivityConnector)
+        )
+        .build()
+
+      running(application) {
+        when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(emptyUserAnswers)))
+        when(mockSubscriptionService.readSubscription(any())(using any[HeaderCarrier]))
+          .thenReturn(Future.failed(NoResultFound))
+        when(mockAccountActivityConnector.retrieveAccountActivity(any(), any(), any())(using any[HeaderCarrier]))
+          .thenReturn(Future.failed(NoResultFound))
+
+        val request = FakeRequest(GET, controllers.payments.routes.StoodoverChargesController.onPageLoad.url)
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/payments/StoodoverChargesControllerSpec.scala
+++ b/test/controllers/payments/StoodoverChargesControllerSpec.scala
@@ -65,135 +65,154 @@ class StoodoverChargesControllerSpec extends SpecBase {
     )
   )
 
-  "StoodoverChargesController" should {
-    "return OK and display the correct view for a GET with no stoodover charges" in {
-
-      val application = applicationBuilder(
-        userAnswers = Some(emptyUserAnswers),
-        enrolments = enrolments
-      )
-        .overrides(
-          bind[SessionRepository].toInstance(mockSessionRepository),
-          bind[SubscriptionService].toInstance(mockSubscriptionService),
-          bind[AccountActivityConnector].toInstance(mockAccountActivityConnector)
-        )
+  "StoodoverChargesController" must {
+    "redirect to homepage when useAccountActivityApi is false" in {
+      val application = applicationBuilder(subscriptionLocalData = None)
+        .configure("features.useAccountActivityApi" -> false)
         .build()
 
       running(application) {
-        when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(emptyUserAnswers)))
-        when(mockSubscriptionService.readSubscription(any())(using any[HeaderCarrier]))
-          .thenReturn(Future.successful(subscriptionData))
-        when(mockAccountActivityConnector.retrieveAccountActivity(any(), any(), any())(using any[HeaderCarrier]))
-          .thenReturn(Future.successful(accountActivityEmptyResponse))
-
-        val request = FakeRequest(GET, controllers.payments.routes.StoodoverChargesController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.StoodoverChargesController.onPageLoad.url)
         val result  = route(application, request).value
-        val view    = application.injector.instanceOf[StoodoverChargesView]
-
-        status(result) mustEqual OK
-        contentAsString(result) mustEqual
-          view(plrReference, Seq.empty, 0, "orgName")(
-            request,
-            applicationConfig,
-            messages(application),
-            isAgent = false
-          ).toString
-      }
-    }
-
-    "return OK and display the correct view for a GET with stoodover charges" in {
-
-      val accountingPeriod: AccountingPeriod           = AccountingPeriod(startDate = LocalDate.of(2025, 1, 1), endDate = LocalDate.of(2025, 12, 31))
-      val row:              StoodoverChargesRow        = StoodoverChargesRow(description = "UKTR - DTT", stoodoverAmount = BigDecimal(1000))
-      val table:            StoodoverChargesTable      = StoodoverChargesTable(accountingPeriod = accountingPeriod, rows = Seq(row))
-      val data:             Seq[StoodoverChargesTable] = Seq(table)
-
-      val application = applicationBuilder(
-        userAnswers = Some(emptyUserAnswers),
-        enrolments = enrolments
-      )
-        .overrides(
-          bind[SessionRepository].toInstance(mockSessionRepository),
-          bind[SubscriptionService].toInstance(mockSubscriptionService),
-          bind[AccountActivityConnector].toInstance(mockAccountActivityConnector)
-        )
-        .build()
-
-      running(application) {
-        when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(emptyUserAnswers)))
-        when(mockSubscriptionService.readSubscription(any())(using any[HeaderCarrier]))
-          .thenReturn(Future.successful(subscriptionData))
-        when(mockAccountActivityConnector.retrieveAccountActivity(any(), any(), any())(using any[HeaderCarrier]))
-          .thenReturn(Future.successful(accountActivityResponse))
-
-        val request = FakeRequest(GET, controllers.payments.routes.StoodoverChargesController.onPageLoad.url)
-        val result  = route(application, request).value
-        val view    = application.injector.instanceOf[StoodoverChargesView]
-
-        status(result) mustEqual OK
-        contentAsString(result) mustEqual
-          view(plrReference, data, BigDecimal(1000), "orgName")(
-            request,
-            applicationConfig,
-            messages(application),
-            isAgent = false
-          ).toString
-      }
-    }
-
-    "redirect to journey recovery when there is no plrReference" in {
-
-      val application = applicationBuilder(
-        userAnswers = None,
-        enrolments = enrolments
-      )
-        .overrides(
-          bind[SessionRepository].toInstance(mockSessionRepository),
-          bind[SubscriptionService].toInstance(mockSubscriptionService),
-          bind[AccountActivityConnector].toInstance(mockAccountActivityConnector)
-        )
-        .build()
-
-      running(application) {
-        when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(emptyUserAnswers)))
-        when(mockSubscriptionService.readSubscription(any())(using any[HeaderCarrier]))
-          .thenReturn(Future.successful(subscriptionData))
-        when(mockAccountActivityConnector.retrieveAccountActivity(any(), any(), any())(using any[HeaderCarrier]))
-          .thenReturn(Future.successful(accountActivityResponse))
-
-        val request = FakeRequest(GET, controllers.payments.routes.StoodoverChargesController.onPageLoad.url)
-        val result  = route(application, request).value
-
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+        redirectLocation(result) mustBe Some(controllers.routes.HomepageController.onPageLoad().url)
       }
     }
 
-    "redirect to journey recovery when the subscription service call fails" in {
+    "allow request when useAccountActivityApi is true and" must {
+      "return OK and display the correct view for a GET with no stoodover charges" in {
 
-      val application = applicationBuilder(
-        userAnswers = Some(emptyUserAnswers),
-        enrolments = enrolments
-      )
-        .overrides(
-          bind[SessionRepository].toInstance(mockSessionRepository),
-          bind[SubscriptionService].toInstance(mockSubscriptionService),
-          bind[AccountActivityConnector].toInstance(mockAccountActivityConnector)
+        val application = applicationBuilder(
+          userAnswers = Some(emptyUserAnswers),
+          enrolments = enrolments
         )
-        .build()
+          .overrides(
+            bind[SessionRepository].toInstance(mockSessionRepository),
+            bind[SubscriptionService].toInstance(mockSubscriptionService),
+            bind[AccountActivityConnector].toInstance(mockAccountActivityConnector)
+          )
+          .configure("features.useAccountActivityApi" -> true)
+          .build()
 
-      running(application) {
-        when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(emptyUserAnswers)))
-        when(mockSubscriptionService.readSubscription(any())(using any[HeaderCarrier]))
-          .thenReturn(Future.failed(NoResultFound))
-        when(mockAccountActivityConnector.retrieveAccountActivity(any(), any(), any())(using any[HeaderCarrier]))
-          .thenReturn(Future.failed(NoResultFound))
+        running(application) {
+          when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(emptyUserAnswers)))
+          when(mockSubscriptionService.readSubscription(any())(using any[HeaderCarrier]))
+            .thenReturn(Future.successful(subscriptionData))
+          when(mockAccountActivityConnector.retrieveAccountActivity(any(), any(), any())(using any[HeaderCarrier]))
+            .thenReturn(Future.successful(accountActivityEmptyResponse))
 
-        val request = FakeRequest(GET, controllers.payments.routes.StoodoverChargesController.onPageLoad.url)
-        val result  = route(application, request).value
+          val request = FakeRequest(GET, controllers.payments.routes.StoodoverChargesController.onPageLoad.url)
+          val result  = route(application, request).value
+          val view    = application.injector.instanceOf[StoodoverChargesView]
 
-        status(result) mustEqual SEE_OTHER
-        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+          status(result) mustEqual OK
+          contentAsString(result) mustEqual
+            view(plrReference, Seq.empty, 0, "orgName")(
+              request,
+              applicationConfig,
+              messages(application),
+              isAgent = false
+            ).toString
+        }
+      }
+
+      "return OK and display the correct view for a GET with stoodover charges" in {
+
+        val accountingPeriod: AccountingPeriod      = AccountingPeriod(startDate = LocalDate.of(2025, 1, 1), endDate = LocalDate.of(2025, 12, 31))
+        val row:              StoodoverChargesRow   = StoodoverChargesRow(description = "UKTR - DTT", stoodoverAmount = BigDecimal(1000))
+        val table:            StoodoverChargesTable = StoodoverChargesTable(accountingPeriod = accountingPeriod, rows = Seq(row))
+        val data: Seq[StoodoverChargesTable] = Seq(table)
+
+        val application = applicationBuilder(
+          userAnswers = Some(emptyUserAnswers),
+          enrolments = enrolments
+        )
+          .overrides(
+            bind[SessionRepository].toInstance(mockSessionRepository),
+            bind[SubscriptionService].toInstance(mockSubscriptionService),
+            bind[AccountActivityConnector].toInstance(mockAccountActivityConnector)
+          )
+          .configure("features.useAccountActivityApi" -> true)
+          .build()
+
+        running(application) {
+          when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(emptyUserAnswers)))
+          when(mockSubscriptionService.readSubscription(any())(using any[HeaderCarrier]))
+            .thenReturn(Future.successful(subscriptionData))
+          when(mockAccountActivityConnector.retrieveAccountActivity(any(), any(), any())(using any[HeaderCarrier]))
+            .thenReturn(Future.successful(accountActivityResponse))
+
+          val request = FakeRequest(GET, controllers.payments.routes.StoodoverChargesController.onPageLoad.url)
+          val result  = route(application, request).value
+          val view    = application.injector.instanceOf[StoodoverChargesView]
+
+          status(result) mustEqual OK
+          contentAsString(result) mustEqual
+            view(plrReference, data, BigDecimal(1000), "orgName")(
+              request,
+              applicationConfig,
+              messages(application),
+              isAgent = false
+            ).toString
+        }
+      }
+
+      "redirect to journey recovery when there is no plrReference" in {
+
+        val application = applicationBuilder(
+          userAnswers = None,
+          enrolments = enrolments
+        )
+          .overrides(
+            bind[SessionRepository].toInstance(mockSessionRepository),
+            bind[SubscriptionService].toInstance(mockSubscriptionService),
+            bind[AccountActivityConnector].toInstance(mockAccountActivityConnector)
+          )
+          .configure("features.useAccountActivityApi" -> true)
+          .build()
+
+        running(application) {
+          when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(emptyUserAnswers)))
+          when(mockSubscriptionService.readSubscription(any())(using any[HeaderCarrier]))
+            .thenReturn(Future.successful(subscriptionData))
+          when(mockAccountActivityConnector.retrieveAccountActivity(any(), any(), any())(using any[HeaderCarrier]))
+            .thenReturn(Future.successful(accountActivityResponse))
+
+          val request = FakeRequest(GET, controllers.payments.routes.StoodoverChargesController.onPageLoad.url)
+          val result  = route(application, request).value
+
+          status(result) mustEqual SEE_OTHER
+          redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+        }
+      }
+
+      "redirect to journey recovery when the subscription service call fails" in {
+
+        val application = applicationBuilder(
+          userAnswers = Some(emptyUserAnswers),
+          enrolments = enrolments
+        )
+          .overrides(
+            bind[SessionRepository].toInstance(mockSessionRepository),
+            bind[SubscriptionService].toInstance(mockSubscriptionService),
+            bind[AccountActivityConnector].toInstance(mockAccountActivityConnector)
+          )
+          .configure("features.useAccountActivityApi" -> true)
+          .build()
+
+        running(application) {
+          when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(emptyUserAnswers)))
+          when(mockSubscriptionService.readSubscription(any())(using any[HeaderCarrier]))
+            .thenReturn(Future.failed(NoResultFound))
+          when(mockAccountActivityConnector.retrieveAccountActivity(any(), any(), any())(using any[HeaderCarrier]))
+            .thenReturn(Future.failed(NoResultFound))
+
+          val request = FakeRequest(GET, controllers.payments.routes.StoodoverChargesController.onPageLoad.url)
+          val result  = route(application, request).value
+
+          status(result) mustEqual SEE_OTHER
+          redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+        }
       }
     }
   }

--- a/test/controllers/payments/StoodoverChargesControllerSpec.scala
+++ b/test/controllers/payments/StoodoverChargesControllerSpec.scala
@@ -103,10 +103,10 @@ class StoodoverChargesControllerSpec extends SpecBase {
 
     "return OK and display the correct view for a GET with stoodover charges" in {
 
-      val accountingPeriod: AccountingPeriod = AccountingPeriod(startDate = LocalDate.of(2025, 1, 1), endDate = LocalDate.of(2025, 12, 31))
-      val row: StoodoverChargesRow = StoodoverChargesRow(description = "UKTR - DTT", stoodoverAmount = BigDecimal(1000))
-      val table: StoodoverChargesTable = StoodoverChargesTable(accountingPeriod = accountingPeriod, rows = Seq(row))
-      val data: Seq[StoodoverChargesTable] = Seq(table)
+      val accountingPeriod: AccountingPeriod           = AccountingPeriod(startDate = LocalDate.of(2025, 1, 1), endDate = LocalDate.of(2025, 12, 31))
+      val row:              StoodoverChargesRow        = StoodoverChargesRow(description = "UKTR - DTT", stoodoverAmount = BigDecimal(1000))
+      val table:            StoodoverChargesTable      = StoodoverChargesTable(accountingPeriod = accountingPeriod, rows = Seq(row))
+      val data:             Seq[StoodoverChargesTable] = Seq(table)
 
       val application = applicationBuilder(
         userAnswers = Some(emptyUserAnswers),
@@ -127,8 +127,8 @@ class StoodoverChargesControllerSpec extends SpecBase {
           .thenReturn(Future.successful(accountActivityResponse))
 
         val request = FakeRequest(GET, controllers.payments.routes.StoodoverChargesController.onPageLoad.url)
-        val result = route(application, request).value
-        val view = application.injector.instanceOf[StoodoverChargesView]
+        val result  = route(application, request).value
+        val view    = application.injector.instanceOf[StoodoverChargesView]
 
         status(result) mustEqual OK
         contentAsString(result) mustEqual
@@ -190,7 +190,7 @@ class StoodoverChargesControllerSpec extends SpecBase {
           .thenReturn(Future.failed(NoResultFound))
 
         val request = FakeRequest(GET, controllers.payments.routes.StoodoverChargesController.onPageLoad.url)
-        val result = route(application, request).value
+        val result  = route(application, request).value
 
         status(result) mustEqual SEE_OTHER
         redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url

--- a/test/models/AccountActivityResponseSpec.scala
+++ b/test/models/AccountActivityResponseSpec.scala
@@ -824,4 +824,241 @@ class AccountActivityResponseSpec extends SpecBase {
       accruedInterest mustEqual 35
     }
   }
+
+  "AccountActivityResponse.toStoodoverCharges" should {
+    "return empty list when no stoodover charges exist" in {
+      val response = AccountActivityResponse(
+        processingDate = LocalDateTime.now(),
+        transactionDetails = Seq(
+          AccountActivityTransaction(
+            transactionType = TransactionType.Payment,
+            transactionDesc = "Pillar 2 Payment on Account",
+            startDate = None,
+            endDate = None,
+            accruedInterest = None,
+            chargeRefNo = None,
+            transactionDate = LocalDate.of(2025, 1, 15),
+            dueDate = None,
+            originalAmount = BigDecimal(500),
+            outstandingAmount = None,
+            clearedAmount = None,
+            standOverAmount = None,
+            appealFlag = None,
+            clearingDetails = None
+          )
+        )
+      )
+
+      response.toStoodoverCharges mustBe empty
+    }
+
+    "return empty list when stoodover charge amount is 0" in {
+      val response = AccountActivityResponse(
+        processingDate = LocalDateTime.now(),
+        transactionDetails = Seq(
+          AccountActivityTransaction(
+            transactionType = TransactionType.Debit,
+            transactionDesc = "UKTR - DTT",
+            startDate = Some(LocalDate.of(2025, 1, 1)),
+            endDate = Some(LocalDate.of(2025, 12, 31)),
+            accruedInterest = None,
+            chargeRefNo = None,
+            transactionDate = LocalDate.of(2025, 2, 15),
+            dueDate = Some(LocalDate.of(2025, 12, 31)),
+            originalAmount = BigDecimal(2000),
+            outstandingAmount = Some(BigDecimal(0)),
+            clearedAmount = Some(BigDecimal(2000)),
+            standOverAmount = Some(BigDecimal(0)),
+            appealFlag = None,
+            clearingDetails = None
+          )
+        )
+      )
+
+      response.toStoodoverCharges mustBe empty
+    }
+
+    "filter out transactions without startDate and endDate" in {
+      val response = AccountActivityResponse(
+        processingDate = LocalDateTime.now(),
+        transactionDetails = Seq(
+          AccountActivityTransaction(
+            transactionType = TransactionType.Debit,
+            transactionDesc = "UKTR - DTT",
+            startDate = None,
+            endDate = None,
+            accruedInterest = None,
+            chargeRefNo = None,
+            transactionDate = LocalDate.of(2025, 2, 15),
+            dueDate = Some(LocalDate.of(2025, 12, 31)),
+            originalAmount = BigDecimal(2000),
+            outstandingAmount = Some(BigDecimal(1000)),
+            clearedAmount = None,
+            standOverAmount = None,
+            appealFlag = None,
+            clearingDetails = None
+          )
+        )
+      )
+
+      response.toStoodoverCharges mustBe empty
+    }
+
+    "convert stoodover charge amounts to StoodoverChargeSummary grouped by accounting period" in {
+      val response = AccountActivityResponse(
+        processingDate = LocalDateTime.now(),
+        transactionDetails = Seq(
+          AccountActivityTransaction(
+            transactionType = TransactionType.Debit,
+            transactionDesc = "UKTR - DTT",
+            startDate = Some(LocalDate.of(2025, 1, 1)),
+            endDate = Some(LocalDate.of(2025, 12, 31)),
+            accruedInterest = None,
+            chargeRefNo = Some("X123456789012"),
+            transactionDate = LocalDate.of(2025, 2, 15),
+            dueDate = Some(LocalDate.of(2025, 12, 31)),
+            originalAmount = BigDecimal(2000),
+            outstandingAmount = None,
+            clearedAmount = Some(BigDecimal(1000)),
+            standOverAmount = Some(BigDecimal(1000)),
+            appealFlag = None,
+            clearingDetails = None
+          ),
+          AccountActivityTransaction(
+            transactionType = TransactionType.Debit,
+            transactionDesc = "UKTR - MTT (IIR)",
+            startDate = Some(LocalDate.of(2025, 1, 1)),
+            endDate = Some(LocalDate.of(2025, 12, 31)),
+            accruedInterest = None,
+            chargeRefNo = Some("X123456789013"),
+            transactionDate = LocalDate.of(2025, 2, 15),
+            dueDate = Some(LocalDate.of(2025, 12, 30)),
+            originalAmount = BigDecimal(1500),
+            outstandingAmount = None,
+            clearedAmount = None,
+            standOverAmount = Some(BigDecimal(1500)),
+            appealFlag = None,
+            clearingDetails = None
+          )
+        )
+      )
+
+      val result = response.toStoodoverCharges
+
+      result must have size 1
+      result.head.accountingPeriod.startDate mustBe LocalDate.of(2025, 1, 1)
+      result.head.accountingPeriod.endDate mustBe LocalDate.of(2025, 12, 31)
+      result.head.items must have size 2
+      result.head.items.head.description mustBe "UKTR - DTT"
+      result.head.items.head.stoodoverAmount mustBe BigDecimal(1000)
+      result.head.items(1).description mustBe "UKTR - MTT (IIR)"
+      result.head.items(1).stoodoverAmount mustBe BigDecimal(1500)
+    }
+
+    "group transactions by different accounting periods" in {
+      val response = AccountActivityResponse(
+        processingDate = LocalDateTime.now(),
+        transactionDetails = Seq(
+          AccountActivityTransaction(
+            transactionType = TransactionType.Debit,
+            transactionDesc = "UKTR - DTT",
+            startDate = Some(LocalDate.of(2025, 1, 1)),
+            endDate = Some(LocalDate.of(2025, 12, 31)),
+            accruedInterest = None,
+            chargeRefNo = Some("X123456789012"),
+            transactionDate = LocalDate.of(2025, 2, 15),
+            dueDate = Some(LocalDate.of(2025, 12, 31)),
+            originalAmount = BigDecimal(2000),
+            outstandingAmount = None,
+            clearedAmount = None,
+            standOverAmount = Some(BigDecimal(1000)),
+            appealFlag = None,
+            clearingDetails = None
+          ),
+          AccountActivityTransaction(
+            transactionType = TransactionType.Debit,
+            transactionDesc = "Determination - DTT",
+            startDate = Some(LocalDate.of(2026, 1, 1)),
+            endDate = Some(LocalDate.of(2026, 12, 31)),
+            accruedInterest = None,
+            chargeRefNo = Some("X123456789013"),
+            transactionDate = LocalDate.of(2026, 2, 15),
+            dueDate = Some(LocalDate.of(2026, 12, 31)),
+            originalAmount = BigDecimal(3000),
+            outstandingAmount = None,
+            clearedAmount = None,
+            standOverAmount = Some(BigDecimal(3000)),
+            appealFlag = None,
+            clearingDetails = None
+          )
+        )
+      )
+
+      val result = response.toStoodoverCharges
+
+      result must have size 2
+
+      result.head.accountingPeriod.endDate mustBe LocalDate.of(2026, 12, 31)
+      result.head.items.head.description mustBe "Determination - DTT"
+      result(1).accountingPeriod.endDate mustBe LocalDate.of(2025, 12, 31)
+      result(1).items.head.description mustBe "UKTR - DTT"
+    }
+
+    "use transactionDate as fallback when startDate or endDate is missing" in {
+      val response = AccountActivityResponse(
+        processingDate = LocalDateTime.now(),
+        transactionDetails = Seq(
+          AccountActivityTransaction(
+            transactionType = TransactionType.Debit,
+            transactionDesc = "UKTR - DTT",
+            startDate = Some(LocalDate.of(2025, 1, 1)),
+            endDate = None,
+            accruedInterest = None,
+            chargeRefNo = Some("X123456789012"),
+            transactionDate = LocalDate.of(2025, 2, 15),
+            dueDate = Some(LocalDate.of(2025, 12, 31)),
+            originalAmount = BigDecimal(2000),
+            outstandingAmount = None,
+            clearedAmount = None,
+            standOverAmount = Some(BigDecimal(1000)),
+            appealFlag = None,
+            clearingDetails = None
+          )
+        )
+      )
+
+      val result = response.toStoodoverCharges
+
+      result.head.accountingPeriod.startDate mustBe LocalDate.of(2025, 1, 1)
+      result.head.accountingPeriod.endDate mustBe LocalDate.of(2025, 2, 15)
+    }
+
+    "map unknown transaction descriptions to original description" in {
+      val response = AccountActivityResponse(
+        processingDate = LocalDateTime.now(),
+        transactionDetails = Seq(
+          AccountActivityTransaction(
+            transactionType = TransactionType.Debit,
+            transactionDesc = "Unknown Transaction Type",
+            startDate = Some(LocalDate.of(2025, 1, 1)),
+            endDate = Some(LocalDate.of(2025, 12, 31)),
+            accruedInterest = None,
+            chargeRefNo = None,
+            transactionDate = LocalDate.of(2025, 2, 15),
+            dueDate = Some(LocalDate.of(2025, 12, 31)),
+            originalAmount = BigDecimal(2000),
+            outstandingAmount = None,
+            clearedAmount = None,
+            standOverAmount = Some(BigDecimal(1000)),
+            appealFlag = None,
+            clearingDetails = None
+          )
+        )
+      )
+
+      val result = response.toStoodoverCharges
+
+      result.head.items.head.description mustBe "Unknown Transaction Type"
+    }
+  }
 }

--- a/test/views/HomepageViewSpec.scala
+++ b/test/views/HomepageViewSpec.scala
@@ -56,6 +56,27 @@ class HomepageViewSpec extends ViewSpecBase {
         .toString()
     )
 
+  lazy val organisationAccountActivityView: Document =
+    Jsoup.parse(
+      page(
+        organisationName,
+        date,
+        BtnBanner.Hide,
+        None,
+        None,
+        DynamicNotificationAreaState.NoNotification,
+        plrRef,
+        isAgent = false,
+        hasReturnsUnderEnquiry = false,
+        useAccountActivity = true
+      )(
+        request,
+        appConfig,
+        messages
+      )
+        .toString()
+    )
+
   lazy val agentView: Document =
     Jsoup.parse(
       page(
@@ -68,6 +89,27 @@ class HomepageViewSpec extends ViewSpecBase {
         plrRef,
         isAgent = true,
         hasReturnsUnderEnquiry = false
+      )(
+        request,
+        appConfig,
+        messages
+      )
+        .toString()
+    )
+
+  lazy val agentAccountActivityView: Document =
+    Jsoup.parse(
+      page(
+        organisationName,
+        date,
+        BtnBanner.Hide,
+        None,
+        None,
+        DynamicNotificationAreaState.NoNotification,
+        plrRef,
+        isAgent = true,
+        hasReturnsUnderEnquiry = false,
+        useAccountActivity = true
       )(
         request,
         appConfig,
@@ -109,27 +151,48 @@ class HomepageViewSpec extends ViewSpecBase {
       links.get(1).attr("href") mustBe controllers.submissionhistory.routes.SubmissionHistoryController.onPageLoad.url
     }
 
-    "display payments card with correct content" in {
-      val paymentsCard:      Element  = organisationView.getElementsByClass("card-half-width").get(1)
-      val paymentsCardLinks: Elements = paymentsCard.getElementsByTag("a")
+    "display payments card with correct content" when {
+      "when account activity toggle is false" in {
+        val paymentsCard:      Element  = organisationView.getElementsByClass("card-half-width").get(1)
+        val paymentsCardLinks: Elements = paymentsCard.getElementsByTag("a")
 
-      paymentsCard.getElementsByTag("h2").text() mustBe "Payments"
+        paymentsCard.getElementsByTag("h2").text() mustBe "Payments"
 
-      paymentsCardLinks.get(0).text() mustBe "View transaction history"
-      paymentsCardLinks.get(0).attr("href") mustBe
-        controllers.routes.TransactionHistoryController.onPageLoadTransactionHistory(None).url
+        paymentsCardLinks.get(0).text() mustBe "View transaction history"
+        paymentsCardLinks.get(0).attr("href") mustBe
+          controllers.routes.TransactionHistoryController.onPageLoadTransactionHistory(None).url
 
-      paymentsCardLinks.get(1).text() mustBe "View outstanding payments"
-      paymentsCardLinks.get(1).attr("href") mustBe
-        controllers.payments.routes.OutstandingPaymentsController.onPageLoad.url
+        paymentsCardLinks.get(1).text() mustBe "View outstanding payments"
+        paymentsCardLinks.get(1).attr("href") mustBe
+          controllers.payments.routes.OutstandingPaymentsController.onPageLoad.url
 
-      paymentsCardLinks.get(2).text() mustBe "Stoodover charges"
-      paymentsCardLinks.get(2).attr("href") mustBe
-        controllers.payments.routes.StoodoverChargesController.onPageLoad.url
+        paymentsCardLinks.get(2).text() mustBe "Request a repayment"
+        paymentsCardLinks.get(2).attr("href") mustBe
+          controllers.repayments.routes.RequestRepaymentBeforeStartController.onPageLoad().url
+      }
 
-      paymentsCardLinks.get(3).text() mustBe "Request a repayment"
-      paymentsCardLinks.get(3).attr("href") mustBe
-        controllers.repayments.routes.RequestRepaymentBeforeStartController.onPageLoad().url
+      "when account activity toggle is true" in {
+        val paymentsCard:      Element  = organisationAccountActivityView.getElementsByClass("card-half-width").get(1)
+        val paymentsCardLinks: Elements = paymentsCard.getElementsByTag("a")
+
+        paymentsCard.getElementsByTag("h2").text() mustBe "Payments"
+
+        paymentsCardLinks.get(0).text() mustBe "View transaction history"
+        paymentsCardLinks.get(0).attr("href") mustBe
+          controllers.routes.TransactionHistoryController.onPageLoadTransactionHistory(None).url
+
+        paymentsCardLinks.get(1).text() mustBe "View outstanding payments"
+        paymentsCardLinks.get(1).attr("href") mustBe
+          controllers.payments.routes.OutstandingPaymentsController.onPageLoad.url
+
+        paymentsCardLinks.get(2).text() mustBe "Stoodover charges"
+        paymentsCardLinks.get(2).attr("href") mustBe
+          controllers.payments.routes.StoodoverChargesController.onPageLoad.url
+
+        paymentsCardLinks.get(3).text() mustBe "Request a repayment"
+        paymentsCardLinks.get(3).attr("href") mustBe
+          controllers.repayments.routes.RequestRepaymentBeforeStartController.onPageLoad().url
+      }
     }
 
     "display manage account card with correct content" in {
@@ -412,49 +475,93 @@ class HomepageViewSpec extends ViewSpecBase {
       returnsCard.getElementsByClass("govuk-body").first().text() mustBe "You have one or more returns under enquiry"
     }
 
-    "show clean Payments card with no tag when no scenario is provided" in {
-      val organisationViewWithOutstandingScenario: Document =
-        Jsoup.parse(
-          page(
-            organisationName,
-            date,
-            BtnBanner.Hide,
-            None,
-            None,
-            DynamicNotificationAreaState.NoNotification,
-            plrRef,
-            isAgent = false,
-            hasReturnsUnderEnquiry = false
-          )(
-            request,
-            appConfig,
-            messages
+    "show clean Payments card with no tag when no scenario is provided" when {
+      "account activity toggle is true" in {
+        val organisationViewWithOutstandingScenario: Document =
+          Jsoup.parse(
+            page(
+              organisationName,
+              date,
+              BtnBanner.Hide,
+              None,
+              None,
+              DynamicNotificationAreaState.NoNotification,
+              plrRef,
+              isAgent = false,
+              hasReturnsUnderEnquiry = false,
+              useAccountActivity = true
+            )(
+              request,
+              appConfig,
+              messages
+            )
+              .toString()
           )
-            .toString()
-        )
-      val returnsCard:       Element  = organisationViewWithOutstandingScenario.getElementsByClass("card-half-width").get(1)
-      val paymentsCardLinks: Elements = returnsCard.getElementsByTag("a")
+        val returnsCard:       Element  = organisationViewWithOutstandingScenario.getElementsByClass("card-half-width").get(1)
+        val paymentsCardLinks: Elements = returnsCard.getElementsByTag("a")
 
-      val statusTags: Elements = returnsCard.getElementsByClass("govuk-tag")
-      statusTags.size() mustBe 0
+        val statusTags: Elements = returnsCard.getElementsByClass("govuk-tag")
+        statusTags.size() mustBe 0
 
-      returnsCard.getElementsByTag("h2").first().ownText() mustBe "Payments"
+        returnsCard.getElementsByTag("h2").first().ownText() mustBe "Payments"
 
-      paymentsCardLinks.get(0).text() mustBe "View transaction history"
-      paymentsCardLinks.get(0).attr("href") mustBe
-        controllers.routes.TransactionHistoryController.onPageLoadTransactionHistory(None).url
+        paymentsCardLinks.get(0).text() mustBe "View transaction history"
+        paymentsCardLinks.get(0).attr("href") mustBe
+          controllers.routes.TransactionHistoryController.onPageLoadTransactionHistory(None).url
 
-      paymentsCardLinks.get(1).text() mustBe "View outstanding payments"
-      paymentsCardLinks.get(1).attr("href") mustBe
-        controllers.payments.routes.OutstandingPaymentsController.onPageLoad.url
+        paymentsCardLinks.get(1).text() mustBe "View outstanding payments"
+        paymentsCardLinks.get(1).attr("href") mustBe
+          controllers.payments.routes.OutstandingPaymentsController.onPageLoad.url
 
-      paymentsCardLinks.get(2).text() mustBe "Stoodover charges"
-      paymentsCardLinks.get(2).attr("href") mustBe
-        controllers.payments.routes.StoodoverChargesController.onPageLoad.url
+        paymentsCardLinks.get(2).text() mustBe "Stoodover charges"
+        paymentsCardLinks.get(2).attr("href") mustBe
+          controllers.payments.routes.StoodoverChargesController.onPageLoad.url
 
-      paymentsCardLinks.get(3).text() mustBe "Request a repayment"
-      paymentsCardLinks.get(3).attr("href") mustBe
-        controllers.repayments.routes.RequestRepaymentBeforeStartController.onPageLoad().url
+        paymentsCardLinks.get(3).text() mustBe "Request a repayment"
+        paymentsCardLinks.get(3).attr("href") mustBe
+          controllers.repayments.routes.RequestRepaymentBeforeStartController.onPageLoad().url
+      }
+
+      "account activity toggle is false" in {
+        val organisationViewWithOutstandingScenario: Document =
+          Jsoup.parse(
+            page(
+              organisationName,
+              date,
+              BtnBanner.Hide,
+              None,
+              None,
+              DynamicNotificationAreaState.NoNotification,
+              plrRef,
+              isAgent = false,
+              hasReturnsUnderEnquiry = false
+            )(
+              request,
+              appConfig,
+              messages
+            )
+              .toString()
+          )
+        val returnsCard:       Element  = organisationViewWithOutstandingScenario.getElementsByClass("card-half-width").get(1)
+        val paymentsCardLinks: Elements = returnsCard.getElementsByTag("a")
+
+        val statusTags: Elements = returnsCard.getElementsByClass("govuk-tag")
+        statusTags.size() mustBe 0
+
+        returnsCard.getElementsByTag("h2").first().ownText() mustBe "Payments"
+
+        paymentsCardLinks.get(0).text() mustBe "View transaction history"
+        paymentsCardLinks.get(0).attr("href") mustBe
+          controllers.routes.TransactionHistoryController.onPageLoadTransactionHistory(None).url
+
+        paymentsCardLinks.get(1).text() mustBe "View outstanding payments"
+        paymentsCardLinks.get(1).attr("href") mustBe
+          controllers.payments.routes.OutstandingPaymentsController.onPageLoad.url
+
+        paymentsCardLinks.get(2).text() mustBe "Request a repayment"
+        paymentsCardLinks.get(2).attr("href") mustBe
+          controllers.repayments.routes.RequestRepaymentBeforeStartController.onPageLoad().url
+      }
     }
 
     "display Payments Outstanding tag with red style when Outstanding scenario is provided" in {
@@ -520,7 +627,8 @@ class HomepageViewSpec extends ViewSpecBase {
 
     val organisationViewScenarios: Seq[ViewScenario] =
       Seq(
-        ViewScenario("organisationView", organisationView)
+        ViewScenario("organisationView", organisationView),
+        ViewScenario("organisationAccountActivityView", organisationAccountActivityView)
       )
 
     behaveLikeAccessiblePage(organisationViewScenarios)
@@ -562,27 +670,48 @@ class HomepageViewSpec extends ViewSpecBase {
         controllers.submissionhistory.routes.SubmissionHistoryController.onPageLoad.url
     }
 
-    "display payments card with correct content" in {
-      val paymentsCard:      Element  = agentView.getElementsByClass("card-half-width").get(1)
-      val paymentsCardLinks: Elements = paymentsCard.getElementsByTag("a")
+    "display payments card with correct content" when {
+      "account activity toggle is true" in {
+        val paymentsCard:      Element  = agentAccountActivityView.getElementsByClass("card-half-width").get(1)
+        val paymentsCardLinks: Elements = paymentsCard.getElementsByTag("a")
 
-      paymentsCard.getElementsByTag("h2").text() mustBe "Payments"
+        paymentsCard.getElementsByTag("h2").text() mustBe "Payments"
 
-      paymentsCardLinks.get(0).text() mustBe "View transaction history"
-      paymentsCard.getElementsByTag("a").get(0).attr("href") mustBe
-        controllers.routes.TransactionHistoryController.onPageLoadTransactionHistory(None).url
+        paymentsCardLinks.get(0).text() mustBe "View transaction history"
+        paymentsCard.getElementsByTag("a").get(0).attr("href") mustBe
+          controllers.routes.TransactionHistoryController.onPageLoadTransactionHistory(None).url
 
-      paymentsCardLinks.get(1).text() mustBe "View outstanding payments"
-      paymentsCard.getElementsByTag("a").get(1).attr("href") mustBe
-        controllers.payments.routes.OutstandingPaymentsController.onPageLoad.url
+        paymentsCardLinks.get(1).text() mustBe "View outstanding payments"
+        paymentsCard.getElementsByTag("a").get(1).attr("href") mustBe
+          controllers.payments.routes.OutstandingPaymentsController.onPageLoad.url
 
-      paymentsCardLinks.get(2).text() mustBe "Stoodover charges"
-      paymentsCard.getElementsByTag("a").get(2).attr("href") mustBe
-        controllers.payments.routes.StoodoverChargesController.onPageLoad.url
+        paymentsCardLinks.get(2).text() mustBe "Stoodover charges"
+        paymentsCard.getElementsByTag("a").get(2).attr("href") mustBe
+          controllers.payments.routes.StoodoverChargesController.onPageLoad.url
 
-      paymentsCardLinks.get(3).text() mustBe "Request a repayment"
-      paymentsCard.getElementsByTag("a").get(3).attr("href") mustBe
-        controllers.repayments.routes.RequestRepaymentBeforeStartController.onPageLoad().url
+        paymentsCardLinks.get(3).text() mustBe "Request a repayment"
+        paymentsCard.getElementsByTag("a").get(3).attr("href") mustBe
+          controllers.repayments.routes.RequestRepaymentBeforeStartController.onPageLoad().url
+      }
+
+      "account activity toggle is false" in {
+        val paymentsCard:      Element  = agentView.getElementsByClass("card-half-width").get(1)
+        val paymentsCardLinks: Elements = paymentsCard.getElementsByTag("a")
+
+        paymentsCard.getElementsByTag("h2").text() mustBe "Payments"
+
+        paymentsCardLinks.get(0).text() mustBe "View transaction history"
+        paymentsCard.getElementsByTag("a").get(0).attr("href") mustBe
+          controllers.routes.TransactionHistoryController.onPageLoadTransactionHistory(None).url
+
+        paymentsCardLinks.get(1).text() mustBe "View outstanding payments"
+        paymentsCard.getElementsByTag("a").get(1).attr("href") mustBe
+          controllers.payments.routes.OutstandingPaymentsController.onPageLoad.url
+
+        paymentsCardLinks.get(2).text() mustBe "Request a repayment"
+        paymentsCard.getElementsByTag("a").get(2).attr("href") mustBe
+          controllers.repayments.routes.RequestRepaymentBeforeStartController.onPageLoad().url
+      }
     }
 
     "display manage account card with correct content" in {
@@ -694,7 +823,8 @@ class HomepageViewSpec extends ViewSpecBase {
 
     val agentViewScenarios: Seq[ViewScenario] =
       Seq(
-        ViewScenario("agentView", agentView)
+        ViewScenario("agentView", agentView),
+        ViewScenario("agentAccountActivityView", agentAccountActivityView)
       )
 
     behaveLikeAccessiblePage(agentViewScenarios)

--- a/test/views/HomepageViewSpec.scala
+++ b/test/views/HomepageViewSpec.scala
@@ -123,8 +123,12 @@ class HomepageViewSpec extends ViewSpecBase {
       paymentsCardLinks.get(1).attr("href") mustBe
         controllers.payments.routes.OutstandingPaymentsController.onPageLoad.url
 
-      paymentsCardLinks.get(2).text() mustBe "Request a repayment"
+      paymentsCardLinks.get(2).text() mustBe "Stoodover charges"
       paymentsCardLinks.get(2).attr("href") mustBe
+        controllers.payments.routes.StoodoverChargesController.onPageLoad.url
+
+      paymentsCardLinks.get(3).text() mustBe "Request a repayment"
+      paymentsCardLinks.get(3).attr("href") mustBe
         controllers.repayments.routes.RequestRepaymentBeforeStartController.onPageLoad().url
     }
 
@@ -444,8 +448,12 @@ class HomepageViewSpec extends ViewSpecBase {
       paymentsCardLinks.get(1).attr("href") mustBe
         controllers.payments.routes.OutstandingPaymentsController.onPageLoad.url
 
-      paymentsCardLinks.get(2).text() mustBe "Request a repayment"
+      paymentsCardLinks.get(2).text() mustBe "Stoodover charges"
       paymentsCardLinks.get(2).attr("href") mustBe
+        controllers.payments.routes.StoodoverChargesController.onPageLoad.url
+
+      paymentsCardLinks.get(3).text() mustBe "Request a repayment"
+      paymentsCardLinks.get(3).attr("href") mustBe
         controllers.repayments.routes.RequestRepaymentBeforeStartController.onPageLoad().url
     }
 
@@ -568,8 +576,12 @@ class HomepageViewSpec extends ViewSpecBase {
       paymentsCard.getElementsByTag("a").get(1).attr("href") mustBe
         controllers.payments.routes.OutstandingPaymentsController.onPageLoad.url
 
-      paymentsCardLinks.get(2).text() mustBe "Request a repayment"
+      paymentsCardLinks.get(2).text() mustBe "Stoodover charges"
       paymentsCard.getElementsByTag("a").get(2).attr("href") mustBe
+        controllers.payments.routes.StoodoverChargesController.onPageLoad.url
+
+      paymentsCardLinks.get(3).text() mustBe "Request a repayment"
+      paymentsCard.getElementsByTag("a").get(3).attr("href") mustBe
         controllers.repayments.routes.RequestRepaymentBeforeStartController.onPageLoad().url
     }
 

--- a/test/views/outstandingpayments/OutstandingPaymentsViewSpec.scala
+++ b/test/views/outstandingpayments/OutstandingPaymentsViewSpec.scala
@@ -169,23 +169,57 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
         h2Elements.get(2).text() mustBe "Details of outstanding payments"
       }
 
-      "table if there are outstanding payments" in {
-        paragraphs.get(5).text() mustBe "We have separated any payments due by accounting period."
+      "table if there are outstanding payments" when {
+        "account activity toggle is true, include stoodover charge content" in {
+          val paragraphs = accountActivityOrganisationView.getElementsByClass("govuk-body")
 
-        val table = organisationView.getElementsByClass("govuk-table").first()
+          paragraphs.get(7).text() mustBe "We have separated any payments due by the associated accounting period where there is one."
+          paragraphs.get(8).text() mustBe "An appealed charge is still part of the amount due until it is partly or completely stoodover."
 
-        val caption: Element = table.getElementsByClass("govuk-table__caption--s").first()
-        caption.text() mustBe "Accounting period: 1 April 2023 to 31 March 2024"
+          accountActivityOrganisationView.getElementsByClass("govuk-link")
 
-        val headers: Elements = table.getElementsByTag("th")
-        headers.get(0).text() mustBe "Description"
-        headers.get(1).text() mustBe "Amount"
-        headers.get(2).text() mustBe "Due date"
+          val viewStoodoverChargesLink = accountActivityOrganisationView.getElementsByClass("govuk-link").get(3)
 
-        val rows: Elements = table.getElementsByTag("td")
-        rows.get(0).text() mustBe "UKTR - DTT"
-        rows.get(1).text() mustBe "£1,000.00"
-        rows.get(2).text() mustBe "31 March 2024"
+          viewStoodoverChargesLink.text() mustBe "View stoodover charges"
+          viewStoodoverChargesLink.attr("href") mustBe controllers.payments.routes.StoodoverChargesController.onPageLoad.url
+
+          val table = accountActivityAppealView.getElementsByClass("govuk-table").first()
+
+          val caption: Element = table.getElementsByClass("govuk-table__caption--s").first()
+          caption.text() mustBe "Accounting period: 1 April 2023 to 31 March 2024"
+
+          val headers: Elements = table.getElementsByTag("th")
+          headers.get(0).text() mustBe "Description"
+          headers.get(1).text() mustBe "Amount"
+          headers.get(2).text() mustBe "Due date"
+
+          val rows: Elements = table.getElementsByTag("td")
+          rows.get(0).text() mustBe "UKTR - DTT Appealed"
+          rows.get(1).text() mustBe "£1,000.00"
+          rows.get(2).text() mustBe "31 March 2024"
+        }
+
+        "account activity toggle is false, show correct content" in {
+          paragraphs.get(5).text() mustBe "We have separated any payments due by the associated accounting period where there is one."
+
+          val table = organisationView.getElementsByClass("govuk-table").first()
+
+          val caption: Element = table.getElementsByClass("govuk-table__caption--s").first()
+          caption.text() mustBe "Accounting period: 1 April 2023 to 31 March 2024"
+
+          val headers: Elements = table.getElementsByTag("th")
+          headers.get(0).text() mustBe "Description"
+          headers.get(1).text() mustBe "Amount"
+          headers.get(2).text() mustBe "Due date"
+
+          val rows: Elements = table.getElementsByTag("td")
+          rows.get(0).text() mustBe "UKTR - DTT"
+          rows.get(1).text() mustBe "£1,000.00"
+          rows.get(2).text() mustBe "31 March 2024"
+
+          paragraphs.text must not include "An appealed charge is still part of the amount due until it is partly or completely stoodover."
+          links.text      must not include "View stoodover charges"
+        }
       }
 
       "display 'No payments due' message if no payments are outstanding" in {
@@ -200,40 +234,22 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
     }
 
     "when account activity is enabled" must {
-      "display the appeal label when there's an appeal flag" in {
-
+      "display the appeal label when the appeal flag is true" in {
         val table = accountActivityAppealView.getElementsByClass("govuk-table").first()
-
-        val caption: Element = table.getElementsByClass("govuk-table__caption--s").first()
-        caption.text() mustBe "Accounting period: 1 April 2023 to 31 March 2024"
-
-        val headers: Elements = table.getElementsByTag("th")
-        headers.get(0).text() mustBe "Description"
-        headers.get(1).text() mustBe "Amount"
-        headers.get(2).text() mustBe "Due date"
 
         val rows: Elements = table.getElementsByTag("td")
         rows.get(0).text() mustBe "UKTR - DTT Appealed"
-        rows.get(1).text() mustBe "£1,000.00"
-        rows.get(2).text() mustBe "31 March 2024"
+
+        accountActivityAppealView.getElementsByClass("govuk-tag--red").size mustBe 1
       }
 
-      "not display the appeal label when there's no appeal flag" in {
-
+      "not display the appeal label when the appeal flag is false" in {
         val table = accountActivityOrganisationView.getElementsByClass("govuk-table").first()
-
-        val caption: Element = table.getElementsByClass("govuk-table__caption--s").first()
-        caption.text() mustBe "Accounting period: 1 April 2023 to 31 March 2024"
-
-        val headers: Elements = table.getElementsByTag("th")
-        headers.get(0).text() mustBe "Description"
-        headers.get(1).text() mustBe "Amount"
-        headers.get(2).text() mustBe "Due date"
 
         val rows: Elements = table.getElementsByTag("td")
         rows.get(0).text() mustBe "UKTR - DTT"
-        rows.get(1).text() mustBe "£1,000.00"
-        rows.get(2).text() mustBe "31 March 2024"
+
+        accountActivityOrganisationView.getElementsByClass("govuk-tag--red").size mustBe 0
       }
     }
 
@@ -278,9 +294,30 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
       }
     }
 
+    "The stoodover charges section" must {
+      "be displayed when account activity toggle is true" in {
+        accountActivityOrganisationView.getElementsByTag("h2").get(3).text() mustBe "Stoodover charges"
+        accountActivityOrganisationView
+          .getElementsByClass("govuk-body")
+          .get(10)
+          .text() mustBe "Details of appealed charges and other standover payments."
+
+        val viewTransactionHistoryLink = accountActivityOrganisationView.getElementsByClass("govuk-link").get(3)
+
+        viewTransactionHistoryLink.text() mustBe "View stoodover charges"
+        viewTransactionHistoryLink.attr("href") mustBe controllers.payments.routes.StoodoverChargesController.onPageLoad.url
+      }
+
+      "not be displayed when account activity toggle is false" in {
+        h2Elements.text() must not include "Stoodover charges"
+        paragraphs.text() must not include "Details of appealed charges and other standover payments."
+        links.text()      must not include "View stoodover charges"
+      }
+    }
+
     "display transaction history section" in {
       h2Elements.get(3).text() mustBe "Transaction history"
-      paragraphs.get(7).text() mustBe "Payments will appear in the transaction history page within 3-5 working days."
+      paragraphs.get(6).text() mustBe "Find details on payments and refunds. It may take up to 5 working days for transactions to appear."
 
       val viewTransactionHistoryLink = links.get(3)
 
@@ -290,7 +327,7 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
 
     "display penalties and charges section" in {
       h2Elements.get(4).text() mustBe "Penalties and interest charges"
-      paragraphs.get(9).text() mustBe "Find out how HMRC may charge your group penalties and interest."
+      paragraphs.get(8).text() mustBe "Find out how HMRC may charge your group penalties and interest."
 
       val penaltiesLink: Element = links.get(4)
 
@@ -337,7 +374,7 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
         agentViewParagraphs.get(2).text() mustBe "Pillar 2 reference: XMPLR0012345678"
         agentViewParagraphs.get(3).text() mustBe "You’ll need to use this reference if you want to make a manual " +
           "payment for this group."
-        agentViewParagraphs.get(9).text() mustBe "Find out how HMRC may charge the group penalties and interest."
+        agentViewParagraphs.get(8).text() mustBe "Find out how HMRC may charge the group penalties and interest."
       }
 
       "display interest warning text section" should {

--- a/test/views/outstandingpayments/OutstandingPaymentsViewSpec.scala
+++ b/test/views/outstandingpayments/OutstandingPaymentsViewSpec.scala
@@ -44,6 +44,17 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
         .toString()
     )
 
+  lazy val accountActivityAppealView: Document =
+    Jsoup.parse(
+      page(dataWithAppeal, plrRef, amountDue(dataWithAppeal), hasOverdueReturnPayment = true, useAccountActivity = true)(
+        request,
+        appConfig,
+        messages,
+        isAgent = false
+      )
+        .toString()
+    )
+
   lazy val agentView: Document =
     Jsoup.parse(page(data, plrRef, amountDue(data), hasOverdueReturnPayment = true)(request, appConfig, messages, isAgent = true).toString())
 
@@ -188,6 +199,85 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
       }
     }
 
+    "when account activity is enabled" must {
+      "display the appeal label when there's an appeal flag" in {
+
+        val table = accountActivityAppealView.getElementsByClass("govuk-table").first()
+
+        val caption: Element = table.getElementsByClass("govuk-table__caption--s").first()
+        caption.text() mustBe "Accounting period: 1 April 2023 to 31 March 2024"
+
+        val headers: Elements = table.getElementsByTag("th")
+        headers.get(0).text() mustBe "Description"
+        headers.get(1).text() mustBe "Amount"
+        headers.get(2).text() mustBe "Due date"
+
+        val rows: Elements = table.getElementsByTag("td")
+        rows.get(0).text() mustBe "UKTR - DTT Appealed"
+        rows.get(1).text() mustBe "£1,000.00"
+        rows.get(2).text() mustBe "31 March 2024"
+      }
+
+      "not display the appeal label when there's no appeal flag" in {
+
+        val table = accountActivityOrganisationView.getElementsByClass("govuk-table").first()
+
+        val caption: Element = table.getElementsByClass("govuk-table__caption--s").first()
+        caption.text() mustBe "Accounting period: 1 April 2023 to 31 March 2024"
+
+        val headers: Elements = table.getElementsByTag("th")
+        headers.get(0).text() mustBe "Description"
+        headers.get(1).text() mustBe "Amount"
+        headers.get(2).text() mustBe "Due date"
+
+        val rows: Elements = table.getElementsByTag("td")
+        rows.get(0).text() mustBe "UKTR - DTT"
+        rows.get(1).text() mustBe "£1,000.00"
+        rows.get(2).text() mustBe "31 March 2024"
+      }
+    }
+
+    "when account activity is disabled" must {
+      "not display the appeal label even when there's an appeal flag" in {
+
+        val row: OutstandingPaymentsRow =
+          OutstandingPaymentsRow(
+            description = "UKTR - DTT",
+            outstandingAmount = 1000.00,
+            dueDate = LocalDate.of(2024, 3, 31),
+            appealFlag = Some(true)
+          )
+        val tableData: OutstandingPaymentsTable      = OutstandingPaymentsTable(accountingPeriod = accountingPeriod, rows = Seq(row))
+        val data:      Seq[OutstandingPaymentsTable] = Seq(tableData)
+
+        lazy val organisationViewWithAppealFlagView: Document =
+          Jsoup.parse(
+            page(data, plrRef, amountDue(data), hasOverdueReturnPayment = true)(
+              request,
+              appConfig,
+              messages,
+              isAgent = false
+            )
+              .toString()
+          )
+
+        val table = organisationViewWithAppealFlagView.getElementsByClass("govuk-table").first()
+
+        val caption: Element = table.getElementsByClass("govuk-table__caption--s").first()
+        caption.text() mustBe "Accounting period: 1 April 2023 to 31 March 2024"
+
+        val headers: Elements = table.getElementsByTag("th")
+        headers.get(0).text() mustBe "Description"
+        headers.get(1).text() mustBe "Amount"
+        headers.get(2).text() mustBe "Due date"
+
+        val rows: Elements = table.getElementsByTag("td")
+        rows.get(0).text() mustBe "UKTR - DTT"
+        rows.get(1).text() mustBe "£1,000.00"
+        rows.get(2).text() mustBe "31 March 2024"
+      }
+    }
+
     "display transaction history section" in {
       h2Elements.get(3).text() mustBe "Transaction history"
       paragraphs.get(7).text() mustBe "Payments will appear in the transaction history page within 3-5 working days."
@@ -288,6 +378,7 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
               .toString()
           )
         ),
+        ViewScenario("accountActivityAppealView", accountActivityAppealView),
         ViewScenario("agentView", agentView),
         ViewScenario(
           "noOverdueReturnPaymentAgentView",
@@ -308,13 +399,20 @@ object OutstandingPaymentsViewSpec {
   val accountingPeriod: AccountingPeriod = AccountingPeriod(startDate = LocalDate.of(2023, 4, 1), endDate = LocalDate.of(2024, 3, 31))
 
   val row: OutstandingPaymentsRow =
-    OutstandingPaymentsRow(description = "UKTR - DTT", outstandingAmount = 1000.00, dueDate = LocalDate.of(2024, 3, 31))
+    OutstandingPaymentsRow(description = "UKTR - DTT", outstandingAmount = 1000.00, dueDate = LocalDate.of(2024, 3, 31), appealFlag = None)
 
   val table: OutstandingPaymentsTable = OutstandingPaymentsTable(accountingPeriod = accountingPeriod, rows = Seq(row))
 
   val data: Seq[OutstandingPaymentsTable] = Seq(table)
 
   val noPaymentsData: Seq[OutstandingPaymentsTable] = Seq(table.copy(rows = Seq(row.copy(outstandingAmount = 0.00))))
+
+  val rowWithAppeal: OutstandingPaymentsRow =
+    OutstandingPaymentsRow(description = "UKTR - DTT", outstandingAmount = 1000.00, dueDate = LocalDate.of(2024, 3, 31), appealFlag = Some(true))
+
+  val tableWithAppeal: OutstandingPaymentsTable = OutstandingPaymentsTable(accountingPeriod = accountingPeriod, rows = Seq(rowWithAppeal))
+
+  val dataWithAppeal: Seq[OutstandingPaymentsTable] = Seq(tableWithAppeal)
 
   def amountDue(data: Seq[OutstandingPaymentsTable]): BigDecimal = data.flatMap(_.rows.map(_.outstandingAmount)).sum.max(0)
 }

--- a/test/views/stoodovercharges/StoodoverChargesViewSpec.scala
+++ b/test/views/stoodovercharges/StoodoverChargesViewSpec.scala
@@ -53,7 +53,9 @@ class StoodoverChargesViewSpec extends ViewSpecBase {
     Jsoup.parse(page(plrRef, data, amountDue(data), "orgName")(request, appConfig, messages, isAgent = false).toString())
 
   lazy val noStoodoverChargesView: Document =
-    Jsoup.parse(page(plrRef, noStoodoverChargesData, amountDue(noStoodoverChargesData), "orgName")(request, appConfig, messages, isAgent = false).toString())
+    Jsoup.parse(
+      page(plrRef, noStoodoverChargesData, amountDue(noStoodoverChargesData), "orgName")(request, appConfig, messages, isAgent = false).toString()
+    )
 
   lazy val agentView: Document =
     Jsoup.parse(page(plrRef, data, amountDue(data), "orgName")(request, appConfig, messages, isAgent = true).toString())

--- a/test/views/stoodovercharges/StoodoverChargesViewSpec.scala
+++ b/test/views/stoodovercharges/StoodoverChargesViewSpec.scala
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.stoodovercharges
+
+import base.ViewSpecBase
+import controllers.routes
+import controllers.routes.*
+import models.subscription.AccountingPeriod
+import models.{StoodoverChargesRow, StoodoverChargesTable}
+import org.jsoup.Jsoup
+import org.jsoup.nodes.{Document, Element}
+import org.jsoup.select.Elements
+import views.behaviours.ViewScenario
+import views.html.stoodoverCharges.StoodoverChargesView
+
+import java.time.LocalDate
+import scala.jdk.CollectionConverters.*
+
+class StoodoverChargesViewSpec extends ViewSpecBase {
+
+  val plrRef: String = "XMPLR0012345678"
+
+  val accountingPeriod: AccountingPeriod = AccountingPeriod(startDate = LocalDate.of(2023, 4, 1), endDate = LocalDate.of(2024, 3, 31), None)
+
+  val row: StoodoverChargesRow =
+    StoodoverChargesRow(description = "UKTR - DTT", stoodoverAmount = BigDecimal(1000))
+
+  val table: StoodoverChargesTable = StoodoverChargesTable(accountingPeriod = accountingPeriod, rows = Seq(row))
+
+  val data: Seq[StoodoverChargesTable] = Seq(table)
+
+  val noStoodoverChargesData: Seq[StoodoverChargesTable] = Seq(table.copy(rows = Seq(row.copy(stoodoverAmount = BigDecimal(0)))))
+
+  def amountDue(data: Seq[StoodoverChargesTable]): BigDecimal = data.flatMap(_.rows.map(_.stoodoverAmount)).sum.max(0)
+
+  lazy val page: StoodoverChargesView = inject[StoodoverChargesView]
+
+  lazy val organisationView: Document =
+    Jsoup.parse(page(plrRef, data, amountDue(data), "orgName")(request, appConfig, messages, isAgent = false).toString())
+
+  lazy val noStoodoverChargesView: Document =
+    Jsoup.parse(page(plrRef, noStoodoverChargesData, amountDue(noStoodoverChargesData), "orgName")(request, appConfig, messages, isAgent = false).toString())
+
+  lazy val agentView: Document =
+    Jsoup.parse(page(plrRef, data, amountDue(data), "orgName")(request, appConfig, messages, isAgent = true).toString())
+
+  lazy val pageTitle:  String   = "Stoodover charges"
+  lazy val h2Elements: Elements = organisationView.getElementsByTag("h2")
+  lazy val paragraphs: Elements = organisationView.getElementsByClass("govuk-body")
+  lazy val links:      Elements = organisationView.getElementsByClass("govuk-link")
+
+  "StoodoverChargesView" should {
+    "have correct width layout" in {
+      organisationView.getElementsByClass("govuk-grid-column-two-thirds").size() mustBe 2
+    }
+
+    "have a title" in {
+      organisationView.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+    }
+
+    "have a unique H1 heading" in {
+      val h1Elements: Elements = organisationView.getElementsByTag("h1")
+      h1Elements.size() mustBe 1
+      h1Elements.text() mustBe pageTitle
+    }
+
+    "have a banner with a link to the Homepage" in {
+      val className: String = "govuk-header__link govuk-header__service-name"
+      organisationView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      agentView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+    }
+
+    "display stoodover total subheading" in {
+      h2Elements.first().text() mustBe "Stoodover total: £1,000"
+    }
+
+    "display details of stoodover charges subheading" in {
+      h2Elements.get(1).text() mustBe "Details of stoodover charges"
+    }
+
+    "display the leading paragraph" in {
+      paragraphs.get(0).text() mustBe "We have separated the charges by accounting period."
+    }
+
+    "display a correct html details section" in {
+      organisationView
+        .getElementsByClass("govuk-details")
+        .first()
+        .getElementsByClass("govuk-details__summary-text")
+        .text() mustBe "Charge description abbreviations"
+
+      val items =
+        organisationView
+          .getElementsByClass("govuk-details__text")
+          .first()
+          .getElementsByClass("govuk-list")
+          .first()
+          .getElementsByTag("li")
+          .eachText()
+          .asScala
+          .toList
+
+      items mustBe List(
+        "UKTR - UK Tax Return",
+        "DTT - Domestic Top-up Tax",
+        "MTT - Multinational Top-up Tax",
+        "IIR - Income Inclusion Rule",
+        "UTPR - Undertaxed Profit Rule",
+        "ORN/GIR - Overseas Return Notification or GloBE Information Return"
+      )
+    }
+
+    "display stoodover charges when present" in {
+      val table = organisationView.getElementsByClass("govuk-table").first()
+
+      val caption: Element = table.getElementsByClass("govuk-table__caption--m").first()
+      caption.text() mustBe "Accounting period: 1 April 2023 to 31 March 2024"
+
+      val headers: Elements = table.getElementsByTag("th")
+      headers.get(0).text() mustBe "Description"
+      headers.get(1).text() mustBe "Stoodover amount"
+
+      val rows: Elements = table.getElementsByTag("td")
+      rows.get(0).text() mustBe "UKTR - DTT"
+      rows.get(1).text() mustBe "£1,000"
+    }
+
+    "display 'No stoodover charges' message if no stood overcharges are present" in {
+      noStoodoverChargesView.getElementsByClass("govuk-body").get(1).text() mustBe "No stoodover charges."
+      noStoodoverChargesView.getElementsByClass("govuk-table").size() mustBe 0
+    }
+  }
+
+  "display outstanding payments section" in {
+    h2Elements.get(2).text() mustBe "Outstanding payments"
+    paragraphs.get(1).text() mustBe "Find full details of any payments due, including penalties and interest."
+
+    val viewOutstandingPaymentsLink = links.get(2)
+
+    viewOutstandingPaymentsLink.text() mustBe "View outstanding payments"
+    viewOutstandingPaymentsLink.attr("href") mustBe controllers.payments.routes.OutstandingPaymentsController.onPageLoad.url
+  }
+
+  "display transaction history section" in {
+    h2Elements.get(3).text() mustBe "Transaction history"
+    paragraphs.get(3).text() mustBe "Find details on payments and refunds. It may take up to 5 working days for transactions to appear."
+
+    val viewTransactionHistoryLink = links.get(3)
+
+    viewTransactionHistoryLink.text() mustBe "View transaction history"
+    viewTransactionHistoryLink.attr("href") mustBe TransactionHistoryController.onPageLoadTransactionHistory(None).url
+  }
+
+  "display agent-specific content" should {
+    "have caption" in {
+      agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0012345678"
+    }
+  }
+
+  val viewScenarios: Seq[ViewScenario] =
+    Seq(
+      ViewScenario("organisationView", organisationView),
+      ViewScenario("noStoodoverChargesView", noStoodoverChargesView),
+      ViewScenario("agentView", agentView)
+    )
+
+  behaveLikeAccessiblePage(viewScenarios)
+}


### PR DESCRIPTION
Homepage changes
Homepage needs a link to ‘Stoodover charges’

Outstanding payment page
When the appeal flag is ‘True’ then display the Tag ‘Appealed’ as per the prototype
Under ‘Details of Outstanding payments’ header add ‘An appealed charge is still part of the amount due until it becomes partly or completely a standover charge’.
All versions of the ‘Outstanding payment’ page should include ‘Stoodover charges’ header
‘Details of appealed charges and stoodover charges’ content
Add a link to ‘View stoodover charges’ page

Add new page ‘Stoodover charges’
Build the Group version of the Stoodover charges page as per the prototype
Things to Highlight about the new page: The ‘standOverAmount’ is retrieved in the JSON from Account Activity API under the ‘Transaction Description’ for the charge/penalty, the Transaction Description is displayed under the ‘Description’ table header and the amount that is stoodover under the ‘Standover amount’ header. If a standOverAmount is present in the JSON returned then add the Description, amount, to the table in the Standover charges page.
The Standover Total’ is the total of all the ‘standOverAmount’ fields present in the JSON returned which are displayed in the table within the Standover charges page.
Build an Agent version of the Standover charges page - only difference being the [‘Group name’] and [‘Group ID] is displayed above the H1.