### PR TITLE
[PIL-2900] Data entry hint text and error messages for new accounting period

### DIFF
--- a/app/controllers/package.scala
+++ b/app/controllers/package.scala
@@ -56,7 +56,7 @@ package object controllers {
         sorted
           .drop(selectedIndex)
           .find(period => !period.canAmendStartDate)
-          .map(_.startDate)
+          .map(_.endDate.plusDays(1))
       } else {
         None
       }

--- a/app/forms/NewAccountingPeriodFormProvider.scala
+++ b/app/forms/NewAccountingPeriodFormProvider.scala
@@ -48,12 +48,12 @@ class NewAccountingPeriodFormProvider @Inject() extends Mappings {
           validateMonthInStringFormat = Some(true)
         )
           .verifying(
-            chosenAccountingPeriod.startDateBoundary match {
-              case Some(_) =>
-                optionalStartDateBoundary(chosenAccountingPeriod.startDateBoundary, "newAccountingPeriod.error.startDate.boundary")
-              case None =>
-                minDate(Pillar2MinStartDate, "newAccountingPeriod.error.startDate.dayMonthYear.minimum")
-            }
+            pillar2MinimumThenOptionalStartBoundary(
+              Pillar2MinStartDate,
+              "newAccountingPeriod.error.startDate.dayMonthYear.minimum",
+              chosenAccountingPeriod.startDateBoundary,
+              "newAccountingPeriod.error.startDate.boundary"
+            )
           ),
         "endDate" -> localDate(
           invalidKey = "newAccountingPeriod.error.endDate.format",

--- a/app/forms/mappings/Constraints.scala
+++ b/app/forms/mappings/Constraints.scala
@@ -153,6 +153,23 @@ trait Constraints {
       }
     }
 
+  protected def pillar2MinimumThenOptionalStartBoundary(
+    pillarMinimum:         LocalDate,
+    pillarMinimumErrorKey: String,
+    startDateBoundary:     Option[LocalDate],
+    boundaryErrorKey:      String
+  ): Constraint[LocalDate] =
+    Constraint { date =>
+      if date.isBefore(pillarMinimum) then Invalid(pillarMinimumErrorKey)
+      else
+        startDateBoundary match {
+          case Some(minDate) if date.isBefore(minDate) =>
+            Invalid(boundaryErrorKey, minDate.minusDays(1).toDateFormat)
+          case _ =>
+            Valid
+        }
+    }
+
   protected def optionalEndDateBoundary(maxEndDate: Option[LocalDate], errorKey: String): Constraint[LocalDate] =
     Constraint { date =>
       maxEndDate match {

--- a/app/models/subscription/ChosenAccountingPeriod.scala
+++ b/app/models/subscription/ChosenAccountingPeriod.scala
@@ -16,6 +16,7 @@
 
 package models.subscription
 
+import play.api.i18n.Messages
 import utils.Constants.Pillar2MinStartDate
 import utils.DateTimeUtils.{toDateEntryFormat, toDateFormat}
 
@@ -28,13 +29,53 @@ case class ChosenAccountingPeriod(
 ) {
   override def toString: String = s"${selectedAccountingPeriod.startDate.toDateFormat} to ${selectedAccountingPeriod.endDate.toDateFormat}"
 
-  def startBoundaryMinusOneDay: LocalDate = startDateBoundary match {
-    case Some(date) => date.minusDays(1)
-    case _          => Pillar2MinStartDate.minusDays(1)
-  }
+  private def originalStartsBeforePillar2: Boolean =
+    selectedAccountingPeriod.startDate.isBefore(Pillar2MinStartDate)
 
-  def startBoundaryHintFormat: String = startBoundaryMinusOneDay.toDateFormat
+  private def endDateHintExampleEntryFormat: String =
+    if originalStartsBeforePillar2 then Pillar2MinStartDate.toDateEntryFormat
+    else selectedAccountingPeriod.endDate.toDateEntryFormat
 
-  def startDateHintEntryFormat: String = selectedAccountingPeriod.startDate.toDateEntryFormat
-  def endDateHintEntryFormat:   String = selectedAccountingPeriod.endDate.toDateEntryFormat
+  def startDateHint(implicit messages: Messages): String =
+    startDateBoundary match {
+      case Some(b) if b.isAfter(Pillar2MinStartDate) =>
+        messages(
+          "newAccountingPeriod.startDate.hint.afterSubmittedPeriodEnd",
+          b.minusDays(1).toDateFormat,
+          selectedAccountingPeriod.startDate.toDateEntryFormat
+        )
+      case _ if originalStartsBeforePillar2 =>
+        messages(
+          "newAccountingPeriod.startDate.hint.onOrAfterPillarEarliest",
+          Pillar2MinStartDate.toDateEntryFormat
+        )
+      case _ =>
+        messages(
+          "newAccountingPeriod.startDate.hint.onOrAfterPillarWithOriginalStart",
+          selectedAccountingPeriod.startDate.toDateEntryFormat
+        )
+    }
+
+  def endDateHint(implicit messages: Messages): String =
+    endDateBoundary match {
+      case Some(maxEnd) =>
+        val firstDayAfterMaxEnd = maxEnd.plusDays(1).toDateFormat
+        if originalStartsBeforePillar2 then {
+          messages(
+            "newAccountingPeriod.endDate.hint.beforeSubmittedStartWithExample",
+            firstDayAfterMaxEnd,
+            Pillar2MinStartDate.toDateEntryFormat
+          )
+        } else {
+          messages(
+            "newAccountingPeriod.endDate.hint.beforeSubmittedStart",
+            firstDayAfterMaxEnd
+          )
+        }
+      case None =>
+        messages(
+          "newAccountingPeriod.endDate.hint.withExample",
+          endDateHintExampleEntryFormat
+        )
+    }
 }

--- a/app/models/subscription/ChosenAccountingPeriod.scala
+++ b/app/models/subscription/ChosenAccountingPeriod.scala
@@ -36,7 +36,7 @@ case class ChosenAccountingPeriod(
     if originalStartsBeforePillar2 then Pillar2MinStartDate.toDateEntryFormat
     else selectedAccountingPeriod.endDate.toDateEntryFormat
 
-  def startDateHint(implicit messages: Messages): String =
+  def startDateHint(using messages: Messages): String =
     startDateBoundary match {
       case Some(b) if b.isAfter(Pillar2MinStartDate) =>
         messages(
@@ -56,7 +56,7 @@ case class ChosenAccountingPeriod(
         )
     }
 
-  def endDateHint(implicit messages: Messages): String =
+  def endDateHint(using messages: Messages): String =
     endDateBoundary match {
       case Some(maxEnd) =>
         val firstDayAfterMaxEnd = maxEnd.plusDays(1).toDateFormat

--- a/app/views/subscriptionview/manageAccount/NewAccountingPeriodView.scala.html
+++ b/app/views/subscriptionview/manageAccount/NewAccountingPeriodView.scala.html
@@ -16,7 +16,6 @@
 
 @import config.FrontendAppConfig
 @import models.subscription.ChosenAccountingPeriod
-@import utils.DateTimeUtils.{toDateFormat, toDateEntryFormat}
 @import viewmodels.LegendSize.Small
 @import views.html.components.gds._
 
@@ -60,13 +59,7 @@
                 field = form("startDate"),
                 legend = LegendViewModel(messages("newAccountingPeriod.startDate.heading")).asPageHeading1(Small, headingLevel = Some("h2"))
             )
-            .withHint(HintViewModel(content = Text(
-                messages(
-                    "newAccountingPeriod.startDate.hint",
-                    chosenAccountingPeriod.startBoundaryHintFormat,
-                    chosenAccountingPeriod.startDateHintEntryFormat)
-                )
-            ))
+            .withHint(HintViewModel(content = Text(chosenAccountingPeriod.startDateHint)))
         )
 
         @govukDateInput(
@@ -74,13 +67,7 @@
                 field = form("endDate"),
                 legend = LegendViewModel(messages("newAccountingPeriod.endDate.heading")).asPageHeading1(Small, headingLevel = Some("h2"))
             )
-            .withHint(HintViewModel(
-                content = chosenAccountingPeriod.endDateBoundary.map { boundary =>
-                    messages("newAccountingPeriod.endDate.hint", boundary.plusDays(1).toDateFormat, chosenAccountingPeriod.endDateHintEntryFormat)
-                }.getOrElse {
-                    messages("newAccountingPeriod.endDate.hintWithoutBoundary", chosenAccountingPeriod.endDateHintEntryFormat)
-                }
-            ))
+            .withHint(HintViewModel(content = Text(chosenAccountingPeriod.endDateHint)))
         )
 
         @govukButton(

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -847,13 +847,16 @@ newAccountingPeriod.p1 = The accounting period is the period covered by the cons
 newAccountingPeriod.p2 = Accounting periods are usually 12 months, but can be longer or shorter.
 
 newAccountingPeriod.startDate.heading = Start date
-newAccountingPeriod.startDate.hint = Enter a date after {0}, for example {1}
+newAccountingPeriod.startDate.hint.onOrAfterPillarWithOriginalStart = Enter a date on or after 31 December 2023, for example {0}, which is the original accounting period start date
+newAccountingPeriod.startDate.hint.afterSubmittedPeriodEnd = Enter a date after {0}, for example {1}, which is the original accounting period start date
+newAccountingPeriod.startDate.hint.onOrAfterPillarEarliest = Enter a date on or after 31 December 2023, for example {0}. This is the earliest permitted date as this is when Pillar 2 started.
 newAccountingPeriod.endDate.heading = End date
-newAccountingPeriod.endDate.hint = Enter a date before {0}, for example {1}
-newAccountingPeriod.endDate.hintWithoutBoundary = Enter a date, for example {0}
+newAccountingPeriod.endDate.hint.withExample = Enter a date, for example {0}
+newAccountingPeriod.endDate.hint.beforeSubmittedStart = Enter a date before {0}, which is the start date of the submitted accounting period
+newAccountingPeriod.endDate.hint.beforeSubmittedStartWithExample = Enter a date before {0}, for example {1}
 newAccountingPeriod.checkYourAnswersLabel = New accounting period
 
-newAccountingPeriod.error.startDate.dayMonthYear.minimum = The start date must be after 31 December 2023. Pillar 2 applies to accounting periods beginning on or after 31 December 2023.
+newAccountingPeriod.error.startDate.dayMonthYear.minimum = The start date must be on or after 31 December 2023. Pillar 2 applies to accounting periods beginning on or after 31 December 2023.
 newAccountingPeriod.error.startDate.format = Enter a date in the correct format
 newAccountingPeriod.error.startDate.boundary = The start date must be after {0}
 newAccountingPeriod.error.startDate.required.all = Enter the start date of the group’s accounting period

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -856,7 +856,7 @@ newAccountingPeriod.endDate.hint.beforeSubmittedStart = Enter a date before {0},
 newAccountingPeriod.endDate.hint.beforeSubmittedStartWithExample = Enter a date before {0}, for example {1}
 newAccountingPeriod.checkYourAnswersLabel = New accounting period
 
-newAccountingPeriod.error.startDate.dayMonthYear.minimum = The start date must be on or after 31 December 2023. Pillar 2 applies to accounting periods beginning on or after 31 December 2023.
+newAccountingPeriod.error.startDate.dayMonthYear.minimum = The start date must be on or after 31 December 2023 Pillar 2 applies to accounting periods beginning on or after 31 December 2023.
 newAccountingPeriod.error.startDate.format = Enter a date in the correct format
 newAccountingPeriod.error.startDate.boundary = The start date must be after {0}
 newAccountingPeriod.error.startDate.required.all = Enter the start date of the group’s accounting period

--- a/test/controllers/DeriveNewAccountingPeriodDateBoundariesSpec.scala
+++ b/test/controllers/DeriveNewAccountingPeriodDateBoundariesSpec.scala
@@ -63,7 +63,7 @@ class DeriveNewAccountingPeriodDateBoundariesSpec extends AnyFreeSpec with Match
       val result         = deriveNewAccountingPeriodDateBoundaries(periods, selectedPeriod)
 
       result.selectedAccountingPeriod mustBe selectedPeriod
-      result.startDateBoundary mustBe Some(LocalDate.of(2022, 1, 1))
+      result.startDateBoundary mustBe Some(LocalDate.of(2023, 1, 1))
       result.endDateBoundary mustBe None
     }
 
@@ -97,7 +97,7 @@ class DeriveNewAccountingPeriodDateBoundariesSpec extends AnyFreeSpec with Match
       val result         = deriveNewAccountingPeriodDateBoundaries(periods, selectedPeriod)
 
       result.selectedAccountingPeriod mustBe selectedPeriod
-      result.startDateBoundary mustBe Some(LocalDate.of(2023, 1, 1))
+      result.startDateBoundary mustBe Some(LocalDate.of(2024, 1, 1))
       result.endDateBoundary mustBe Some(LocalDate.of(2025, 12, 31))
     }
 
@@ -114,7 +114,7 @@ class DeriveNewAccountingPeriodDateBoundariesSpec extends AnyFreeSpec with Match
       val result         = deriveNewAccountingPeriodDateBoundaries(periods, selectedPeriod)
 
       result.selectedAccountingPeriod mustBe selectedPeriod
-      result.startDateBoundary mustBe Some(LocalDate.of(2026, 1, 1))
+      result.startDateBoundary mustBe Some(LocalDate.of(2027, 1, 1))
       result.endDateBoundary mustBe Some(LocalDate.of(2026, 12, 31))
     }
 
@@ -131,7 +131,7 @@ class DeriveNewAccountingPeriodDateBoundariesSpec extends AnyFreeSpec with Match
       val result         = deriveNewAccountingPeriodDateBoundaries(periods, selectedPeriod)
 
       result.selectedAccountingPeriod mustBe selectedPeriod
-      result.startDateBoundary mustBe Some(LocalDate.of(2023, 1, 1))
+      result.startDateBoundary mustBe Some(LocalDate.of(2024, 1, 1))
       result.endDateBoundary mustBe Some(LocalDate.of(2025, 12, 31))
     }
   }

--- a/test/controllers/subscription/manageAccount/NewAccountingPeriodControllerSpec.scala
+++ b/test/controllers/subscription/manageAccount/NewAccountingPeriodControllerSpec.scala
@@ -21,9 +21,11 @@ import forms.NewAccountingPeriodFormProvider
 import generators.Generators
 import models.subscription.*
 import models.{NormalMode, UserAnswers}
+import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import pages.NewAccountingPeriodPage
+import play.api.i18n.Messages
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
 import views.html.subscriptionview.manageAccount.NewAccountingPeriodView
@@ -110,21 +112,11 @@ class NewAccountingPeriodControllerSpec extends SpecBase with Generators {
           val request = FakeRequest(GET, routes.NewAccountingPeriodController.onPageLoad(NormalMode).url)
           val result  = route(application, request).value
 
-          val view = application.injector.instanceOf[NewAccountingPeriodView]
-
           status(result) mustEqual OK
-          contentAsString(result) mustEqual view(
-            formProvider(chosenAccountingPeriod),
-            chosenAccountingPeriod,
-            isAgent = false,
-            organisationName = None,
-            plrReference = plrReference,
-            mode = NormalMode
-          )(
-            request,
-            applicationConfig,
-            messages(application)
-          ).toString
+          implicit val msgs: Messages = messages(application)
+          val doc = Jsoup.parse(contentAsString(result))
+          doc.getElementById("startDate-hint").text mustEqual chosenAccountingPeriod.startDateHint
+          doc.getElementById("endDate-hint").text mustEqual chosenAccountingPeriod.endDateHint
         }
       }
 
@@ -143,21 +135,11 @@ class NewAccountingPeriodControllerSpec extends SpecBase with Generators {
           val request = FakeRequest(GET, routes.NewAccountingPeriodController.onPageLoad(NormalMode).url)
           val result  = route(application, request).value
 
-          val view = application.injector.instanceOf[NewAccountingPeriodView]
-
           status(result) mustEqual OK
-          contentAsString(result) mustEqual view(
-            formProvider(chosenAccountingPeriod),
-            chosenAccountingPeriod,
-            isAgent = false,
-            organisationName = None,
-            plrReference = plrReference,
-            mode = NormalMode
-          )(
-            request,
-            applicationConfig,
-            messages(application)
-          ).toString
+          implicit val msgs: Messages = messages(application)
+          val doc = Jsoup.parse(contentAsString(result))
+          doc.getElementById("startDate-hint").text mustEqual chosenAccountingPeriod.startDateHint
+          doc.getElementById("endDate-hint").text mustEqual chosenAccountingPeriod.endDateHint
         }
       }
 

--- a/test/controllers/subscription/manageAccount/NewAccountingPeriodControllerSpec.scala
+++ b/test/controllers/subscription/manageAccount/NewAccountingPeriodControllerSpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import forms.NewAccountingPeriodFormProvider
 import generators.Generators
 import models.subscription.*
-import models.{NormalMode, UserAnswers}
+import models.{CheckMode, NormalMode, UserAnswers}
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -117,6 +117,29 @@ class NewAccountingPeriodControllerSpec extends SpecBase with Generators {
           val doc        = Jsoup.parse(contentAsString(result))
           doc.getElementById("startDate-hint").text mustEqual chosenAccountingPeriod.startDateHint
           doc.getElementById("endDate-hint").text mustEqual chosenAccountingPeriod.endDateHint
+        }
+      }
+
+      "use new-accounting-period route and new accounting period heading" in {
+        val application = applicationBuilder(subscriptionLocalData = Some(localDataWithAmendablePeriods))
+          .configure("features.amendMultipleAccountingPeriods" -> true)
+          .build()
+
+        running(application) {
+          val pageUrl = routes.NewAccountingPeriodController.onPageLoad(NormalMode).url
+          pageUrl must include("/new-accounting-period")
+          pageUrl must not include "/change-accounting-period"
+
+          val request = FakeRequest(GET, pageUrl)
+          val result  = route(application, request).value
+          status(result) mustEqual OK
+
+          val msgs = messages(application)
+          val doc  = Jsoup.parse(contentAsString(result))
+          doc.select("h1").text mustEqual msgs("newAccountingPeriod.heading")
+
+          val checkModeUrl = routes.NewAccountingPeriodController.onPageLoad(CheckMode).url
+          checkModeUrl must include("/change-new-accounting-period")
         }
       }
 

--- a/test/controllers/subscription/manageAccount/NewAccountingPeriodControllerSpec.scala
+++ b/test/controllers/subscription/manageAccount/NewAccountingPeriodControllerSpec.scala
@@ -113,8 +113,8 @@ class NewAccountingPeriodControllerSpec extends SpecBase with Generators {
           val result  = route(application, request).value
 
           status(result) mustEqual OK
-          implicit val msgs: Messages = messages(application)
-          val doc = Jsoup.parse(contentAsString(result))
+          given Messages = messages(application)
+          val doc        = Jsoup.parse(contentAsString(result))
           doc.getElementById("startDate-hint").text mustEqual chosenAccountingPeriod.startDateHint
           doc.getElementById("endDate-hint").text mustEqual chosenAccountingPeriod.endDateHint
         }
@@ -136,8 +136,8 @@ class NewAccountingPeriodControllerSpec extends SpecBase with Generators {
           val result  = route(application, request).value
 
           status(result) mustEqual OK
-          implicit val msgs: Messages = messages(application)
-          val doc = Jsoup.parse(contentAsString(result))
+          given Messages = messages(application)
+          val doc        = Jsoup.parse(contentAsString(result))
           doc.getElementById("startDate-hint").text mustEqual chosenAccountingPeriod.startDateHint
           doc.getElementById("endDate-hint").text mustEqual chosenAccountingPeriod.endDateHint
         }

--- a/test/forms/NewAccountingPeriodFormProviderSpec.scala
+++ b/test/forms/NewAccountingPeriodFormProviderSpec.scala
@@ -16,8 +16,9 @@
 
 package forms
 
+import controllers.deriveNewAccountingPeriodDateBoundaries
 import forms.behaviours.DateBehaviours
-import models.subscription.{AccountingPeriod, ChosenAccountingPeriod}
+import models.subscription.{AccountingPeriod, AccountingPeriodV2, ChosenAccountingPeriod}
 import org.scalatest.matchers.should.Matchers.*
 import play.api.data.{Form, FormError}
 import utils.DateTimeUtils.toDateFormat
@@ -85,6 +86,53 @@ class NewAccountingPeriodFormProviderSpec extends DateBehaviours {
 
     val startDate = LocalDate.of(2023, 6, 1)
     val endDate   = LocalDate.of(2025, 12, 31)
+
+    val data = Map(
+      "startDate.day"   -> startDate.getDayOfMonth.toString,
+      "startDate.month" -> startDate.getMonthValue.toString,
+      "startDate.year"  -> startDate.getYear.toString,
+      "endDate.day"     -> endDate.getDayOfMonth.toString,
+      "endDate.month"   -> endDate.getMonthValue.toString,
+      "endDate.year"    -> endDate.getYear.toString
+    )
+
+    form.bind(data).errors shouldEqual Seq(
+      FormError("startDate", "newAccountingPeriod.error.startDate.dayMonthYear.minimum")
+    )
+  }
+
+  "prefer Pillar 2 minimum error over start boundary when a submitted period sets a boundary" in {
+    val due   = LocalDate.of(2026, 3, 31)
+    val p2027 = AccountingPeriodV2(
+      startDate = LocalDate.of(2027, 1, 1),
+      endDate = LocalDate.of(2027, 12, 31),
+      dueDate = due,
+      canAmendStartDate = true,
+      canAmendEndDate = true
+    )
+    val p2026 = AccountingPeriodV2(
+      startDate = LocalDate.of(2026, 1, 1),
+      endDate = LocalDate.of(2026, 12, 31),
+      dueDate = due,
+      canAmendStartDate = true,
+      canAmendEndDate = true
+    )
+    val p2025Submitted = AccountingPeriodV2(
+      startDate = LocalDate.of(2025, 1, 1),
+      endDate = LocalDate.of(2025, 12, 31),
+      dueDate = due,
+      canAmendStartDate = false,
+      canAmendEndDate = false
+    )
+
+    val selected = p2026.toAccountingPeriod
+    val chosen   = deriveNewAccountingPeriodDateBoundaries(Seq(p2027, p2026, p2025Submitted), selected)
+
+    chosen.startDateBoundary mustBe Some(LocalDate.of(2026, 1, 1))
+
+    val form: Form[AccountingPeriod] = formProvider(chosen)
+    val startDate = LocalDate.of(2023, 6, 1)
+    val endDate   = LocalDate.of(2026, 12, 31)
 
     val data = Map(
       "startDate.day"   -> startDate.getDayOfMonth.toString,

--- a/test/forms/NewAccountingPeriodFormProviderSpec.scala
+++ b/test/forms/NewAccountingPeriodFormProviderSpec.scala
@@ -56,12 +56,12 @@ class NewAccountingPeriodFormProviderSpec extends DateBehaviours {
 
   "throw a form error for a start date that is before a start date boundary" in {
 
-    val startDateBoundary      = LocalDate.of(2024, 1, 1)
+    val startDateBoundary      = LocalDate.of(2025, 6, 1)
     val accountingPeriodChosen = chosenAccountingPeriod.copy(startDateBoundary = Some(startDateBoundary))
     val form: Form[AccountingPeriod] = formProvider(accountingPeriodChosen)
 
-    val startDate = LocalDate.of(2023, 12, 30)
-    val endDate   = LocalDate.of(2024, 9, 29)
+    val startDate = LocalDate.of(2024, 1, 1)
+    val endDate   = LocalDate.of(2025, 12, 31)
 
     val data = Map(
       "startDate.day"   -> startDate.getDayOfMonth.toString,
@@ -74,6 +74,29 @@ class NewAccountingPeriodFormProviderSpec extends DateBehaviours {
 
     form.bind(data).errors shouldEqual Seq(
       FormError("startDate", "newAccountingPeriod.error.startDate.boundary", List(startDateBoundary.minusDays(1).toDateFormat))
+    )
+  }
+
+  "throw the Pillar 2 minimum error before the start date boundary when the start date is before 31 December 2023" in {
+
+    val startDateBoundary      = LocalDate.of(2025, 6, 1)
+    val accountingPeriodChosen = chosenAccountingPeriod.copy(startDateBoundary = Some(startDateBoundary))
+    val form: Form[AccountingPeriod] = formProvider(accountingPeriodChosen)
+
+    val startDate = LocalDate.of(2023, 6, 1)
+    val endDate   = LocalDate.of(2025, 12, 31)
+
+    val data = Map(
+      "startDate.day"   -> startDate.getDayOfMonth.toString,
+      "startDate.month" -> startDate.getMonthValue.toString,
+      "startDate.year"  -> startDate.getYear.toString,
+      "endDate.day"     -> endDate.getDayOfMonth.toString,
+      "endDate.month"   -> endDate.getMonthValue.toString,
+      "endDate.year"    -> endDate.getYear.toString
+    )
+
+    form.bind(data).errors shouldEqual Seq(
+      FormError("startDate", "newAccountingPeriod.error.startDate.dayMonthYear.minimum")
     )
   }
 

--- a/test/views/subscriptionview/manageAccount/NewAccountingPeriodViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/NewAccountingPeriodViewSpec.scala
@@ -101,7 +101,8 @@ class NewAccountingPeriodViewSpec extends ViewSpecBase {
         startDateFieldset.getElementsByClass("govuk-fieldset__legend").text mustBe "Start date"
         startDateFieldset
           .getElementById("startDate-hint")
-          .text mustBe s"Enter a date after 30 December 2023, for example 16 3 2026"
+          .text mustBe
+          "Enter a date on or after 31 December 2023, for example 16 3 2026, which is the original accounting period start date"
 
         startDateFieldset.getElementsByClass("govuk-date-input__item").get(0).text mustBe "Day"
         Option(startDateFieldset.getElementById("startDate.day")) mustBe defined
@@ -113,7 +114,7 @@ class NewAccountingPeriodViewSpec extends ViewSpecBase {
         endDateFieldset.getElementsByClass("govuk-fieldset__legend").text mustBe "End date"
         endDateFieldset
           .getElementById("endDate-hint")
-          .text mustBe s"Enter a date, for example 15 3 2027"
+          .text mustBe "Enter a date, for example 15 3 2027"
 
         endDateFieldset.getElementsByClass("govuk-date-input__item").get(0).text mustBe "Day"
         Option(endDateFieldset.getElementById("endDate.day")) mustBe defined
@@ -130,11 +131,12 @@ class NewAccountingPeriodViewSpec extends ViewSpecBase {
 
           view(chosenAccountingPeriod = chosenAccountingPeriod)
             .getElementById("startDate-hint")
-            .text mustBe s"Enter a date after 30 December 2023, for example 16 3 2026"
+            .text mustBe
+            "Enter a date on or after 31 December 2023, for example 16 3 2026, which is the original accounting period start date"
 
           view(chosenAccountingPeriod = chosenAccountingPeriod)
             .getElementById("endDate-hint")
-            .text mustBe s"Enter a date, for example 15 3 2027"
+            .text mustBe "Enter a date, for example 15 3 2027"
         }
 
         "there are boundaries" in {
@@ -147,11 +149,42 @@ class NewAccountingPeriodViewSpec extends ViewSpecBase {
 
           view(chosenAccountingPeriod = chosenAccountingPeriod)
             .getElementById("startDate-hint")
-            .text mustBe s"Enter a date after 31 December 2023, for example 16 3 2024"
+            .text mustBe
+            "Enter a date after 31 December 2023, for example 16 3 2024, which is the original accounting period start date"
 
           view(chosenAccountingPeriod = chosenAccountingPeriod)
             .getElementById("endDate-hint")
-            .text mustBe s"Enter a date before 1 January 2026, for example 15 3 2025"
+            .text mustBe
+            "Enter a date before 1 January 2026, which is the start date of the submitted accounting period"
+        }
+
+        "the original period starts before 31 December 2023" in {
+          val prePillarPeriod = ChosenAccountingPeriod(
+            selectedAccountingPeriod = AccountingPeriod(LocalDate.of(2021, 1, 1), LocalDate.of(2021, 6, 1)),
+            startDateBoundary = None,
+            endDateBoundary = None
+          )
+
+          view(chosenAccountingPeriod = prePillarPeriod)
+            .getElementById("startDate-hint")
+            .text mustBe
+            "Enter a date on or after 31 December 2023, for example 31 12 2023. This is the earliest permitted date as this is when Pillar 2 started."
+
+          view(chosenAccountingPeriod = prePillarPeriod)
+            .getElementById("endDate-hint")
+            .text mustBe "Enter a date, for example 31 12 2023"
+        }
+
+        "the original period starts before 31 December 2023 and there is an end date boundary" in {
+          val prePillarPeriod = ChosenAccountingPeriod(
+            selectedAccountingPeriod = AccountingPeriod(LocalDate.of(2021, 1, 1), LocalDate.of(2021, 6, 1)),
+            startDateBoundary = None,
+            endDateBoundary = Some(LocalDate.of(2025, 12, 31))
+          )
+
+          view(chosenAccountingPeriod = prePillarPeriod)
+            .getElementById("endDate-hint")
+            .text mustBe "Enter a date before 1 January 2026, for example 31 12 2023"
         }
       }
 
@@ -197,7 +230,8 @@ class NewAccountingPeriodViewSpec extends ViewSpecBase {
         startDateFieldset.getElementsByClass("govuk-fieldset__legend").text mustBe "Start date"
         startDateFieldset
           .getElementById("startDate-hint")
-          .text mustBe s"Enter a date after 30 December 2023, for example 16 3 2026"
+          .text mustBe
+          "Enter a date on or after 31 December 2023, for example 16 3 2026, which is the original accounting period start date"
 
         startDateFieldset.getElementsByClass("govuk-date-input__item").get(0).text mustBe "Day"
         Option(startDateFieldset.getElementById("startDate.day")) mustBe defined
@@ -209,7 +243,7 @@ class NewAccountingPeriodViewSpec extends ViewSpecBase {
         endDateFieldset.getElementsByClass("govuk-fieldset__legend").text mustBe "End date"
         endDateFieldset
           .getElementById("endDate-hint")
-          .text mustBe s"Enter a date, for example 15 3 2027"
+          .text mustBe "Enter a date, for example 15 3 2027"
 
         endDateFieldset.getElementsByClass("govuk-date-input__item").get(0).text mustBe "Day"
         Option(endDateFieldset.getElementById("endDate.day")) mustBe defined
@@ -226,11 +260,12 @@ class NewAccountingPeriodViewSpec extends ViewSpecBase {
 
           view(chosenAccountingPeriod = chosenAccountingPeriod, isAgent = true)
             .getElementById("startDate-hint")
-            .text mustBe s"Enter a date after 30 December 2023, for example 16 3 2026"
+            .text mustBe
+            "Enter a date on or after 31 December 2023, for example 16 3 2026, which is the original accounting period start date"
 
           view(chosenAccountingPeriod = chosenAccountingPeriod, isAgent = true)
             .getElementById("endDate-hint")
-            .text mustBe s"Enter a date, for example 15 3 2027"
+            .text mustBe "Enter a date, for example 15 3 2027"
         }
 
         "there are boundaries" in {
@@ -243,11 +278,13 @@ class NewAccountingPeriodViewSpec extends ViewSpecBase {
 
           view(chosenAccountingPeriod = chosenAccountingPeriod, isAgent = true)
             .getElementById("startDate-hint")
-            .text mustBe s"Enter a date after 31 December 2023, for example 16 3 2024"
+            .text mustBe
+            "Enter a date after 31 December 2023, for example 16 3 2024, which is the original accounting period start date"
 
           view(chosenAccountingPeriod = chosenAccountingPeriod, isAgent = true)
             .getElementById("endDate-hint")
-            .text mustBe s"Enter a date before 1 January 2026, for example 15 3 2025"
+            .text mustBe
+            "Enter a date before 1 January 2026, which is the start date of the submitted accounting period"
         }
       }
 


### PR DESCRIPTION
## Summary
Implements PIL-2900: correct hint text and validation on **What is the group's new accounting period?** (accounting period change).

## Changes
- **Validation (Scenarios 1–2):** Apply Pillar 2 **on or after 31 December 2023** long error before any submitted-period start rule (`pillar2MinimumThenOptionalStartBoundary`).
- **Boundaries:** `deriveNewAccountingPeriodDateBoundaries` sets minimum start from **end of non-amendable period + 1 day** (not period start).
- **Hints (Scenarios 3–8):** `ChosenAccountingPeriod` exposes `startDateHint` / `endDateHint`; new `messages.en` keys for each branch (pre-Pillar periods, after submitted end, end before next submitted start, etc.).