### PR TITLE
PIL-2886: Added group name and ID for agent views in the BTN journey

### DIFF
--- a/app/controllers/btn/BTNAccountingPeriodController.scala
+++ b/app/controllers/btn/BTNAccountingPeriodController.scala
@@ -103,15 +103,22 @@ class BTNAccountingPeriodController @Inject() (
               AccountingPeriod(period.startDate, period.endDate),
               entitiesInsideOutsideUk = userAnswers.get(EntitiesInsideOutsideUKPage).getOrElse(false)
             )
-            .as(Ok(btnAlreadyInPlaceView()))
+            .as(
+              Ok(btnAlreadyInPlaceView(request.subscriptionLocalData.plrReference, request.isAgent, request.subscriptionLocalData.organisationName))
+            )
         case BTNAccountingPeriodService.Outcome.UktrReturnAlreadySubmitted =>
-          Future.successful(Ok(viewReturnSubmitted(request.isAgent, period)))
+          Future.successful(
+            Ok(
+              viewReturnSubmitted(request.subscriptionLocalData.plrReference, request.isAgent, request.subscriptionLocalData.organisationName, period)
+            )
+          )
         case BTNAccountingPeriodService.Outcome.ShowAccountingPeriod(summaryList, hasMultipleAccountingPeriods, currentAP) =>
           Future.successful(
             Ok(
               accountingPeriodView(
                 summaryList,
                 mode,
+                request.subscriptionLocalData.plrReference,
                 request.isAgent,
                 request.subscriptionLocalData.organisationName,
                 hasMultipleAccountingPeriods,

--- a/app/controllers/btn/BTNBeforeStartController.scala
+++ b/app/controllers/btn/BTNBeforeStartController.scala
@@ -69,8 +69,19 @@ class BTNBeforeStartController @Inject() (
         } yield maybeSubscriptionData
       ).value
         .flatMap {
-          case Some(_) => Future.successful(Ok(view(request.isAgent, filteredAccountingPeriodDetails.size > 1, mode)))
-          case None    => Future.successful(Redirect(controllers.btn.routes.BTNProblemWithServiceController.onPageLoad))
+          case Some(_) =>
+            Future.successful(
+              Ok(
+                view(
+                  request.subscriptionLocalData.plrReference,
+                  request.isAgent,
+                  request.subscriptionLocalData.organisationName,
+                  filteredAccountingPeriodDetails.size > 1,
+                  mode
+                )
+              )
+            )
+          case None => Future.successful(Redirect(controllers.btn.routes.BTNProblemWithServiceController.onPageLoad))
         }
         .recover { case _ =>
           Redirect(controllers.btn.routes.BTNProblemWithServiceController.onPageLoad)

--- a/app/controllers/btn/BTNChooseAccountingPeriodController.scala
+++ b/app/controllers/btn/BTNChooseAccountingPeriodController.scala
@@ -65,7 +65,18 @@ class BTNChooseAccountingPeriodController @Inject() (
                 }
               }
               .getOrElse(form)
-            Future.successful(Ok(view(preparedForm, mode, request.isAgent, request.subscriptionLocalData.organisationName, accountingPeriods)))
+            Future.successful(
+              Ok(
+                view(
+                  preparedForm,
+                  mode,
+                  request.subscriptionLocalData.plrReference,
+                  request.isAgent,
+                  request.subscriptionLocalData.organisationName,
+                  accountingPeriods
+                )
+              )
+            )
           case None =>
             logger.error("user answers not found")
             Future.successful(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad()))
@@ -89,6 +100,7 @@ class BTNChooseAccountingPeriodController @Inject() (
                       view(
                         formWithErrors,
                         mode,
+                        request.subscriptionLocalData.plrReference,
                         request.isAgent,
                         request.subscriptionLocalData.organisationName,
                         accountingPeriods

--- a/app/controllers/btn/BTNEntitiesInUKOnlyController.scala
+++ b/app/controllers/btn/BTNEntitiesInUKOnlyController.scala
@@ -59,7 +59,9 @@ class BTNEntitiesInUKOnlyController @Inject() (
             case Some(value) => form.fill(value)
           }
 
-          Future.successful(Ok(view(preparedForm, request.isAgent, request.subscriptionLocalData.organisationName, mode)))
+          Future.successful(
+            Ok(view(preparedForm, request.subscriptionLocalData.plrReference, request.isAgent, request.subscriptionLocalData.organisationName, mode))
+          )
         case None =>
           logger.error("user answers not found")
           Future.successful(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad()))
@@ -76,7 +78,17 @@ class BTNEntitiesInUKOnlyController @Inject() (
             .bindFromRequest()
             .fold(
               formWithErrors =>
-                Future.successful(BadRequest(view(formWithErrors, request.isAgent, request.subscriptionLocalData.organisationName, mode))),
+                Future.successful(
+                  BadRequest(
+                    view(
+                      formWithErrors,
+                      request.subscriptionLocalData.plrReference,
+                      request.isAgent,
+                      request.subscriptionLocalData.organisationName,
+                      mode
+                    )
+                  )
+                ),
               value =>
                 for {
                   updatedAnswers <- Future.fromTry(userAnswers.set(EntitiesInsideOutsideUKPage, value))

--- a/app/controllers/btn/BTNEntitiesInsideOutsideUKController.scala
+++ b/app/controllers/btn/BTNEntitiesInsideOutsideUKController.scala
@@ -60,7 +60,9 @@ class BTNEntitiesInsideOutsideUKController @Inject() (
             case Some(value) => form.fill(value)
           }
 
-          Future.successful(Ok(view(preparedForm, request.isAgent, request.subscriptionLocalData.organisationName, mode)))
+          Future.successful(
+            Ok(view(preparedForm, request.subscriptionLocalData.plrReference, request.isAgent, request.subscriptionLocalData.organisationName, mode))
+          )
         case None =>
           logger.error("user answers not found")
           Future.successful(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad()))
@@ -78,7 +80,15 @@ class BTNEntitiesInsideOutsideUKController @Inject() (
             .fold(
               formWithErrors =>
                 Future.successful(
-                  BadRequest(view(formWithErrors, request.isAgent, request.subscriptionLocalData.organisationName, mode))
+                  BadRequest(
+                    view(
+                      formWithErrors,
+                      request.subscriptionLocalData.plrReference,
+                      request.isAgent,
+                      request.subscriptionLocalData.organisationName,
+                      mode
+                    )
+                  )
                 ),
               value =>
                 for {
@@ -95,7 +105,16 @@ class BTNEntitiesInsideOutsideUKController @Inject() (
   def onPageLoadAmendGroupDetails(): Action[AnyContent] = (identify andThen getSubscriptionData) { request =>
     given Request[AnyContent] = request
     request.maybeSubscriptionLocalData
-      .map(subData => Ok(viewAmend(subData.subMneOrDomestic, request.isAgent)))
+      .map(subData =>
+        Ok(
+          viewAmend(
+            subData.subMneOrDomestic,
+            subData.plrReference,
+            request.isAgent,
+            subData.organisationName
+          )
+        )
+      )
       .getOrElse(Redirect(controllers.btn.routes.BTNProblemWithServiceController.onPageLoad))
   }
 }

--- a/app/controllers/btn/BTNUnderEnquiryWarningController.scala
+++ b/app/controllers/btn/BTNUnderEnquiryWarningController.scala
@@ -17,24 +17,28 @@
 package controllers.btn
 
 import config.FrontendAppConfig
+import controllers.actions.{IdentifierAction, SubscriptionDataRequiredAction, SubscriptionDataRetrievalAction}
 import models.NormalMode
 import play.api.i18n.I18nSupport
 import play.api.mvc.*
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.btn.BTNUnderEnquiryWarningView
 
-import javax.inject.Inject
+import javax.inject.{Inject, Named}
 
 class BTNUnderEnquiryWarningController @Inject() (
-  val controllerComponents: MessagesControllerComponents,
-  view:                     BTNUnderEnquiryWarningView
+  val controllerComponents:               MessagesControllerComponents,
+  @Named("EnrolmentIdentifier") identify: IdentifierAction,
+  getSubscriptionData:                    SubscriptionDataRetrievalAction,
+  requireSubscriptionData:                SubscriptionDataRequiredAction,
+  view:                                   BTNUnderEnquiryWarningView
 )(using appConfig: FrontendAppConfig)
     extends FrontendBaseController
     with I18nSupport {
 
-  def onPageLoad: Action[AnyContent] = Action { request =>
+  def onPageLoad: Action[AnyContent] = (identify andThen getSubscriptionData andThen requireSubscriptionData) { request =>
     given Request[AnyContent] = request
-    Ok(view())
+    Ok(view(request.subscriptionLocalData.plrReference, request.isAgent, request.subscriptionLocalData.organisationName))
   }
 
   def onSubmit: Action[AnyContent] = Action { _ =>

--- a/app/controllers/btn/CheckYourAnswersController.scala
+++ b/app/controllers/btn/CheckYourAnswersController.scala
@@ -85,7 +85,7 @@ class CheckYourAnswersController @Inject() (
                     ).flatten
                   ).withCssClass("govuk-!-margin-bottom-9")
 
-                  Ok(view(summaryList, request.isAgent, request.subscriptionLocalData.organisationName))
+                  Ok(view(summaryList, request.subscriptionLocalData.plrReference, request.isAgent, request.subscriptionLocalData.organisationName))
                 }
             case _ =>
               Redirect(controllers.routes.IndexController.onPageLoad)

--- a/app/views/btn/BTNAccountingPeriodView.scala.html
+++ b/app/views/btn/BTNAccountingPeriodView.scala.html
@@ -31,13 +31,15 @@
         formHelper: FormWithCSRF
 )
 
-@(list: SummaryList, mode: Mode, isAgent: Boolean, organisationName: Option[String], hasMultipleAccountingPeriods: Boolean, currentAP: Boolean)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(list: SummaryList, mode: Mode, plrReference: String, isAgent: Boolean, organisationName: Option[String], hasMultipleAccountingPeriods: Boolean, currentAP: Boolean)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @layout(pageTitle = titleNoForm(messages("btn.accountingPeriod.title")), bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
     @formHelper(action = controllers.btn.routes.BTNAccountingPeriodController.onSubmit(mode), Symbol("autoComplete") -> "off") {
 
         @if(isAgent && organisationName.isDefined) {
-          <span class="govuk-caption-m">@organisationName.get</span>
+            <span class="govuk-caption-m"><strong>Group: </strong>@organisationName<strong> ID: </strong>@plrReference</span>
+        } else if(isAgent) {
+            <span class="govuk-caption-m"><strong>ID: </strong>@plrReference</span>
         }
 
         @heading(messages("btn.accountingPeriod.header"), classes = "govuk-heading-l")

--- a/app/views/btn/BTNAccountingPeriodView.scala.html
+++ b/app/views/btn/BTNAccountingPeriodView.scala.html
@@ -37,7 +37,7 @@
     @formHelper(action = controllers.btn.routes.BTNAccountingPeriodController.onSubmit(mode), Symbol("autoComplete") -> "off") {
 
         @if(isAgent && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}: </strong>@plrReference</span>
+            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName <strong>@{messages("homepage.id")}: </strong>@plrReference</span>
         } else if(isAgent) {
             <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
         }

--- a/app/views/btn/BTNAccountingPeriodView.scala.html
+++ b/app/views/btn/BTNAccountingPeriodView.scala.html
@@ -37,9 +37,9 @@
     @formHelper(action = controllers.btn.routes.BTNAccountingPeriodController.onSubmit(mode), Symbol("autoComplete") -> "off") {
 
         @if(isAgent && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>Group: </strong>@organisationName<strong> ID: </strong>@plrReference</span>
+            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}: </strong>@plrReference</span>
         } else if(isAgent) {
-            <span class="govuk-caption-m"><strong>ID: </strong>@plrReference</span>
+            <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
         }
 
         @heading(messages("btn.accountingPeriod.header"), classes = "govuk-heading-l")

--- a/app/views/btn/BTNAlreadyInPlaceView.scala.html
+++ b/app/views/btn/BTNAlreadyInPlaceView.scala.html
@@ -29,7 +29,7 @@
     @layout(pageTitle = titleNoForm(messages("btn.alreadyInPlace.title")), bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
         @formHelper(action = controllers.btn.routes.BTNAccountingPeriodController.onSubmit(NormalMode), Symbol("autoComplete") -> "off") {
             @if(isAgent && organisationName.isDefined) {
-                <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}: </strong>@plrReference</span>
+                <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName <strong>@{messages("homepage.id")}: </strong>@plrReference</span>
             } else if(isAgent) {
                 <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
             }

--- a/app/views/btn/BTNAlreadyInPlaceView.scala.html
+++ b/app/views/btn/BTNAlreadyInPlaceView.scala.html
@@ -25,9 +25,15 @@
         formHelper: FormWithCSRF
 )
 
-@()(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(plrReference: String, isAgent: Boolean, organisationName: Option[String])(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
     @layout(pageTitle = titleNoForm(messages("btn.alreadyInPlace.title")), bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
         @formHelper(action = controllers.btn.routes.BTNAccountingPeriodController.onSubmit(NormalMode), Symbol("autoComplete") -> "off") {
+            @if(isAgent && organisationName.isDefined) {
+                <span class="govuk-caption-m"><strong>Group: </strong>@organisationName<strong> ID: </strong>@plrReference</span>
+            } else if(isAgent) {
+                <span class="govuk-caption-m"><strong>ID: </strong>@plrReference</span>
+            }
+
             @heading(messages("btn.alreadyInPlace.heading"), classes = "govuk-heading-l")
 
             @p(messages("btn.alreadyInPlace.p1"))

--- a/app/views/btn/BTNAlreadyInPlaceView.scala.html
+++ b/app/views/btn/BTNAlreadyInPlaceView.scala.html
@@ -29,9 +29,9 @@
     @layout(pageTitle = titleNoForm(messages("btn.alreadyInPlace.title")), bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
         @formHelper(action = controllers.btn.routes.BTNAccountingPeriodController.onSubmit(NormalMode), Symbol("autoComplete") -> "off") {
             @if(isAgent && organisationName.isDefined) {
-                <span class="govuk-caption-m"><strong>Group: </strong>@organisationName<strong> ID: </strong>@plrReference</span>
+                <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}: </strong>@plrReference</span>
             } else if(isAgent) {
-                <span class="govuk-caption-m"><strong>ID: </strong>@plrReference</span>
+                <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
             }
 
             @heading(messages("btn.alreadyInPlace.heading"), classes = "govuk-heading-l")

--- a/app/views/btn/BTNAmendDetailsView.scala.html
+++ b/app/views/btn/BTNAmendDetailsView.scala.html
@@ -26,7 +26,7 @@
         paragraphMessageWithLink: ParagraphMessageWithLink
 )
 
-@(mneOrDomestic: MneOrDomestic, isAgent: Boolean)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(mneOrDomestic: MneOrDomestic, plrReference: String, isAgent: Boolean, organisationName: Option[String])(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @layout(
     pageTitle = if(isAgent) {
@@ -36,6 +36,12 @@
     },
     bannerUrl = Some(routes.HomepageController.onPageLoad().url)
 ) {
+
+    @if(isAgent && organisationName.isDefined) {
+        <span class="govuk-caption-m"><strong>Group: </strong>@organisationName<strong> ID: </strong>@plrReference</span>
+    } else if(isAgent) {
+        <span class="govuk-caption-m"><strong>ID: </strong>@plrReference</span>
+    }
 
     @if(isAgent) {
         @heading(messages("btn.entitiesInsideOutsideUK.amend.agent.heading"), classes = "govuk-heading-l")

--- a/app/views/btn/BTNAmendDetailsView.scala.html
+++ b/app/views/btn/BTNAmendDetailsView.scala.html
@@ -38,9 +38,9 @@
 ) {
 
     @if(isAgent && organisationName.isDefined) {
-        <span class="govuk-caption-m"><strong>Group: </strong>@organisationName<strong> ID: </strong>@plrReference</span>
+        <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}: </strong>@plrReference</span>
     } else if(isAgent) {
-        <span class="govuk-caption-m"><strong>ID: </strong>@plrReference</span>
+        <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
     }
 
     @if(isAgent) {

--- a/app/views/btn/BTNBeforeStartView.scala.html
+++ b/app/views/btn/BTNBeforeStartView.scala.html
@@ -28,9 +28,16 @@
         govukInsetText: GovukInsetText
 )
 
-@(isAgent: Boolean, hasMultipleAccountingPeriods: Boolean, mode: Mode)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(plrReference: String, isAgent: Boolean, organisationName: Option[String], hasMultipleAccountingPeriods: Boolean, mode: Mode)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @layout(pageTitle = titleNoForm(messages("btn.beforeStart.title")), bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
+
+    @if(isAgent && organisationName.isDefined) {
+        <span class="govuk-caption-m"><strong>Group: </strong>@organisationName<strong> ID: </strong>@plrReference</span>
+    } else if(isAgent) {
+        <span class="govuk-caption-m"><strong>ID: </strong>@plrReference</span>
+    }
+
     @heading(messages("btn.beforeStart.header"), classes = "govuk-heading-l")
 
     @if(isAgent) {

--- a/app/views/btn/BTNBeforeStartView.scala.html
+++ b/app/views/btn/BTNBeforeStartView.scala.html
@@ -33,9 +33,9 @@
 @layout(pageTitle = titleNoForm(messages("btn.beforeStart.title")), bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
     @if(isAgent && organisationName.isDefined) {
-        <span class="govuk-caption-m"><strong>Group: </strong>@organisationName<strong> ID: </strong>@plrReference</span>
+        <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}: </strong>@plrReference</span>
     } else if(isAgent) {
-        <span class="govuk-caption-m"><strong>ID: </strong>@plrReference</span>
+        <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
     }
 
     @heading(messages("btn.beforeStart.header"), classes = "govuk-heading-l")

--- a/app/views/btn/BTNChooseAccountingPeriodView.scala.html
+++ b/app/views/btn/BTNChooseAccountingPeriodView.scala.html
@@ -30,7 +30,7 @@
     formHelper: FormWithCSRF
 )
 
-@(form: Form[Int], mode: Mode, isAgent: Boolean, organisationName: Option[String], accountingPeriodDetails: Seq[(AccountingPeriodDetails, Int)])(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(form: Form[Int], mode: Mode, plrReference: String, isAgent: Boolean, organisationName: Option[String], accountingPeriodDetails: Seq[(AccountingPeriodDetails, Int)])(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @layout(pageTitle = title(form, messages("btn.chooseAccountingPeriod.title")), bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
@@ -41,7 +41,9 @@
         }
 
         @if(isAgent && organisationName.isDefined) {
-          <span class="govuk-caption-m">@organisationName.get</span>
+            <span class="govuk-caption-m"><strong>Group: </strong>@organisationName<strong> ID: </strong>@plrReference</span>
+        } else if(isAgent) {
+            <span class="govuk-caption-m"><strong>ID: </strong>@plrReference</span>
         }
 
         @heading(messages("btn.chooseAccountingPeriod.heading"), classes = "govuk-heading-l")

--- a/app/views/btn/BTNChooseAccountingPeriodView.scala.html
+++ b/app/views/btn/BTNChooseAccountingPeriodView.scala.html
@@ -41,9 +41,9 @@
         }
 
         @if(isAgent && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>Group: </strong>@organisationName<strong> ID: </strong>@plrReference</span>
+            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}: </strong>@plrReference</span>
         } else if(isAgent) {
-            <span class="govuk-caption-m"><strong>ID: </strong>@plrReference</span>
+            <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
         }
 
         @heading(messages("btn.chooseAccountingPeriod.heading"), classes = "govuk-heading-l")

--- a/app/views/btn/BTNConfirmationView.scala.html
+++ b/app/views/btn/BTNConfirmationView.scala.html
@@ -36,12 +36,13 @@
 @(companyName: Option[String], plrRef: Option[String], submissionDate: String, accountingPeriodStartDate: LocalDate, accountingPeriodEndDate: LocalDate, isAgent: Boolean, showUnderEnquiryWarning: Boolean)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @layout(pageTitle = titleNoForm(messages("btn.confirmation.title")), showBackLink = false, bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
-    @if(isAgent) {
-        <div class="govuk-hint govuk-!-margin-top-0">
-            <span><strong>@{messages("homepage.group")}:</strong> @companyName</span>
-            <span><strong>@{messages("homepage.id")}:</strong> @plrRef</span>
-        </div>
+
+    @if(isAgent && companyName.isDefined) {
+        <span class="govuk-caption-m"><strong>Group: </strong>@companyName<strong> ID: </strong>@plrRef</span>
+    } else if(isAgent) {
+        <span class="govuk-caption-m"><strong>ID: </strong>@plrRef</span>
     }
+
     @govukPanel(Panel(
       title = Text(messages("btn.confirmation.heading")),
       content = HtmlContent(""),

--- a/app/views/btn/BTNConfirmationView.scala.html
+++ b/app/views/btn/BTNConfirmationView.scala.html
@@ -38,9 +38,9 @@
 @layout(pageTitle = titleNoForm(messages("btn.confirmation.title")), showBackLink = false, bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
     @if(isAgent && companyName.isDefined) {
-        <span class="govuk-caption-m"><strong>Group: </strong>@companyName<strong> ID: </strong>@plrRef</span>
+        <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@companyName<strong> @{messages("homepage.id")}: </strong>@plrRef</span>
     } else if(isAgent) {
-        <span class="govuk-caption-m"><strong>ID: </strong>@plrRef</span>
+        <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrRef</span>
     }
 
     @govukPanel(Panel(

--- a/app/views/btn/BTNConfirmationView.scala.html
+++ b/app/views/btn/BTNConfirmationView.scala.html
@@ -38,7 +38,7 @@
 @layout(pageTitle = titleNoForm(messages("btn.confirmation.title")), showBackLink = false, bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
     @if(isAgent && companyName.isDefined) {
-        <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@companyName<strong> @{messages("homepage.id")}: </strong>@plrRef</span>
+        <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@companyName<strong> @{messages("homepage.id")}:</strong> @plrRef</span>
     } else if(isAgent) {
         <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrRef</span>
     }

--- a/app/views/btn/BTNEntitiesInUKOnlyView.scala.html
+++ b/app/views/btn/BTNEntitiesInUKOnlyView.scala.html
@@ -35,9 +35,9 @@
         }
 
         @if(isAgent && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>Group: </strong>@organisationName<strong> ID: </strong>@plrReference</span>
+            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}: </strong>@plrReference</span>
         } else if(isAgent) {
-            <span class="govuk-caption-m"><strong>ID: </strong>@plrReference</span>
+            <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
         }
 
         @govukRadios(

--- a/app/views/btn/BTNEntitiesInUKOnlyView.scala.html
+++ b/app/views/btn/BTNEntitiesInUKOnlyView.scala.html
@@ -35,7 +35,7 @@
         }
 
         @if(isAgent && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}: </strong>@plrReference</span>
+            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
         } else if(isAgent) {
             <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
         }

--- a/app/views/btn/BTNEntitiesInUKOnlyView.scala.html
+++ b/app/views/btn/BTNEntitiesInUKOnlyView.scala.html
@@ -25,7 +25,7 @@
     govukButton: GovukButton
 )
 
-@(form: Form[_], isAgent: Boolean, organisationName: Option[String], mode: Mode)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(form: Form[_], plrReference: String, isAgent: Boolean, organisationName: Option[String], mode: Mode)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @layout(pageTitle = title(form, messages("btn.entitiesInsideOutsideUK.title.uk")), bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
     @formHelper(action = controllers.btn.routes.BTNEntitiesInUKOnlyController.onSubmit(mode), Symbol("autoComplete") -> "off") {
@@ -35,7 +35,9 @@
         }
 
         @if(isAgent && organisationName.isDefined) {
-            <span class="govuk-caption-m">@organisationName.get</span>
+            <span class="govuk-caption-m"><strong>Group: </strong>@organisationName<strong> ID: </strong>@plrReference</span>
+        } else if(isAgent) {
+            <span class="govuk-caption-m"><strong>ID: </strong>@plrReference</span>
         }
 
         @govukRadios(

--- a/app/views/btn/BTNEntitiesInsideOutsideUKView.scala.html
+++ b/app/views/btn/BTNEntitiesInsideOutsideUKView.scala.html
@@ -35,9 +35,9 @@
         }
 
         @if(isAgent && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>Group: </strong>@organisationName<strong> ID: </strong>@plrReference</span>
+            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}: </strong>@plrReference</span>
         } else if(isAgent) {
-            <span class="govuk-caption-m"><strong>ID: </strong>@plrReference</span>
+            <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
         }
 
         @govukRadios(

--- a/app/views/btn/BTNEntitiesInsideOutsideUKView.scala.html
+++ b/app/views/btn/BTNEntitiesInsideOutsideUKView.scala.html
@@ -35,7 +35,7 @@
         }
 
         @if(isAgent && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}: </strong>@plrReference</span>
+            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
         } else if(isAgent) {
             <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
         }

--- a/app/views/btn/BTNEntitiesInsideOutsideUKView.scala.html
+++ b/app/views/btn/BTNEntitiesInsideOutsideUKView.scala.html
@@ -25,7 +25,7 @@
     govukButton: GovukButton
 )
 
-@(form: Form[_], isAgent: Boolean, organisationName: Option[String], mode: Mode)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(form: Form[_], plrReference: String, isAgent: Boolean, organisationName: Option[String], mode: Mode)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @layout(pageTitle = title(form, messages("btn.entitiesInsideOutsideUK.title.ukAndOther")), bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
     @formHelper(action = controllers.btn.routes.BTNEntitiesInsideOutsideUKController.onSubmit(mode), Symbol("autoComplete") -> "off") {
@@ -35,7 +35,9 @@
         }
 
         @if(isAgent && organisationName.isDefined) {
-            <span class="govuk-caption-m">@organisationName.get</span>
+            <span class="govuk-caption-m"><strong>Group: </strong>@organisationName<strong> ID: </strong>@plrReference</span>
+        } else if(isAgent) {
+            <span class="govuk-caption-m"><strong>ID: </strong>@plrReference</span>
         }
 
         @govukRadios(

--- a/app/views/btn/BTNReturnSubmittedView.scala.html
+++ b/app/views/btn/BTNReturnSubmittedView.scala.html
@@ -44,7 +44,7 @@
 ) {
     @formHelper(action = controllers.btn.routes.BTNAccountingPeriodController.onSubmit(NormalMode), Symbol("autoComplete") -> "off") {
         @if(isAgent && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}: </strong>@plrReference</span>
+            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
         } else if(isAgent) {
             <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
         }

--- a/app/views/btn/BTNReturnSubmittedView.scala.html
+++ b/app/views/btn/BTNReturnSubmittedView.scala.html
@@ -29,7 +29,7 @@
         paragraphMessageWithLink: ParagraphMessageWithLink,
         formHelper: FormWithCSRF
 )
-@(isAgent: Boolean, accountingPeriodDetails: AccountingPeriodDetails)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(plrReference: String, isAgent: Boolean, organisationName: Option[String], accountingPeriodDetails: AccountingPeriodDetails)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @accountingPeriodStartDate=@{accountingPeriodDetails.startDate.toDateFormat}
 @accountingPeriodEndDate = @{accountingPeriodDetails.endDate.toDateFormat}
@@ -43,6 +43,12 @@
     bannerUrl = Some(routes.HomepageController.onPageLoad().url)
 ) {
     @formHelper(action = controllers.btn.routes.BTNAccountingPeriodController.onSubmit(NormalMode), Symbol("autoComplete") -> "off") {
+        @if(isAgent && organisationName.isDefined) {
+            <span class="govuk-caption-m"><strong>Group: </strong>@organisationName<strong> ID: </strong>@plrReference</span>
+        } else if(isAgent) {
+            <span class="govuk-caption-m"><strong>ID: </strong>@plrReference</span>
+        }
+
         @if(isAgent) {
             @heading(messages("btn.returnSubmitted.agent.heading", accountingPeriodStartDate, accountingPeriodEndDate), classes = "govuk-heading-l")
             @p(messages("btn.returnSubmitted.agent.p1"))

--- a/app/views/btn/BTNReturnSubmittedView.scala.html
+++ b/app/views/btn/BTNReturnSubmittedView.scala.html
@@ -44,9 +44,9 @@
 ) {
     @formHelper(action = controllers.btn.routes.BTNAccountingPeriodController.onSubmit(NormalMode), Symbol("autoComplete") -> "off") {
         @if(isAgent && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>Group: </strong>@organisationName<strong> ID: </strong>@plrReference</span>
+            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}: </strong>@plrReference</span>
         } else if(isAgent) {
-            <span class="govuk-caption-m"><strong>ID: </strong>@plrReference</span>
+            <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
         }
 
         @if(isAgent) {

--- a/app/views/btn/BTNUnderEnquiryWarningView.scala.html
+++ b/app/views/btn/BTNUnderEnquiryWarningView.scala.html
@@ -33,7 +33,7 @@
 @layout(pageTitle = titleNoForm(messages("btn.underEnquiryWarning.title")), showBackLink = true) {
 
   @if(isAgent && organisationName.isDefined) {
-    <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}: </strong>@plrReference</span>
+    <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
   } else if(isAgent) {
     <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
   }

--- a/app/views/btn/BTNUnderEnquiryWarningView.scala.html
+++ b/app/views/btn/BTNUnderEnquiryWarningView.scala.html
@@ -28,9 +28,15 @@
     formWithCSRF: FormWithCSRF
 )
 
-@()(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(plrReference: String, isAgent: Boolean, organisationName: Option[String])(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @layout(pageTitle = titleNoForm(messages("btn.underEnquiryWarning.title")), showBackLink = true) {
+
+  @if(isAgent && organisationName.isDefined) {
+    <span class="govuk-caption-m"><strong>Group: </strong>@organisationName<strong> ID: </strong>@plrReference</span>
+  } else if(isAgent) {
+    <span class="govuk-caption-m"><strong>ID: </strong>@plrReference</span>
+  }
 
   @heading(messages("btn.underEnquiryWarning.heading"), classes = "govuk-heading-l")
 

--- a/app/views/btn/BTNUnderEnquiryWarningView.scala.html
+++ b/app/views/btn/BTNUnderEnquiryWarningView.scala.html
@@ -33,9 +33,9 @@
 @layout(pageTitle = titleNoForm(messages("btn.underEnquiryWarning.title")), showBackLink = true) {
 
   @if(isAgent && organisationName.isDefined) {
-    <span class="govuk-caption-m"><strong>Group: </strong>@organisationName<strong> ID: </strong>@plrReference</span>
+    <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}: </strong>@plrReference</span>
   } else if(isAgent) {
-    <span class="govuk-caption-m"><strong>ID: </strong>@plrReference</span>
+    <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
   }
 
   @heading(messages("btn.underEnquiryWarning.heading"), classes = "govuk-heading-l")

--- a/app/views/btn/CheckYourAnswersView.scala.html
+++ b/app/views/btn/CheckYourAnswersView.scala.html
@@ -30,13 +30,15 @@
         formHelper: FormWithCSRF
 )
 
-@(list: SummaryList, isAgent: Boolean, organisationName: Option[String])(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(list: SummaryList, plrReference: String, isAgent: Boolean, organisationName: Option[String])(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @layout(pageTitle = titleNoForm(messages("btn.cya.title")), bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
   @formHelper(action = controllers.btn.routes.CheckYourAnswersController.onSubmit) {
 
     @if(isAgent && organisationName.isDefined) {
-      <span class="govuk-caption-m">@organisationName.get</span>
+        <span class="govuk-caption-m"><strong>Group: </strong>@organisationName<strong> ID: </strong>@plrReference</span>
+    } else if(isAgent) {
+        <span class="govuk-caption-m"><strong>ID: </strong>@plrReference</span>
     }
 
     @heading(messages("btn.cya.heading"), classes = "govuk-heading-l")

--- a/app/views/btn/CheckYourAnswersView.scala.html
+++ b/app/views/btn/CheckYourAnswersView.scala.html
@@ -36,9 +36,9 @@
   @formHelper(action = controllers.btn.routes.CheckYourAnswersController.onSubmit) {
 
     @if(isAgent && organisationName.isDefined) {
-        <span class="govuk-caption-m"><strong>Group: </strong>@organisationName<strong> ID: </strong>@plrReference</span>
+        <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}: </strong>@plrReference</span>
     } else if(isAgent) {
-        <span class="govuk-caption-m"><strong>ID: </strong>@plrReference</span>
+        <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
     }
 
     @heading(messages("btn.cya.heading"), classes = "govuk-heading-l")

--- a/app/views/stoodoverCharges/StoodoverChargesView.scala.html
+++ b/app/views/stoodoverCharges/StoodoverChargesView.scala.html
@@ -36,7 +36,7 @@
 @layout(pageTitle = titleNoForm(messages("payments.stoodoverCharges.title")), twoThirdsPagelayout = false, bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
     @if(isAgent) {
-        <span class="govuk-caption-m"><strong>Group:</strong> @organisationName <strong>ID:</strong> @plrReference</span>
+        <span class="govuk-caption-m"><strong>Group: </strong>@organisationName<strong> ID: </strong>@plrReference</span>
     }
 
     <div class="govuk-grid-row">

--- a/app/views/stoodoverCharges/StoodoverChargesView.scala.html
+++ b/app/views/stoodoverCharges/StoodoverChargesView.scala.html
@@ -36,7 +36,7 @@
 @layout(pageTitle = titleNoForm(messages("payments.stoodoverCharges.title")), twoThirdsPagelayout = false, bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
     @if(isAgent) {
-        <span class="govuk-caption-m"><strong>Group: </strong>@organisationName<strong> ID: </strong>@plrReference</span>
+        <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}: </strong>@plrReference</span>
     }
 
     <div class="govuk-grid-row">

--- a/app/views/stoodoverCharges/StoodoverChargesView.scala.html
+++ b/app/views/stoodoverCharges/StoodoverChargesView.scala.html
@@ -36,7 +36,7 @@
 @layout(pageTitle = titleNoForm(messages("payments.stoodoverCharges.title")), twoThirdsPagelayout = false, bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
     @if(isAgent) {
-        <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}: </strong>@plrReference</span>
+        <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
     }
 
     <div class="govuk-grid-row">

--- a/app/views/subscriptionview/manageAccount/NewAccountingPeriodView.scala.html
+++ b/app/views/subscriptionview/manageAccount/NewAccountingPeriodView.scala.html
@@ -45,7 +45,9 @@
         }
 
         @if(isAgent && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>Group:</strong> @organisationName <strong>ID:</strong> @plrReference</span>
+            <span class="govuk-caption-m"><strong>Group: </strong>@organisationName<strong> ID: </strong>@plrReference</span>
+        } else if(isAgent) {
+            <span class="govuk-caption-m"><strong>ID: </strong>@plrReference</span>
         }
 
         @heading(messages("newAccountingPeriod.heading"), "govuk-heading-l")

--- a/app/views/subscriptionview/manageAccount/NewAccountingPeriodView.scala.html
+++ b/app/views/subscriptionview/manageAccount/NewAccountingPeriodView.scala.html
@@ -45,7 +45,7 @@
         }
 
         @if(isAgent && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}: </strong>@plrReference</span>
+            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
         } else if(isAgent) {
             <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
         }

--- a/app/views/subscriptionview/manageAccount/NewAccountingPeriodView.scala.html
+++ b/app/views/subscriptionview/manageAccount/NewAccountingPeriodView.scala.html
@@ -45,9 +45,9 @@
         }
 
         @if(isAgent && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>Group: </strong>@organisationName<strong> ID: </strong>@plrReference</span>
+            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}: </strong>@plrReference</span>
         } else if(isAgent) {
-            <span class="govuk-caption-m"><strong>ID: </strong>@plrReference</span>
+            <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
         }
 
         @heading(messages("newAccountingPeriod.heading"), "govuk-heading-l")

--- a/test/controllers/btn/BTNAccountingPeriodControllerSpec.scala
+++ b/test/controllers/btn/BTNAccountingPeriodControllerSpec.scala
@@ -107,6 +107,7 @@ class BTNAccountingPeriodControllerSpec extends SpecBase {
           contentAsString(result) mustEqual view(
             list(LocalDate.now(), LocalDate.now.plusYears(1)),
             NormalMode,
+            plrReference,
             isAgent = false,
             Some("orgName"),
             hasMultipleAccountingPeriods = false,
@@ -136,6 +137,7 @@ class BTNAccountingPeriodControllerSpec extends SpecBase {
           contentAsString(result) mustEqual view(
             list(chosenAccountPeriod.startDate, chosenAccountPeriod.endDate),
             NormalMode,
+            plrReference,
             isAgent = false,
             Some("orgName"),
             hasMultipleAccountingPeriods = true,
@@ -205,7 +207,7 @@ class BTNAccountingPeriodControllerSpec extends SpecBase {
         val result  = route(application, request).value
         val view    = application.injector.instanceOf[BTNReturnSubmittedView]
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(isAgent = false, osResponse.success.accountingPeriodDetails.head)(
+        contentAsString(result) mustEqual view(plrReference, isAgent = false, Some("orgName"), osResponse.success.accountingPeriodDetails.head)(
           request,
           applicationConfig,
           messages(application)
@@ -225,7 +227,7 @@ class BTNAccountingPeriodControllerSpec extends SpecBase {
         val result  = route(application, request).value
         val view    = application.injector.instanceOf[BTNAlreadyInPlaceView]
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view()(
+        contentAsString(result) mustEqual view(plrReference, isAgent = false, Some("orgName"))(
           request,
           applicationConfig,
           messages(application)

--- a/test/controllers/btn/BTNBeforeStartControllerSpec.scala
+++ b/test/controllers/btn/BTNBeforeStartControllerSpec.scala
@@ -68,7 +68,7 @@ class BTNBeforeStartControllerSpec extends SpecBase {
 
         status(result) mustEqual OK
 
-        contentAsString(result) mustEqual view(isAgent = false, hasMultipleAccountingPeriods = false, NormalMode)(
+        contentAsString(result) mustEqual view(plrReference, isAgent = false, Some("orgName"), hasMultipleAccountingPeriods = false, NormalMode)(
           request,
           applicationConfig,
           messages(application)
@@ -91,7 +91,7 @@ class BTNBeforeStartControllerSpec extends SpecBase {
 
         status(result) mustBe OK
 
-        contentAsString(result) mustEqual view(isAgent = false, hasMultipleAccountingPeriods = true, NormalMode)(
+        contentAsString(result) mustEqual view(plrReference, isAgent = false, Some("orgName"), hasMultipleAccountingPeriods = true, NormalMode)(
           request,
           applicationConfig,
           messages(application)

--- a/test/controllers/btn/BTNChooseAccountingPeriodControllerSpec.scala
+++ b/test/controllers/btn/BTNChooseAccountingPeriodControllerSpec.scala
@@ -72,7 +72,7 @@ class BTNChooseAccountingPeriodControllerSpec extends SpecBase {
 
         status(result) mustEqual OK
 
-        contentAsString(result) mustEqual view(form, mode, isAgent = false, Some(organisationName), zippedAccountingPeriodDetails)(
+        contentAsString(result) mustEqual view(form, mode, plrReference, isAgent = false, Some(organisationName), zippedAccountingPeriodDetails)(
           request,
           applicationConfig,
           messages(application)
@@ -95,6 +95,7 @@ class BTNChooseAccountingPeriodControllerSpec extends SpecBase {
         contentAsString(result) mustEqual view(
           form.fill(chosenAccountingPeriod._2),
           mode,
+          plrReference,
           isAgent = false,
           Some(organisationName),
           zippedAccountingPeriodDetails
@@ -161,7 +162,7 @@ class BTNChooseAccountingPeriodControllerSpec extends SpecBase {
         val result = route(application, request).value
 
         status(result) mustEqual BAD_REQUEST
-        contentAsString(result) mustEqual view(boundForm, mode, isAgent = false, Some(organisationName), zippedAccountingPeriodDetails)(
+        contentAsString(result) mustEqual view(boundForm, mode, plrReference, isAgent = false, Some(organisationName), zippedAccountingPeriodDetails)(
           request,
           applicationConfig,
           messages(application)

--- a/test/controllers/btn/BTNEntitiesInUKOnlyControllerSpec.scala
+++ b/test/controllers/btn/BTNEntitiesInUKOnlyControllerSpec.scala
@@ -65,7 +65,7 @@ class BTNEntitiesInUKOnlyControllerSpec extends SpecBase with MockitoSugar {
         val view = application.injector.instanceOf[BTNEntitiesInUKOnlyView]
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(form, isAgent = false, Some("orgName"), NormalMode)(
+        contentAsString(result) mustEqual view(form, PlrReference, isAgent = false, Some("orgName"), NormalMode)(
           request,
           applicationConfig,
           messages(application)
@@ -93,7 +93,7 @@ class BTNEntitiesInUKOnlyControllerSpec extends SpecBase with MockitoSugar {
         val result = route(application, request).value
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(form.fill(true), isAgent = false, Some("orgName"), NormalMode)(
+        contentAsString(result) mustEqual view(form.fill(true), PlrReference, isAgent = false, Some("orgName"), NormalMode)(
           request,
           applicationConfig,
           messages(application)
@@ -152,7 +152,7 @@ class BTNEntitiesInUKOnlyControllerSpec extends SpecBase with MockitoSugar {
         val result = route(application, request).value
 
         status(result) mustEqual BAD_REQUEST
-        contentAsString(result) mustEqual view(boundForm, isAgent = false, Some("orgName"), NormalMode)(
+        contentAsString(result) mustEqual view(boundForm, PlrReference, isAgent = false, Some("orgName"), NormalMode)(
           request,
           applicationConfig,
           messages(application)

--- a/test/controllers/btn/BTNEntitiesInsideOutsideUKControllerSpec.scala
+++ b/test/controllers/btn/BTNEntitiesInsideOutsideUKControllerSpec.scala
@@ -64,7 +64,7 @@ class BTNEntitiesInsideOutsideUKControllerSpec extends SpecBase with MockitoSuga
         val view = application.injector.instanceOf[BTNEntitiesInsideOutsideUKView]
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(form, isAgent = false, Some("orgName"), NormalMode)(
+        contentAsString(result) mustEqual view(form, PlrReference, isAgent = false, Some("orgName"), NormalMode)(
           request,
           applicationConfig,
           messages(application)
@@ -85,7 +85,7 @@ class BTNEntitiesInsideOutsideUKControllerSpec extends SpecBase with MockitoSuga
         val result = route(application, request).value
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(form.fill(true), isAgent = false, Some("orgName"), NormalMode)(
+        contentAsString(result) mustEqual view(form.fill(true), PlrReference, isAgent = false, Some("orgName"), NormalMode)(
           request,
           applicationConfig,
           messages(application)
@@ -144,7 +144,7 @@ class BTNEntitiesInsideOutsideUKControllerSpec extends SpecBase with MockitoSuga
         val result = route(application, request).value
 
         status(result) mustEqual BAD_REQUEST
-        contentAsString(result) mustEqual view(boundForm, isAgent = false, Some("orgName"), NormalMode)(
+        contentAsString(result) mustEqual view(boundForm, PlrReference, isAgent = false, Some("orgName"), NormalMode)(
           request,
           applicationConfig,
           messages(application)
@@ -180,7 +180,11 @@ class BTNEntitiesInsideOutsideUKControllerSpec extends SpecBase with MockitoSuga
         val view = application.injector.instanceOf[BTNAmendDetailsView]
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(MneOrDomestic.Uk, isAgent = false)(request, applicationConfig, messages(application)).toString
+        contentAsString(result) mustEqual view(MneOrDomestic.Uk, PlrReference, isAgent = false, Some("orgName"))(
+          request,
+          applicationConfig,
+          messages(application)
+        ).toString
       }
     }
 

--- a/test/controllers/btn/BTNUnderEnquiryWarningControllerSpec.scala
+++ b/test/controllers/btn/BTNUnderEnquiryWarningControllerSpec.scala
@@ -27,7 +27,7 @@ class BTNUnderEnquiryWarningControllerSpec extends SpecBase {
 
     "return OK and the correct view for a GET" in {
 
-      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+      val application = applicationBuilder(subscriptionLocalData = Some(someSubscriptionLocalData)).build()
 
       running(application) {
         val request = FakeRequest(GET, controllers.btn.routes.BTNUnderEnquiryWarningController.onPageLoad.url)
@@ -37,7 +37,11 @@ class BTNUnderEnquiryWarningControllerSpec extends SpecBase {
         val view = application.injector.instanceOf[BTNUnderEnquiryWarningView]
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view()(request, applicationConfig, messages(application)).toString
+        contentAsString(result) mustEqual view(PlrReference, isAgent = false, Some("orgName"))(
+          request,
+          applicationConfig,
+          messages(application)
+        ).toString
       }
     }
 

--- a/test/controllers/btn/CheckYourAnswersControllerSpec.scala
+++ b/test/controllers/btn/CheckYourAnswersControllerSpec.scala
@@ -92,7 +92,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
           val view    = application.injector.instanceOf[CheckYourAnswersView]
 
           status(result) mustEqual OK
-          contentAsString(result) mustEqual view(btnCyaSummaryList(), isAgent = false, Some("orgName"))(
+          contentAsString(result) mustEqual view(btnCyaSummaryList(), PlrReference, isAgent = false, Some("orgName"))(
             request,
             applicationConfig,
             messages(application)
@@ -120,6 +120,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
           status(result) mustEqual OK
           contentAsString(result) mustEqual view(
             buildSummaryList(testLocalDateFrom, testLocalDateTo, testLocalDateTo.plusMonths(2)),
+            PlrReference,
             isAgent = false,
             Some("orgName")
           )(

--- a/test/views/btn/BTNAccountingPeriodViewSpec.scala
+++ b/test/views/btn/BTNAccountingPeriodViewSpec.scala
@@ -35,9 +35,9 @@ import scala.language.implicitConversions
 class BTNAccountingPeriodViewSpec extends ViewSpecBase {
 
   lazy val page:            BTNAccountingPeriodView = inject[BTNAccountingPeriodView]
+  lazy val plrReference:    String                  = "XMPLR0123456789"
   lazy val startDate:       String                  = "7 January 2024"
   lazy val endDate:         String                  = "7 January 2025"
-  lazy val agentView:       Document                = view(isAgent = true)
   lazy val pageTitle:       String                  = "Confirm account period for Below-Threshold Notification"
   lazy val bannerClassName: String                  = "govuk-header__link govuk-header__service-name"
 
@@ -51,114 +51,53 @@ class BTNAccountingPeriodViewSpec extends ViewSpecBase {
     )
   )
 
-  def view(isAgent: Boolean = false, hasMultipleAccountingPeriods: Boolean = false, currentAP: Boolean = true): Document =
+  def organisationView(hasMultipleAccountingPeriods: Boolean = false, currentAP: Boolean = true): Document =
     Jsoup.parse(
-      page(list, NormalMode, isAgent, Some("orgName"), hasMultipleAccountingPeriods, currentAP)(request, appConfig, messages).toString()
+      page(list, NormalMode, plrReference, isAgent = false, Some("orgName"), hasMultipleAccountingPeriods, currentAP)(request, appConfig, messages)
+        .toString()
+    )
+
+  def agentView(hasMultipleAccountingPeriods: Boolean = false, currentAP: Boolean = true): Document =
+    Jsoup.parse(
+      page(list, NormalMode, plrReference, isAgent = true, Some("orgName"), hasMultipleAccountingPeriods, currentAP)(request, appConfig, messages)
+        .toString()
+    )
+
+  def agentNoOrgView(hasMultipleAccountingPeriods: Boolean = false, currentAP: Boolean = true): Document =
+    Jsoup.parse(
+      page(list, NormalMode, plrReference, isAgent = true, organisationName = None, hasMultipleAccountingPeriods, currentAP)(
+        request,
+        appConfig,
+        messages
+      ).toString()
     )
 
   "BTNAccountingPeriodView" when {
     "it's an organisation" should {
 
       "have a title" in {
-        view().title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+        organisationView().title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
       }
 
       "have a unique H1 heading" in {
-        val h1Elements: Elements = view().getElementsByTag("h1")
+        val h1Elements: Elements = organisationView().getElementsByTag("h1")
         h1Elements.size() mustBe 1
         h1Elements.text() mustBe pageTitle
       }
 
       "have a banner with a link to the Homepage" in {
-        view().getElementsByClass(bannerClassName).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        organisationView().getElementsByClass(bannerClassName).attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "have a paragraph" in {
-        view().getElementsByClass("govuk-body").first().text mustBe
+        organisationView().getElementsByClass("govuk-body").first().text mustBe
           "Your group will keep below-threshold status from this accounting period onwards, unless you file a UK tax return."
       }
 
       "have a summary list" in {
-        val summaryListElements: Elements = view().getElementsByClass("govuk-summary-list")
-        val summaryListKeys:     Elements = view().getElementsByClass("govuk-summary-list__key")
-        val summaryListItems:    Elements = view().getElementsByClass("govuk-summary-list__value")
-
-        summaryListElements.size() mustBe 1
-
-        summaryListKeys.get(0).text() mustBe "Start date of accounting period"
-        summaryListItems.get(0).text() mustBe startDate
-
-        summaryListKeys.get(1).text() mustBe "End date of accounting period"
-        summaryListItems.get(1).text() mustBe endDate
-      }
-
-      "have a link for selecting a different accounting period when they have multiple accounting periods" in {
-        val link: Element = view(hasMultipleAccountingPeriods = true).getElementsByClass("govuk-body").get(1).getElementsByTag("a").first()
-
-        link.text mustBe "Select different accounting period"
-        link.attr("href") mustBe controllers.btn.routes.BTNChooseAccountingPeriodController.onPageLoad(NormalMode).url
-        link.attr("target") mustBe "_self"
-        link.attr("rel") mustNot be("noopener noreferrer")
-      }
-
-      "have a paragraph with link if it's the current accounting period" in {
-        val paragraph: Element = view().getElementsByClass("govuk-body").get(1)
-        val link:      Element = paragraph.getElementsByTag("a").first()
-
-        paragraph.text mustBe "If the accounting period dates are wrong, update your group’s accounting period dates before continuing."
-        link.text mustBe "update your group’s accounting period dates"
-        link.attr("href") mustBe
-          controllers.subscription.manageAccount.routes.ManageGroupDetailsCheckYourAnswersController.onPageLoad().url
-        link.attr("target") mustBe "_self"
-        link.attr("rel") mustNot be("noopener noreferrer")
-      }
-
-      "not have a paragraph with link if it's a previous accounting period" in {
-        val paragraphs: Elements = view(hasMultipleAccountingPeriods = true, currentAP = false).getElementsByClass("govuk-body")
-        val link:       Element  = paragraphs.get(1).getElementsByTag("a").first()
-
-        paragraphs.text mustNot include("If the accounting period dates are wrong, update your group’s accounting period dates before continuing.")
-        link.text mustNot include("update your group’s accounting period dates")
-        link.attr("href") mustNot include(
-          controllers.subscription.manageAccount.routes.ManageGroupDetailsCheckYourAnswersController.onPageLoad().url
-        )
-      }
-
-      "have a 'Continue' button" in {
-        val continueButton: Element = view().getElementsByClass("govuk-button").first()
-        continueButton.text mustBe "Continue"
-        continueButton.attr("type") mustBe "submit"
-      }
-    }
-
-    "it's an agent" should {
-      "have a title" in {
-        agentView.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
-      }
-
-      "have a unique H1 heading" in {
-        val h1Elements: Elements = agentView.getElementsByTag("h1")
-        h1Elements.size() mustBe 1
-        h1Elements.text() mustBe pageTitle
-      }
-
-      "have a banner with a link to the Homepage" in {
-        agentView.getElementsByClass(bannerClassName).attr("href") mustBe routes.HomepageController.onPageLoad().url
-      }
-
-      "have a caption" in {
-        agentView.getElementsByClass("govuk-caption-m").text mustBe "orgName"
-      }
-
-      "have a paragraph" in {
-        agentView.getElementsByClass("govuk-body").first().text mustBe "The group will keep below-threshold status " +
-          "from this accounting period onwards, unless a UK Tax Return is filed."
-      }
-
-      "have a summary list" in {
-        val summaryListElements: Elements = agentView.getElementsByClass("govuk-summary-list")
-        val summaryListKeys:     Elements = agentView.getElementsByClass("govuk-summary-list__key")
-        val summaryListItems:    Elements = agentView.getElementsByClass("govuk-summary-list__value")
+        val summaryListElements: Elements = organisationView().getElementsByClass("govuk-summary-list")
+        val summaryListKeys:     Elements = organisationView().getElementsByClass("govuk-summary-list__key")
+        val summaryListItems:    Elements = organisationView().getElementsByClass("govuk-summary-list__value")
 
         summaryListElements.size() mustBe 1
 
@@ -171,7 +110,86 @@ class BTNAccountingPeriodViewSpec extends ViewSpecBase {
 
       "have a link for selecting a different accounting period when they have multiple accounting periods" in {
         val link: Element =
-          view(isAgent = true, hasMultipleAccountingPeriods = true).getElementsByClass("govuk-body").get(1).getElementsByTag("a").first()
+          organisationView(hasMultipleAccountingPeriods = true).getElementsByClass("govuk-body").get(1).getElementsByTag("a").first()
+
+        link.text mustBe "Select different accounting period"
+        link.attr("href") mustBe controllers.btn.routes.BTNChooseAccountingPeriodController.onPageLoad(NormalMode).url
+        link.attr("target") mustBe "_self"
+        link.attr("rel") mustNot be("noopener noreferrer")
+      }
+
+      "have a paragraph with link if it's the current accounting period" in {
+        val paragraph: Element = organisationView().getElementsByClass("govuk-body").get(1)
+        val link:      Element = paragraph.getElementsByTag("a").first()
+
+        paragraph.text mustBe "If the accounting period dates are wrong, update your group’s accounting period dates before continuing."
+        link.text mustBe "update your group’s accounting period dates"
+        link.attr("href") mustBe
+          controllers.subscription.manageAccount.routes.ManageGroupDetailsCheckYourAnswersController.onPageLoad().url
+        link.attr("target") mustBe "_self"
+        link.attr("rel") mustNot be("noopener noreferrer")
+      }
+
+      "not have a paragraph with link if it's a previous accounting period" in {
+        val paragraphs: Elements = organisationView(hasMultipleAccountingPeriods = true, currentAP = false).getElementsByClass("govuk-body")
+        val link:       Element  = paragraphs.get(1).getElementsByTag("a").first()
+
+        paragraphs.text mustNot include("If the accounting period dates are wrong, update your group’s accounting period dates before continuing.")
+        link.text mustNot include("update your group’s accounting period dates")
+        link.attr("href") mustNot include(
+          controllers.subscription.manageAccount.routes.ManageGroupDetailsCheckYourAnswersController.onPageLoad().url
+        )
+      }
+
+      "have a 'Continue' button" in {
+        val continueButton: Element = organisationView().getElementsByClass("govuk-button").first()
+        continueButton.text mustBe "Continue"
+        continueButton.attr("type") mustBe "submit"
+      }
+    }
+
+    "it's an agent" should {
+      "have a title" in {
+        agentView().title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+      }
+
+      "have a unique H1 heading" in {
+        val h1Elements: Elements = agentView().getElementsByTag("h1")
+        h1Elements.size() mustBe 1
+        h1Elements.text() mustBe pageTitle
+      }
+
+      "have a banner with a link to the Homepage" in {
+        agentView().getElementsByClass(bannerClassName).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      }
+
+      "have a caption" in {
+        agentView().getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
+        agentNoOrgView().getElementsByClass("govuk-caption-m").text mustBe "ID: XMPLR0123456789"
+      }
+
+      "have a paragraph" in {
+        agentView().getElementsByClass("govuk-body").first().text mustBe "The group will keep below-threshold status " +
+          "from this accounting period onwards, unless a UK Tax Return is filed."
+      }
+
+      "have a summary list" in {
+        val summaryListElements: Elements = agentView().getElementsByClass("govuk-summary-list")
+        val summaryListKeys:     Elements = agentView().getElementsByClass("govuk-summary-list__key")
+        val summaryListItems:    Elements = agentView().getElementsByClass("govuk-summary-list__value")
+
+        summaryListElements.size() mustBe 1
+
+        summaryListKeys.get(0).text() mustBe "Start date of accounting period"
+        summaryListItems.get(0).text() mustBe startDate
+
+        summaryListKeys.get(1).text() mustBe "End date of accounting period"
+        summaryListItems.get(1).text() mustBe endDate
+      }
+
+      "have a link for selecting a different accounting period when they have multiple accounting periods" in {
+        val link: Element =
+          agentView(hasMultipleAccountingPeriods = true).getElementsByClass("govuk-body").get(1).getElementsByTag("a").first()
         link.text mustBe "Select different accounting period"
         link.attr("href") mustBe
           controllers.btn.routes.BTNChooseAccountingPeriodController.onPageLoad(NormalMode).url
@@ -180,7 +198,7 @@ class BTNAccountingPeriodViewSpec extends ViewSpecBase {
       }
 
       "have a paragraph with link if it's the current accounting period" in {
-        val paragraph: Element = agentView.getElementsByClass("govuk-body").get(1)
+        val paragraph: Element = agentView().getElementsByClass("govuk-body").get(1)
         val link:      Element = paragraph.getElementsByTag("a").first()
 
         paragraph.text mustBe "If the accounting period dates are wrong, update the group’s accounting period dates before continuing."
@@ -192,7 +210,7 @@ class BTNAccountingPeriodViewSpec extends ViewSpecBase {
       }
 
       "not have a paragraph with link if it's a previous accounting period" in {
-        val paragraphs: Elements = view(isAgent = true, hasMultipleAccountingPeriods = true, currentAP = false).getElementsByClass("govuk-body")
+        val paragraphs: Elements = agentView(hasMultipleAccountingPeriods = true, currentAP = false).getElementsByClass("govuk-body")
         val link:       Element  = paragraphs.get(1).getElementsByTag("a").first()
 
         paragraphs.text mustNot include("If the accounting period dates are wrong, update the group’s accounting period dates before continuing.")
@@ -203,7 +221,7 @@ class BTNAccountingPeriodViewSpec extends ViewSpecBase {
       }
 
       "have a 'Continue' button" in {
-        val continueButton: Element = agentView.getElementsByClass("govuk-button").first()
+        val continueButton: Element = agentView().getElementsByClass("govuk-button").first()
         continueButton.text mustBe "Continue"
         continueButton.attr("type") mustBe "submit"
       }
@@ -211,12 +229,13 @@ class BTNAccountingPeriodViewSpec extends ViewSpecBase {
 
     val viewScenarios: Seq[ViewScenario] =
       Seq(
-        ViewScenario("view", view()),
-        ViewScenario("hasMultipleAccountingPeriodsView", view(hasMultipleAccountingPeriods = true)),
-        ViewScenario("previousAccountingPeriodView", view(hasMultipleAccountingPeriods = true, currentAP = false)),
-        ViewScenario("agentView", agentView),
-        ViewScenario("hasMultipleAccountingPeriodsAgentView", view(isAgent = true, hasMultipleAccountingPeriods = true)),
-        ViewScenario("previousAccountingPeriodAgentView", view(isAgent = true, hasMultipleAccountingPeriods = true, currentAP = false))
+        ViewScenario("view", organisationView()),
+        ViewScenario("hasMultipleAccountingPeriodsView", organisationView(hasMultipleAccountingPeriods = true)),
+        ViewScenario("previousAccountingPeriodView", organisationView(hasMultipleAccountingPeriods = true, currentAP = false)),
+        ViewScenario("agentView", agentView()),
+        ViewScenario("agentNoOrgView", agentNoOrgView()),
+        ViewScenario("hasMultipleAccountingPeriodsAgentView", agentView(hasMultipleAccountingPeriods = true)),
+        ViewScenario("previousAccountingPeriodAgentView", agentView(hasMultipleAccountingPeriods = true, currentAP = false))
       )
 
     behaveLikeAccessiblePage(viewScenarios)

--- a/test/views/btn/BTNAlreadyInPlaceViewSpec.scala
+++ b/test/views/btn/BTNAlreadyInPlaceViewSpec.scala
@@ -26,41 +26,52 @@ import views.html.btn.BTNAlreadyInPlaceView
 
 class BTNAlreadyInPlaceViewSpec extends ViewSpecBase {
 
-  lazy val page:      BTNAlreadyInPlaceView = inject[BTNAlreadyInPlaceView]
-  lazy val view:      Document              = Jsoup.parse(page()(request, appConfig, messages).toString())
-  lazy val pageTitle: String                = "The group has already submitted a Below-Threshold Notification for this accounting period"
+  lazy val page:         BTNAlreadyInPlaceView = inject[BTNAlreadyInPlaceView]
+  lazy val plrReference: String                = "XMPLR0123456789"
+  lazy val pageTitle:    String                = "The group has already submitted a Below-Threshold Notification for this accounting period"
+
+  lazy val organisationView: Document = Jsoup.parse(page(plrReference, isAgent = false, Some("orgName"))(request, appConfig, messages).toString())
+  lazy val agentView:        Document = Jsoup.parse(page(plrReference, isAgent = true, Some("orgName"))(request, appConfig, messages).toString())
+  lazy val agentNoOrgView:   Document = Jsoup.parse(page(plrReference, isAgent = true, None)(request, appConfig, messages).toString())
 
   "BTNAlreadyInPlaceView" should {
     "have a title" in {
-      view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+      organisationView.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
     }
 
     "have a unique H1 heading" in {
-      val h1Elements: Elements = view.getElementsByTag("h1")
+      val h1Elements: Elements = organisationView.getElementsByTag("h1")
       h1Elements.size() mustBe 1
       h1Elements.text() mustBe pageTitle
     }
 
     "have a banner with a link to the Homepage" in {
       val className: String = "govuk-header__link govuk-header__service-name"
-      view.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      organisationView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have a paragraph" in {
-      view.getElementsByClass("govuk-body").get(0).text mustBe "You cannot submit two notifications for the same period."
+      organisationView.getElementsByClass("govuk-body").get(0).text mustBe "You cannot submit two notifications for the same period."
     }
 
     "have a Return to Homepage link" in {
-      val returnLink: Element = view.getElementsByClass("govuk-body").last().getElementsByTag("a").first()
+      val returnLink: Element = organisationView.getElementsByClass("govuk-body").last().getElementsByTag("a").first()
 
       returnLink.text mustBe "Return to homepage"
       returnLink.attr("href") mustBe controllers.routes.HomepageController.onPageLoad().url
       returnLink.attr("target") mustBe "_self"
     }
 
+    "have a caption for an agent view" in {
+      agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
+      agentNoOrgView.getElementsByClass("govuk-caption-m").text mustBe "ID: XMPLR0123456789"
+    }
+
     val viewScenarios: Seq[ViewScenario] =
       Seq(
-        ViewScenario("view", view)
+        ViewScenario("organisationView", organisationView),
+        ViewScenario("agentView", agentView),
+        ViewScenario("agentNoOrgView", agentNoOrgView)
       )
 
     behaveLikeAccessiblePage(viewScenarios)

--- a/test/views/btn/BTNAmendDetailsViewSpec.scala
+++ b/test/views/btn/BTNAmendDetailsViewSpec.scala
@@ -26,42 +26,46 @@ import views.behaviours.ViewScenario
 import views.html.btn.BTNAmendDetailsView
 
 class BTNAmendDetailsViewSpec extends ViewSpecBase {
-
+  lazy val plrReference:    String              = "XMPLR0123456789"
   lazy val page:            BTNAmendDetailsView = inject[BTNAmendDetailsView]
   lazy val pageTitle:       String              = "Based on your answer, you need to amend your details"
   lazy val pageTitleAgent:  String              = "Group details amend needed"
   lazy val bannerClassName: String              = "govuk-header__link govuk-header__service-name"
 
-  def viewUkOnly(isAgent: Boolean = false): Document =
-    Jsoup.parse(page(MneOrDomestic.Uk, isAgent)(request, appConfig, messages).toString())
-  def viewUkAndOther(isAgent: Boolean = false): Document =
-    Jsoup.parse(page(MneOrDomestic.UkAndOther, isAgent)(request, appConfig, messages).toString())
+  lazy val organisationViewUkOnly: Document =
+    Jsoup.parse(page(MneOrDomestic.Uk, plrReference, isAgent = false, Some("orgName"))(request, appConfig, messages).toString())
+  lazy val organisationViewUkAndOther: Document =
+    Jsoup.parse(page(MneOrDomestic.UkAndOther, plrReference, false, Some("orgName"))(request, appConfig, messages).toString())
+  def agentViewUkOnly(organisationName: Option[String] = Some("orgName")): Document =
+    Jsoup.parse(page(MneOrDomestic.Uk, plrReference, isAgent = true, organisationName)(request, appConfig, messages).toString())
+  def agentViewUkAndOther(organisationName: Option[String] = Some("orgName")): Document =
+    Jsoup.parse(page(MneOrDomestic.UkAndOther, plrReference, isAgent = true, organisationName)(request, appConfig, messages).toString())
 
   "BTNAmendDetailsView" when {
     "it's an organisation view" should {
       "have a title" in {
-        viewUkOnly().title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
-        viewUkAndOther().title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+        organisationViewUkOnly.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+        organisationViewUkAndOther.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
       }
 
       "have a unique H1 heading" in {
-        val ukOnlyH1Elements: Elements = viewUkOnly().getElementsByTag("h1")
+        val ukOnlyH1Elements: Elements = organisationViewUkOnly.getElementsByTag("h1")
         ukOnlyH1Elements.size() mustBe 1
         ukOnlyH1Elements.text() mustBe pageTitle
 
-        val ukAndOtherH1Elements: Elements = viewUkAndOther().getElementsByTag("h1")
+        val ukAndOtherH1Elements: Elements = organisationViewUkAndOther.getElementsByTag("h1")
         ukAndOtherH1Elements.size() mustBe 1
         ukAndOtherH1Elements.text() mustBe pageTitle
       }
 
       "have a banner with a link to the Homepage" in {
-        viewUkOnly().getElementsByClass(bannerClassName).attr("href") mustBe routes.HomepageController.onPageLoad().url
-        viewUkAndOther().getElementsByClass(bannerClassName).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        organisationViewUkOnly.getElementsByClass(bannerClassName).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        organisationViewUkAndOther.getElementsByClass(bannerClassName).attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "have paragraph content and link" in {
-        val ukOnlyParagraphs:     Elements = viewUkOnly().getElementsByClass("govuk-body")
-        val ukAndOtherParagraphs: Elements = viewUkAndOther().getElementsByClass("govuk-body")
+        val ukOnlyParagraphs:     Elements = organisationViewUkOnly.getElementsByClass("govuk-body")
+        val ukAndOtherParagraphs: Elements = organisationViewUkAndOther.getElementsByClass("govuk-body")
 
         ukOnlyParagraphs.get(0).text() mustBe "You reported that your group only has entities in the UK."
         ukOnlyParagraphs.get(1).text() mustBe "If this has changed, you must amend your group details to " +
@@ -79,30 +83,37 @@ class BTNAmendDetailsViewSpec extends ViewSpecBase {
       }
 
       "have a back link" in {
-        viewUkOnly().getElementsByClass("govuk-back-link").text mustBe "Back"
-        viewUkAndOther().getElementsByClass("govuk-back-link").text mustBe "Back"
+        organisationViewUkOnly.getElementsByClass("govuk-back-link").text mustBe "Back"
+        organisationViewUkAndOther.getElementsByClass("govuk-back-link").text mustBe "Back"
       }
     }
 
     "it's an agent view" should {
       "have a title" in {
-        viewUkOnly(isAgent = true).title() mustBe s"$pageTitleAgent - Report Pillar 2 Top-up Taxes - GOV.UK"
-        viewUkAndOther(isAgent = true).title() mustBe s"$pageTitleAgent - Report Pillar 2 Top-up Taxes - GOV.UK"
+        agentViewUkOnly().title() mustBe s"$pageTitleAgent - Report Pillar 2 Top-up Taxes - GOV.UK"
+        agentViewUkAndOther().title() mustBe s"$pageTitleAgent - Report Pillar 2 Top-up Taxes - GOV.UK"
+      }
+
+      "have a caption" in {
+        agentViewUkOnly().getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
+        agentViewUkAndOther().getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
+        agentViewUkOnly(organisationName = None).getElementsByClass("govuk-caption-m").text mustBe "ID: XMPLR0123456789"
+        agentViewUkAndOther(organisationName = None).getElementsByClass("govuk-caption-m").text mustBe "ID: XMPLR0123456789"
       }
 
       "have a unique H1 heading" in {
-        viewUkOnly(isAgent = true).getElementsByTag("h1").text mustBe pageTitleAgent
-        viewUkAndOther(isAgent = true).getElementsByTag("h1").text mustBe pageTitleAgent
+        agentViewUkOnly().getElementsByTag("h1").text mustBe pageTitleAgent
+        agentViewUkAndOther().getElementsByTag("h1").text mustBe pageTitleAgent
       }
 
       "have a banner with a link to the Homepage" in {
-        viewUkOnly(isAgent = true).getElementsByClass(bannerClassName).attr("href") mustBe routes.HomepageController.onPageLoad().url
-        viewUkAndOther(isAgent = true).getElementsByClass(bannerClassName).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        agentViewUkOnly().getElementsByClass(bannerClassName).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        agentViewUkAndOther().getElementsByClass(bannerClassName).attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "have paragraph content and link" in {
-        val ukOnlyParagraphs:     Elements = viewUkOnly(isAgent = true).getElementsByClass("govuk-body")
-        val ukAndOtherParagraphs: Elements = viewUkAndOther(isAgent = true).getElementsByClass("govuk-body")
+        val ukOnlyParagraphs:     Elements = agentViewUkOnly().getElementsByClass("govuk-body")
+        val ukAndOtherParagraphs: Elements = agentViewUkAndOther().getElementsByClass("govuk-body")
 
         ukOnlyParagraphs.get(0).text() mustBe "You reported that the group only has entities in the UK."
         ukOnlyParagraphs.get(1).text() mustBe "If this has changed, you must amend the group details to update " +
@@ -120,17 +131,19 @@ class BTNAmendDetailsViewSpec extends ViewSpecBase {
       }
 
       "have a back link" in {
-        viewUkOnly(isAgent = true).getElementsByClass("govuk-back-link").text mustBe "Back"
-        viewUkAndOther(isAgent = true).getElementsByClass("govuk-back-link").text mustBe "Back"
+        agentViewUkOnly().getElementsByClass("govuk-back-link").text mustBe "Back"
+        agentViewUkAndOther().getElementsByClass("govuk-back-link").text mustBe "Back"
       }
     }
 
     val viewScenarios: Seq[ViewScenario] =
       Seq(
-        ViewScenario("viewUkOnly", viewUkOnly()),
-        ViewScenario("viewUkAndOther", viewUkAndOther()),
-        ViewScenario("agentViewUkOnly", viewUkOnly(isAgent = true)),
-        ViewScenario("agentViewUkAndOther", viewUkAndOther(isAgent = true))
+        ViewScenario("organisationViewUkOnly", organisationViewUkOnly),
+        ViewScenario("organisationViewUkAndOther", organisationViewUkAndOther),
+        ViewScenario("agentViewUkOnly", agentViewUkOnly()),
+        ViewScenario("agentViewUkAndOther", agentViewUkAndOther()),
+        ViewScenario("agentNoOrgViewUkOnly", agentViewUkOnly(organisationName = None)),
+        ViewScenario("agentNoOrgViewUkAndOther", agentViewUkAndOther(organisationName = None))
       )
 
     behaveLikeAccessiblePage(viewScenarios)

--- a/test/views/btn/BTNBeforeStartViewSpec.scala
+++ b/test/views/btn/BTNBeforeStartViewSpec.scala
@@ -20,38 +20,56 @@ import base.ViewSpecBase
 import controllers.routes
 import models.NormalMode
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
-import org.jsoup.nodes.Element
+import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
 import views.behaviours.ViewScenario
 import views.html.btn.BTNBeforeStartView
 
 class BTNBeforeStartViewSpec extends ViewSpecBase {
 
-  lazy val page:      BTNBeforeStartView = inject[BTNBeforeStartView]
-  lazy val pageTitle: String             = "Below-Threshold Notification (BTN)"
+  lazy val page:         BTNBeforeStartView = inject[BTNBeforeStartView]
+  lazy val pageTitle:    String             = "Below-Threshold Notification (BTN)"
+  lazy val plrReference: String             = "XMPLR0123456789"
 
-  def view(isAgent: Boolean = false, hasMultipleAccountPeriods: Boolean = false): Document =
-    Jsoup.parse(page(isAgent, hasMultipleAccountPeriods, NormalMode)(request, appConfig, messages).toString())
+  def organisationView(hasMultipleAccountPeriods: Boolean = false, organisationName: Option[String] = Some("orgName")): Document =
+    Jsoup.parse(
+      page(plrReference, isAgent = false, organisationName, hasMultipleAccountPeriods, NormalMode)(
+        request,
+        appConfig,
+        messages
+      ).toString()
+    )
+
+  def agentView(hasMultipleAccountPeriods: Boolean = false, organisationName: Option[String] = Some("orgName")): Document =
+    Jsoup.parse(
+      page(plrReference, isAgent = true, organisationName, hasMultipleAccountPeriods, NormalMode)(request, appConfig, messages)
+        .toString()
+    )
+
+  def agentViewNoOrg(hasMultipleAccountPeriods: Boolean = false): Document =
+    Jsoup.parse(
+      page(plrReference, isAgent = true, organisationName = None, hasMultipleAccountPeriods, NormalMode)(request, appConfig, messages)
+        .toString()
+    )
 
   "BTNBeforeStartView" should {
     "have a title" in {
-      view().title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+      organisationView().title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
     }
 
     "have a unique H1 heading" in {
-      val h1Elements: Elements = view().getElementsByTag("h1")
+      val h1Elements: Elements = organisationView().getElementsByTag("h1")
       h1Elements.size() mustBe 1
       h1Elements.text() mustBe pageTitle
     }
 
     "have a banner with a link to the Homepage" in {
       val className: String = "govuk-header__link govuk-header__service-name"
-      view().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      organisationView().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have two h2 headings" in {
-      val h2Elements: Elements = view().getElementsByTag("h2")
+      val h2Elements: Elements = organisationView().getElementsByTag("h2")
       h2Elements.get(0).text mustBe "Who can submit a Below-Threshold Notification"
       h2Elements.get(0).hasClass("govuk-heading-m") mustBe true
       h2Elements.get(1).text mustBe "Before you start"
@@ -59,7 +77,7 @@ class BTNBeforeStartViewSpec extends ViewSpecBase {
     }
 
     "have group specific content" in {
-      val paragraphs: Elements = view().getElementsByClass("govuk-body")
+      val paragraphs: Elements = organisationView().getElementsByClass("govuk-body")
 
       paragraphs.get(0).text mustBe
         "The Below-Threshold Notification satisfies your group’s obligation to submit a UK Tax Return for the " +
@@ -67,12 +85,16 @@ class BTNBeforeStartViewSpec extends ViewSpecBase {
         "group remains below-threshold."
       paragraphs.get(1).text mustBe "You can submit a Below-Threshold Notification if the group:"
 
-      view().getElementsByClass("govuk-inset-text").text mustBe
+      organisationView().getElementsByClass("govuk-inset-text").text mustBe
         "If you need to submit a UK tax return for this accounting period you do not qualify for a Below-Threshold Notification."
     }
 
     "have agent specific content" in {
-      val paragraphs: Elements = view(isAgent = true).getElementsByClass("govuk-body")
+
+      agentView().getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
+      agentViewNoOrg().getElementsByClass("govuk-caption-m").text mustBe "ID: XMPLR0123456789"
+
+      val paragraphs: Elements = agentView().getElementsByClass("govuk-body")
 
       paragraphs.get(0).text mustBe
         "The Below-Threshold Notification satisfies the group’s obligation to submit a UK Tax Return for the " +
@@ -81,13 +103,13 @@ class BTNBeforeStartViewSpec extends ViewSpecBase {
 
       paragraphs.get(1).text mustBe "The group can submit a Below-Threshold Notification if it:"
 
-      view(isAgent = true).getElementsByClass("govuk-inset-text").text mustBe
+      agentView().getElementsByClass("govuk-inset-text").text mustBe
         "If your client needs to submit a UK tax return for this accounting period they do not qualify for a Below-Threshold Notification."
     }
 
     "have the following common content" in {
-      val paragraphs: Elements = view().getElementsByClass("govuk-body")
-      val listItems:  Elements = view().getElementsByTag("li")
+      val paragraphs: Elements = organisationView().getElementsByClass("govuk-body")
+      val listItems:  Elements = organisationView().getElementsByTag("li")
 
       paragraphs.get(2).text() mustBe "To submit a Below-Threshold Notification you’ll need to tell us:"
 
@@ -105,14 +127,14 @@ class BTNBeforeStartViewSpec extends ViewSpecBase {
 
     "have a button" that {
       "links to the accounting period page when there is only one accounting period present" in {
-        val button: Element = view().getElementsByClass("govuk-button").first()
+        val button: Element = organisationView().getElementsByClass("govuk-button").first()
 
         button.text mustBe "Continue"
         button.attr("href") mustBe controllers.btn.routes.BTNAccountingPeriodController.onPageLoad(NormalMode).url
       }
 
       "links to the choose accounting period page when there are multiple accounting periods present" in {
-        val button: Element = view(hasMultipleAccountPeriods = true).getElementsByClass("govuk-button").first()
+        val button: Element = organisationView(hasMultipleAccountPeriods = true).getElementsByClass("govuk-button").first()
 
         button.text mustBe "Continue"
         button.attr("href") mustBe controllers.btn.routes.BTNChooseAccountingPeriodController.onPageLoad(NormalMode).url
@@ -121,9 +143,10 @@ class BTNBeforeStartViewSpec extends ViewSpecBase {
 
     val viewScenarios: Seq[ViewScenario] =
       Seq(
-        ViewScenario("view", view()),
-        ViewScenario("hasMultipleAccountPeriodsView", view(hasMultipleAccountPeriods = true)),
-        ViewScenario("agentView", view(isAgent = true))
+        ViewScenario("view", organisationView()),
+        ViewScenario("hasMultipleAccountPeriodsView", organisationView(hasMultipleAccountPeriods = true)),
+        ViewScenario("agentView", agentView()),
+        ViewScenario("agentViewNoOrg", agentViewNoOrg())
       )
 
     behaveLikeAccessiblePage(viewScenarios)

--- a/test/views/btn/BTNChooseAccountingPeriodViewSpec.scala
+++ b/test/views/btn/BTNChooseAccountingPeriodViewSpec.scala
@@ -33,46 +33,63 @@ class BTNChooseAccountingPeriodViewSpec extends ViewSpecBase {
   lazy val formProvider: BTNChooseAccountingPeriodFormProvider = new BTNChooseAccountingPeriodFormProvider
   lazy val page:         BTNChooseAccountingPeriodView         = inject[BTNChooseAccountingPeriodView]
   lazy val pageTitle:        String = "Which accounting period would you like to register a Below-Threshold Notification for?"
+  lazy val plrReference:     String = "XMPLR0123456789"
   lazy val organisationName: String = "orgName"
   lazy val accountingPeriodDetails: Seq[(AccountingPeriodDetails, Int)] = Seq(
     AccountingPeriodDetails(LocalDate.now.minusYears(1), LocalDate.now(), LocalDate.now.plusYears(1), underEnquiry = false, Seq.empty),
     AccountingPeriodDetails(LocalDate.now.minusYears(2), LocalDate.now.minusYears(1), LocalDate.now(), underEnquiry = false, Seq.empty)
   ).zipWithIndex
 
-  def view(isAgent: Boolean = false): Document =
-    Jsoup.parse(page(formProvider(), NormalMode, isAgent, Some(organisationName), accountingPeriodDetails)(request, appConfig, messages).toString())
+  lazy val organisationView: Document =
+    Jsoup.parse(
+      page(formProvider(), NormalMode, plrReference, isAgent = false, Some(organisationName), accountingPeriodDetails)(request, appConfig, messages)
+        .toString()
+    )
+
+  lazy val agentView: Document =
+    Jsoup.parse(
+      page(formProvider(), NormalMode, plrReference, isAgent = true, Some(organisationName), accountingPeriodDetails)(request, appConfig, messages)
+        .toString()
+    )
+
+  lazy val agentNoOrgView: Document =
+    Jsoup.parse(
+      page(formProvider(), NormalMode, plrReference, isAgent = true, organisationName = None, accountingPeriodDetails)(request, appConfig, messages)
+        .toString()
+    )
 
   "BTNChooseAccountingPeriodView" should {
     "have a title" in {
-      view().title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+      organisationView.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
     }
 
     "have a unique H1 heading" in {
-      val h1Elements: Elements = view().getElementsByTag("h1")
+      val h1Elements: Elements = organisationView.getElementsByTag("h1")
       h1Elements.size() mustBe 1
       h1Elements.text() mustBe pageTitle
     }
 
     "have a banner with a link to the Homepage" in {
       val className: String = "govuk-header__link govuk-header__service-name"
-      view().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
-      view(isAgent = true).getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      organisationView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      agentView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have a caption for an agent view" in {
-      view(isAgent = true).getElementsByClass("govuk-caption-m").text mustBe organisationName
+      agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
+      agentNoOrgView.getElementsByClass("govuk-caption-m").text mustBe "ID: XMPLR0123456789"
     }
 
     "not have a caption for organisation view" in {
-      view().getElementsByClass("govuk-caption-m").text mustNot include(organisationName)
+      organisationView.getElementsByClass("govuk-caption-m").text mustNot include(organisationName)
     }
 
     "have a paragraph" in {
-      view().getElementsByClass("govuk-body").get(0).text mustBe "We only list the current and previous accounting periods."
+      organisationView.getElementsByClass("govuk-body").get(0).text mustBe "We only list the current and previous accounting periods."
     }
 
     "have radio items" in {
-      val radioButtons: Elements = view().getElementsByClass("govuk-label govuk-radios__label")
+      val radioButtons: Elements = organisationView.getElementsByClass("govuk-label govuk-radios__label")
 
       radioButtons.size() mustBe 2
       radioButtons.get(0).text mustBe s"${accountingPeriodDetails.head._1.formattedDates}"
@@ -80,15 +97,16 @@ class BTNChooseAccountingPeriodViewSpec extends ViewSpecBase {
     }
 
     "have a 'Continue' button" in {
-      val continueButton: Element = view().getElementsByClass("govuk-button").first()
+      val continueButton: Element = organisationView.getElementsByClass("govuk-button").first()
       continueButton.text mustBe "Continue"
       continueButton.attr("type") mustBe "submit"
     }
 
     val viewScenarios: Seq[ViewScenario] =
       Seq(
-        ViewScenario("view", view()),
-        ViewScenario("agentView", view(isAgent = true))
+        ViewScenario("view", organisationView),
+        ViewScenario("agentView", agentView),
+        ViewScenario("agentNoOrgView", agentNoOrgView)
       )
 
     behaveLikeAccessiblePage(viewScenarios)

--- a/test/views/btn/BTNConfirmationViewSpec.scala
+++ b/test/views/btn/BTNConfirmationViewSpec.scala
@@ -55,6 +55,15 @@ class BTNConfirmationViewSpec extends ViewSpecBase {
       ).toString()
     )
 
+  def agentNoOrgView(showUnderEnquiryWarning: Boolean = false): Document =
+    Jsoup.parse(
+      page(companyName = None, Some(plrRef), submissionDateTime, accountingPeriodStart, accountingPeriodEnd, isAgent = true, showUnderEnquiryWarning)(
+        request,
+        appConfig,
+        messages
+      ).toString()
+    )
+
   "BTNConfirmationView" should {
 
     "have a title" in {
@@ -102,10 +111,9 @@ class BTNConfirmationViewSpec extends ViewSpecBase {
 
     "have paragraph content (containing company name) and a link when in an agent flow" in {
       val paragraphs: Elements = agentView().getElementsByClass("govuk-body")
-      val hints:      Elements = agentView().getElementsByClass("govuk-hint")
 
-      hints.get(0).text() mustBe
-        s"Group: $companyName ID: $plrRef"
+      agentView().getElementsByClass("govuk-caption-m").text mustBe "Group: Test Company ID: somePillar2Id"
+      agentNoOrgView().getElementsByClass("govuk-caption-m").text mustBe "ID: somePillar2Id"
 
       paragraphs.get(0).text() mustBe
         s"You have submitted a Below-Threshold Notification on: $submissionDateTime."
@@ -145,6 +153,7 @@ class BTNConfirmationViewSpec extends ViewSpecBase {
         ViewScenario("groupView", groupView()),
         ViewScenario("showUnderEnquiryWarningGroupView", groupView(showUnderEnquiryWarning = true)),
         ViewScenario("agentView", agentView()),
+        ViewScenario("agentNoOrgView", agentNoOrgView()),
         ViewScenario("showUnderEnquiryWarningAgentView", agentView(showUnderEnquiryWarning = true))
       )
 

--- a/test/views/btn/BTNEntitiesInUKOnlyViewSpec.scala
+++ b/test/views/btn/BTNEntitiesInUKOnlyViewSpec.scala
@@ -27,32 +27,39 @@ import views.behaviours.ViewScenario
 import views.html.btn.BTNEntitiesInUKOnlyView
 
 class BTNEntitiesInUKOnlyViewSpec extends ViewSpecBase {
+  lazy val plrReference: String                          = "XMPLR0123456789"
   lazy val formProvider: BTNEntitiesInUKOnlyFormProvider = new BTNEntitiesInUKOnlyFormProvider
   lazy val page:         BTNEntitiesInUKOnlyView         = inject[BTNEntitiesInUKOnlyView]
   lazy val pageTitle:    String                          = "Does the group still have entities located only in the UK?"
 
-  def view(isAgent: Boolean = false): Document =
-    Jsoup.parse(page(formProvider(), isAgent, Some("orgName"), NormalMode)(request, appConfig, messages).toString())
+  lazy val organisationView: Document =
+    Jsoup.parse(page(formProvider(), plrReference, isAgent = false, Some("orgName"), NormalMode)(request, appConfig, messages).toString())
+
+  lazy val agentView: Document =
+    Jsoup.parse(page(formProvider(), plrReference, isAgent = true, Some("orgName"), NormalMode)(request, appConfig, messages).toString())
+
+  lazy val agentNoOrgView: Document =
+    Jsoup.parse(page(formProvider(), plrReference, isAgent = true, organisationName = None, NormalMode)(request, appConfig, messages).toString())
 
   "BTNEntitiesInUKOnlyView" should {
     "have a title" in {
-      view().title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+      organisationView.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
     }
 
     "have a unique H1 heading" in {
-      val h1Elements: Elements = view().getElementsByTag("h1")
+      val h1Elements: Elements = organisationView.getElementsByTag("h1")
       h1Elements.size() mustBe 1
       h1Elements.text() mustBe pageTitle
     }
 
     "have a banner with a link to the Homepage" in {
       val className: String = "govuk-header__link govuk-header__service-name"
-      view().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
-      view(isAgent = true).getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      organisationView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      agentView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have radio items" in {
-      val radioButtons: Elements = view().getElementsByClass("govuk-label govuk-radios__label")
+      val radioButtons: Elements = organisationView.getElementsByClass("govuk-label govuk-radios__label")
 
       radioButtons.size() mustBe 2
       radioButtons.get(0).text mustBe "Yes"
@@ -60,19 +67,21 @@ class BTNEntitiesInUKOnlyViewSpec extends ViewSpecBase {
     }
 
     "have a 'Continue' button" in {
-      val continueButton: Element = view().getElementsByClass("govuk-button").first()
+      val continueButton: Element = organisationView.getElementsByClass("govuk-button").first()
       continueButton.text mustBe "Continue"
       continueButton.attr("type") mustBe "submit"
     }
 
-    "have a caption displaying the organisation name for an agent view" in {
-      view(isAgent = true).getElementsByClass("govuk-caption-m").text mustBe "orgName"
+    "have a caption for agent view" in {
+      agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
+      agentNoOrgView.getElementsByClass("govuk-caption-m").text mustBe "ID: XMPLR0123456789"
     }
 
     val viewScenarios: Seq[ViewScenario] =
       Seq(
-        ViewScenario("view", view()),
-        ViewScenario("agentView", view(isAgent = true))
+        ViewScenario("organisationView", organisationView),
+        ViewScenario("agentView", agentView),
+        ViewScenario("agentNoOrgView", agentNoOrgView)
       )
 
     behaveLikeAccessiblePage(viewScenarios)

--- a/test/views/btn/BTNEntitiesInsideOutsideUKViewSpec.scala
+++ b/test/views/btn/BTNEntitiesInsideOutsideUKViewSpec.scala
@@ -28,32 +28,39 @@ import views.html.btn.BTNEntitiesInsideOutsideUKView
 
 class BTNEntitiesInsideOutsideUKViewSpec extends ViewSpecBase {
   lazy val formProvider: BTNEntitiesInsideOutsideUKFormProvider = new BTNEntitiesInsideOutsideUKFormProvider
+  lazy val plrReference: String                                 = "XMPLR0123456789"
   lazy val page:         BTNEntitiesInsideOutsideUKView         = inject[BTNEntitiesInsideOutsideUKView]
   lazy val pageTitle:    String                                 = "Does the group still have entities located in both the UK and outside the UK?"
 
-  def view(isAgent: Boolean = false): Document =
-    Jsoup.parse(page(formProvider(), isAgent, Some("orgName"), NormalMode)(request, appConfig, messages).toString())
+  lazy val organisationView: Document =
+    Jsoup.parse(page(formProvider(), plrReference, isAgent = false, Some("orgName"), NormalMode)(request, appConfig, messages).toString())
+
+  lazy val agentView: Document =
+    Jsoup.parse(page(formProvider(), plrReference, isAgent = true, Some("orgName"), NormalMode)(request, appConfig, messages).toString())
+
+  lazy val agentNoOrgView: Document =
+    Jsoup.parse(page(formProvider(), plrReference, isAgent = true, organisationName = None, NormalMode)(request, appConfig, messages).toString())
 
   "BTN Entities Both In UK And Outside View" should {
 
     "have a title" in {
-      view().title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+      organisationView.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
     }
 
     "have a unique H1 heading" in {
-      val h1Elements: Elements = view().getElementsByTag("h1")
+      val h1Elements: Elements = organisationView.getElementsByTag("h1")
       h1Elements.size() mustBe 1
       h1Elements.text() mustBe pageTitle
     }
 
     "have a banner with a link to the Homepage" in {
       val className: String = "govuk-header__link govuk-header__service-name"
-      view().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
-      view(isAgent = true).getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      organisationView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      agentView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have radio items" in {
-      val radioButtons: Elements = view().getElementsByClass("govuk-label govuk-radios__label")
+      val radioButtons: Elements = organisationView.getElementsByClass("govuk-label govuk-radios__label")
 
       radioButtons.size() mustBe 2
       radioButtons.get(0).text mustBe "Yes"
@@ -61,19 +68,21 @@ class BTNEntitiesInsideOutsideUKViewSpec extends ViewSpecBase {
     }
 
     "have a 'Continue' button" in {
-      val continueButton: Element = view().getElementsByClass("govuk-button").first()
+      val continueButton: Element = organisationView.getElementsByClass("govuk-button").first()
       continueButton.text mustBe "Continue"
       continueButton.attr("type") mustBe "submit"
     }
 
-    "have a caption displaying the organisation name for an agent view" in {
-      view(isAgent = true).getElementsByClass("govuk-caption-m").text mustBe "orgName"
+    "have a caption for agent view" in {
+      agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
+      agentNoOrgView.getElementsByClass("govuk-caption-m").text mustBe "ID: XMPLR0123456789"
     }
 
     val viewScenarios: Seq[ViewScenario] =
       Seq(
-        ViewScenario("view", view()),
-        ViewScenario("agentView", view(isAgent = true))
+        ViewScenario("view", organisationView),
+        ViewScenario("agentView", agentView),
+        ViewScenario("agentNoOrgView", agentNoOrgView)
       )
 
     behaveLikeAccessiblePage(viewScenarios)

--- a/test/views/btn/BTNReturnSubmittedViewSpec.scala
+++ b/test/views/btn/BTNReturnSubmittedViewSpec.scala
@@ -34,6 +34,7 @@ import java.time.{LocalDate, ZonedDateTime}
 class BTNReturnSubmittedViewSpec extends ViewSpecBase {
 
   lazy val page:                      BTNReturnSubmittedView = inject[BTNReturnSubmittedView]
+  lazy val plrReference:              String                 = "XMPLR0123456789"
   lazy val accountingPeriodStartDate: LocalDate              = LocalDate.now().minusYears(1)
   lazy val accountingPeriodEndDate:   LocalDate              = LocalDate.now()
   lazy val accountingPeriodDueDate:   LocalDate              = LocalDate.now().plusYears(1)
@@ -50,44 +51,51 @@ class BTNReturnSubmittedViewSpec extends ViewSpecBase {
     Seq(Obligation(UKTR, Fulfilled, canAmend = true, Seq(Submission(UKTR_CREATE, ZonedDateTime.now(), None))))
   )
 
-  def view(isAgent: Boolean = false): Document = Jsoup.parse(page(isAgent, accountingPeriodDetails)(request, appConfig, messages).toString())
+  lazy val organisationView: Document =
+    Jsoup.parse(page(plrReference, isAgent = false, Some("orgName"), accountingPeriodDetails)(request, appConfig, messages).toString())
+
+  lazy val agentView: Document =
+    Jsoup.parse(page(plrReference, isAgent = true, Some("orgName"), accountingPeriodDetails)(request, appConfig, messages).toString())
+
+  lazy val agentNoOrgView: Document =
+    Jsoup.parse(page(plrReference, isAgent = true, organisationName = None, accountingPeriodDetails)(request, appConfig, messages).toString())
 
   "BTNAccountingPeriodView" when {
     "it's an organisation" should {
       "have a title" in {
-        view().title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+        organisationView.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
       }
 
       "have a unique H1 heading" in {
-        val h1Elements: Elements = view().getElementsByTag("h1")
+        val h1Elements: Elements = organisationView.getElementsByTag("h1")
         h1Elements.size() mustBe 1
         h1Elements.text() mustBe pageTitle
       }
 
       "have a banner with a link to the Homepage" in {
         val className: String = "govuk-header__link govuk-header__service-name"
-        view().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
-        view(isAgent = true).getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        organisationView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        agentView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "have a paragraph" in {
-        view().getElementsByClass("govuk-body").get(0).text mustBe
+        organisationView.getElementsByClass("govuk-body").get(0).text mustBe
           "By continuing, your UK Tax Return will be replaced for this period."
       }
 
       "have an inset text" in {
-        view().getElementsByClass("govuk-inset-text").text mustBe
+        organisationView.getElementsByClass("govuk-inset-text").text mustBe
           "If you need to submit a UK Tax Return for this accounting period you do not qualify for a Below-Threshold Notification."
       }
 
       "have a 'Continue' button" in {
-        val continueButton: Element = view().getElementsByClass("govuk-button").first()
+        val continueButton: Element = organisationView.getElementsByClass("govuk-button").first()
         continueButton.text mustBe "Continue"
         continueButton.attr("type") mustBe "submit"
       }
 
       "have a Return to Homepage link" in {
-        val link: Element = view().getElementsByClass("govuk-body").last().getElementsByTag("a").first()
+        val link: Element = organisationView.getElementsByClass("govuk-body").last().getElementsByTag("a").first()
         link.text mustBe "Return to homepage"
         link.attr("href") mustBe controllers.routes.HomepageController.onPageLoad().url
         link.attr("target") mustBe "_self"
@@ -98,33 +106,38 @@ class BTNReturnSubmittedViewSpec extends ViewSpecBase {
 
     "it's an agent" should {
       "have a title" in {
-        view(isAgent = true).title() mustBe s"$agentPageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+        agentView.title() mustBe s"$agentPageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+      }
+
+      "have a caption" in {
+        agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
+        agentNoOrgView.getElementsByClass("govuk-caption-m").text mustBe "ID: XMPLR0123456789"
       }
 
       "have a unique H1 heading" in {
-        val h1Elements: Elements = view(isAgent = true).getElementsByTag("h1")
+        val h1Elements: Elements = agentView.getElementsByTag("h1")
         h1Elements.size() mustBe 1
         h1Elements.text() mustBe agentPageTitle
       }
 
       "have a paragraph" in {
-        view(isAgent = true).getElementsByClass("govuk-body").get(0).text mustBe
+        agentView.getElementsByClass("govuk-body").get(0).text mustBe
           "By continuing, the group’s UK Tax Return will be replaced for this period."
       }
 
       "have an inset text" in {
-        view(isAgent = true).getElementsByClass("govuk-inset-text").text mustBe
+        agentView.getElementsByClass("govuk-inset-text").text mustBe
           "If the group needs to submit a UK Tax Return for this accounting period they do not qualify for a Below-Threshold Notification."
       }
 
       "have a 'Continue' button" in {
-        val continueButton: Element = view(isAgent = true).getElementsByClass("govuk-button").first()
+        val continueButton: Element = agentView.getElementsByClass("govuk-button").first()
         continueButton.text mustBe "Continue"
         continueButton.attr("type") mustBe "submit"
       }
 
       "have a Return to Homepage link" in {
-        val link: Element = view(true).getElementsByClass("govuk-body").last().getElementsByTag("a").first()
+        val link: Element = agentView.getElementsByClass("govuk-body").last().getElementsByTag("a").first()
 
         link.text mustBe "Return to homepage"
         link.attr("href") mustBe controllers.routes.HomepageController.onPageLoad().url
@@ -135,8 +148,9 @@ class BTNReturnSubmittedViewSpec extends ViewSpecBase {
 
     val viewScenarios: Seq[ViewScenario] =
       Seq(
-        ViewScenario("view", view()),
-        ViewScenario("agentView", view(isAgent = true))
+        ViewScenario("view", organisationView),
+        ViewScenario("agentView", agentView),
+        ViewScenario("agentNoOrgView", agentNoOrgView)
       )
 
     behaveLikeAccessiblePage(viewScenarios)

--- a/test/views/btn/BTNUnderEnquiryWarningViewSpec.scala
+++ b/test/views/btn/BTNUnderEnquiryWarningViewSpec.scala
@@ -26,24 +26,29 @@ import views.html.btn.BTNUnderEnquiryWarningView
 
 class BTNUnderEnquiryWarningViewSpec extends ViewSpecBase {
 
-  lazy val page:      BTNUnderEnquiryWarningView = inject[BTNUnderEnquiryWarningView]
-  lazy val view:      Document                   = Jsoup.parse(page()(request, appConfig, messages).toString())
-  lazy val pageTitle: String                     = "You have one or more returns under enquiry"
+  lazy val page:         BTNUnderEnquiryWarningView = inject[BTNUnderEnquiryWarningView]
+  lazy val plrReference: String                     = "XMPLR0123456789"
+  lazy val pageTitle:    String                     = "You have one or more returns under enquiry"
+
+  lazy val organisationView: Document = Jsoup.parse(page(plrReference, isAgent = false, Some("orgName"))(request, appConfig, messages).toString())
+  lazy val agentView:        Document = Jsoup.parse(page(plrReference, isAgent = true, Some("orgName"))(request, appConfig, messages).toString())
+  lazy val agentNoOrgView:   Document =
+    Jsoup.parse(page(plrReference, isAgent = true, organisationName = None)(request, appConfig, messages).toString())
 
   "BTNUnderEnquiryWarningView" should {
 
     "have a title" in {
-      view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+      organisationView.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
     }
 
     "have a unique H1 heading" in {
-      val h1Elements: Elements = view.getElementsByTag("h1")
+      val h1Elements: Elements = organisationView.getElementsByTag("h1")
       h1Elements.size() mustBe 1
       h1Elements.text() mustBe pageTitle
     }
 
     "have paragraph content" in {
-      val paragraphs: Elements = view.getElementsByClass("govuk-body")
+      val paragraphs: Elements = organisationView.getElementsByClass("govuk-body")
       paragraphs.get(0).text mustBe "You cannot add a Below-Threshold Notification to an accounting period that is currently under enquiry."
       paragraphs
         .get(1)
@@ -51,18 +56,25 @@ class BTNUnderEnquiryWarningViewSpec extends ViewSpecBase {
     }
 
     "have a continue button" in {
-      view.getElementsByClass("govuk-button").text mustBe "Continue"
+      organisationView.getElementsByClass("govuk-button").text mustBe "Continue"
     }
 
     "have a return to homepage link" in {
-      val link = view.select("a:contains(Return to home page)")
+      val link = organisationView.select("a:contains(Return to home page)")
       link.size() mustBe 1
       link.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
+    "have a caption for agent view" in {
+      agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
+      agentNoOrgView.getElementsByClass("govuk-caption-m").text mustBe "ID: XMPLR0123456789"
+    }
+
     val viewScenarios: Seq[ViewScenario] =
       Seq(
-        ViewScenario("view", view)
+        ViewScenario("organisationView", organisationView),
+        ViewScenario("agentView", agentView),
+        ViewScenario("agentNoOrgView", agentNoOrgView)
       )
 
     behaveLikeAccessiblePage(viewScenarios)

--- a/test/views/btn/CheckYourAnswersViewSpec.scala
+++ b/test/views/btn/CheckYourAnswersViewSpec.scala
@@ -36,6 +36,7 @@ import java.time.LocalDate
 
 class CheckYourAnswersViewSpec extends ViewSpecBase {
 
+  lazy val plrReference:     String               = "XMPLR0123456789"
   lazy val startDate:        LocalDate            = LocalDate.of(2024, 10, 24)
   lazy val endDate:          LocalDate            = LocalDate.of(2025, 10, 24)
   lazy val accountingPeriod: AccountingPeriod     = AccountingPeriod(startDate, endDate)
@@ -53,42 +54,50 @@ class CheckYourAnswersViewSpec extends ViewSpecBase {
       ).flatten
     ).withCssClass("govuk-!-margin-bottom-9")
 
-  def view(summaryList: SummaryList = summaryListCYA(), isAgent: Boolean = false): Document =
-    Jsoup.parse(page(summaryList, isAgent, Some("orgName"))(request, appConfig, realMessagesApi.preferred(request)).toString())
+  def organisationView(summaryList: SummaryList = summaryListCYA()): Document =
+    Jsoup.parse(page(summaryList, plrReference, isAgent = false, Some("orgName"))(request, appConfig, realMessagesApi.preferred(request)).toString())
+
+  def agentView(summaryList: SummaryList = summaryListCYA()): Document =
+    Jsoup.parse(page(summaryList, plrReference, isAgent = true, Some("orgName"))(request, appConfig, realMessagesApi.preferred(request)).toString())
+
+  def agentNoOrgView(summaryList: SummaryList = summaryListCYA()): Document =
+    Jsoup.parse(
+      page(summaryList, plrReference, isAgent = true, organisationName = None)(request, appConfig, realMessagesApi.preferred(request)).toString()
+    )
 
   def getSummaryListActions(doc: Document): Elements = doc.getElementsByClass("govuk-summary-list__actions")
 
   "CheckYourAnswersView" must {
 
     "have a title" in {
-      view().title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+      organisationView().title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
     }
 
     "have a unique H1 heading" in {
-      val h1Elements: Elements = view().getElementsByTag("h1")
+      val h1Elements: Elements = organisationView().getElementsByTag("h1")
       h1Elements.size() mustBe 1
       h1Elements.text() mustBe pageTitle
     }
 
     "have a banner with a link to the Homepage" in {
       val className: String = "govuk-header__link govuk-header__service-name"
-      view().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
-      view(isAgent = true).getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      organisationView().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      agentView().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have a paragraph" in {
-      view().getElementsByClass("govuk-body").get(0).text mustBe "If you submit a Below-Threshold Notification for " +
+      organisationView().getElementsByClass("govuk-body").get(0).text mustBe "If you submit a Below-Threshold Notification for " +
         "a previous accounting period, any return you have submitted this accounting period will be removed."
     }
 
     "have an H2 heading" in {
-      val h2Elements: Elements = view().getElementsByTag("h2")
+      val h2Elements: Elements = organisationView().getElementsByTag("h2")
       h2Elements.get(0).text() mustBe "Submit your Below-Threshold Notification"
       h2Elements.get(0).hasClass("govuk-heading-s") mustBe true
     }
 
     "have a second paragraph" in {
-      view().getElementsByClass("govuk-body").get(1).text mustBe "By submitting these details, you are confirming " +
+      organisationView().getElementsByClass("govuk-body").get(1).text mustBe "By submitting these details, you are confirming " +
         "that the information is correct and complete to the best of your knowledge."
     }
 
@@ -97,7 +106,7 @@ class CheckYourAnswersViewSpec extends ViewSpecBase {
       "UK only entities" should {
 
         "have a summary list" in {
-          val ukOnlyEntitiesView:  Document = view(summaryList = summaryListCYA(ukOnlyEntities = true))
+          val ukOnlyEntitiesView:  Document = organisationView(summaryList = summaryListCYA(ukOnlyEntities = true))
           val summaryListElements: Elements = ukOnlyEntitiesView.getElementsByClass("govuk-summary-list")
           val summaryListKeys:     Elements = ukOnlyEntitiesView.getElementsByClass("govuk-summary-list__key")
           val summaryListItems:    Elements = ukOnlyEntitiesView.getElementsByClass("govuk-summary-list__value")
@@ -115,7 +124,7 @@ class CheckYourAnswersViewSpec extends ViewSpecBase {
         "have the correct summary list actions" when {
 
           "single accounting period" in {
-            val summaryListActions: Elements = getSummaryListActions(view(summaryList = summaryListCYA(ukOnlyEntities = true)))
+            val summaryListActions: Elements = getSummaryListActions(organisationView(summaryList = summaryListCYA(ukOnlyEntities = true)))
 
             summaryListActions.get(0).text mustBe "Change are the entities still located only in the UK?"
             summaryListActions.get(0).getElementsByTag("a").attr("href") mustBe
@@ -124,7 +133,7 @@ class CheckYourAnswersViewSpec extends ViewSpecBase {
 
           "multiple accounting periods" in {
             val summaryListActions: Elements =
-              getSummaryListActions(view(summaryList = summaryListCYA(ukOnlyEntities = true, multipleAccountingPeriods = true)))
+              getSummaryListActions(organisationView(summaryList = summaryListCYA(ukOnlyEntities = true, multipleAccountingPeriods = true)))
 
             summaryListActions.get(0).text mustBe "Change group’s accounting period"
             summaryListActions.get(0).getElementsByTag("a").attr("href") mustBe
@@ -140,7 +149,7 @@ class CheckYourAnswersViewSpec extends ViewSpecBase {
       "when inside and outside UK entities" should {
 
         "have a summary list" in {
-          val ukAndOtherEntities:  Document = view(summaryList = summaryListCYA(ukOnlyEntities = false))
+          val ukAndOtherEntities:  Document = organisationView(summaryList = summaryListCYA(ukOnlyEntities = false))
           val summaryListElements: Elements = ukAndOtherEntities.getElementsByClass("govuk-summary-list")
           val summaryListKeys:     Elements = ukAndOtherEntities.getElementsByClass("govuk-summary-list__key")
           val summaryListItems:    Elements = ukAndOtherEntities.getElementsByClass("govuk-summary-list__value")
@@ -157,7 +166,7 @@ class CheckYourAnswersViewSpec extends ViewSpecBase {
 
         "have a summary list actions" when {
           "single accounting period" in {
-            val summaryListActions: Elements = getSummaryListActions(view())
+            val summaryListActions: Elements = getSummaryListActions(organisationView())
 
             summaryListActions.get(0).text mustBe "Change are the entities still located in both the UK and outside the UK?"
             summaryListActions.get(0).getElementsByTag("a").attr("href") mustBe
@@ -165,7 +174,7 @@ class CheckYourAnswersViewSpec extends ViewSpecBase {
           }
 
           "multiple accounting periods" in {
-            val summaryListActions: Elements = getSummaryListActions(view(summaryList = summaryListCYA(multipleAccountingPeriods = true)))
+            val summaryListActions: Elements = getSummaryListActions(organisationView(summaryList = summaryListCYA(multipleAccountingPeriods = true)))
 
             summaryListActions.get(0).text mustBe "Change group’s accounting period"
             summaryListActions.get(0).getElementsByTag("a").attr("href") mustBe
@@ -180,19 +189,21 @@ class CheckYourAnswersViewSpec extends ViewSpecBase {
     }
 
     "have a 'Confirm and submit' button" in {
-      val continueButton: Element = view().getElementsByClass("govuk-button").first()
+      val continueButton: Element = organisationView().getElementsByClass("govuk-button").first()
       continueButton.text mustBe "Confirm and submit"
       continueButton.attr("type") mustBe "submit"
     }
 
     "have a caption displaying the organisation name for an agent view" in {
-      view(isAgent = true).getElementsByClass("govuk-caption-m").text mustBe "orgName"
+      agentView().getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
+      agentNoOrgView().getElementsByClass("govuk-caption-m").text mustBe "ID: XMPLR0123456789"
     }
 
     val viewScenarios: Seq[ViewScenario] =
       Seq(
-        ViewScenario("view", view()),
-        ViewScenario("agentView", view(isAgent = true))
+        ViewScenario("view", organisationView()),
+        ViewScenario("agentView", agentView()),
+        ViewScenario("agentNoOrgView", agentNoOrgView())
       )
 
     behaveLikeAccessiblePage(viewScenarios)

--- a/test/views/subscriptionview/manageAccount/NewAccountingPeriodViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/NewAccountingPeriodViewSpec.scala
@@ -41,60 +41,76 @@ class NewAccountingPeriodViewSpec extends ViewSpecBase {
   val endDate:          LocalDate        = LocalDate.of(2027, 3, 15)
   val accountingPeriod: AccountingPeriod = AccountingPeriod(startDate, endDate)
 
-  val chosenAccountingPeriod: ChosenAccountingPeriod = ChosenAccountingPeriod(
+  val chosenAccountingPeriodData: ChosenAccountingPeriod = ChosenAccountingPeriod(
     accountingPeriod,
     None,
     None
   )
 
-  def view(
-    chosenAccountingPeriod: ChosenAccountingPeriod = chosenAccountingPeriod,
-    isAgent:                Boolean = false,
-    orgName:                Option[String] = None
-  ): Document =
+  def organisationView(chosenAccountingPeriod: ChosenAccountingPeriod = chosenAccountingPeriodData): Document =
     Jsoup.parse(
-      page(formProvider(chosenAccountingPeriod), chosenAccountingPeriod, isAgent, orgName, plrReference, NormalMode)(request, appConfig, messages)
+      page(formProvider(chosenAccountingPeriod), chosenAccountingPeriod, isAgent = false, Some("orgName"), plrReference, NormalMode)(
+        request,
+        appConfig,
+        messages
+      )
         .toString()
     )
 
-  lazy val organisationView: Document = view()
-  lazy val agentView:        Document = view(isAgent = true, orgName = Some("orgName"))
-  lazy val agentViewNoOrg:   Document = view(isAgent = true)
+  def agentView(chosenAccountingPeriod: ChosenAccountingPeriod = chosenAccountingPeriodData): Document =
+    Jsoup.parse(
+      page(formProvider(chosenAccountingPeriod), chosenAccountingPeriod, isAgent = true, Some("orgName"), plrReference, NormalMode)(
+        request,
+        appConfig,
+        messages
+      )
+        .toString()
+    )
+
+  def agentNoOrgView(chosenAccountingPeriod: ChosenAccountingPeriod = chosenAccountingPeriodData): Document =
+    Jsoup.parse(
+      page(formProvider(chosenAccountingPeriod), chosenAccountingPeriod, isAgent = true, organisationName = None, plrReference, NormalMode)(
+        request,
+        appConfig,
+        messages
+      )
+        .toString()
+    )
 
   "NewAccountingPeriodView" when {
     "it's an organisation" must {
       "have a title" in {
-        organisationView.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+        organisationView().title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
       }
 
       "have a unique H1 heading" in {
-        val h1Elements: Elements = organisationView.getElementsByTag("h1")
+        val h1Elements: Elements = organisationView().getElementsByTag("h1")
         h1Elements.size() mustBe 1
         h1Elements.text() mustBe pageTitle
       }
 
       "have a banner with a link to the Homepage" in {
         val className: String = "govuk-header__link govuk-header__service-name"
-        organisationView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        organisationView().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "have inset text" in {
-        organisationView.getElementsByClass("govuk-inset-text").text mustBe
+        organisationView().getElementsByClass("govuk-inset-text").text mustBe
           s"You are changing accounting period: ${startDate.toDateFormat} to ${endDate.toDateFormat}"
-        organisationView.getElementsByClass("govuk-inset-text").html must include("<br>")
+        organisationView().getElementsByClass("govuk-inset-text").html must include("<br>")
       }
 
       "have the following paragraph content" in {
-        organisationView.getElementsByClass("govuk-body").get(0).text mustBe
+        organisationView().getElementsByClass("govuk-body").get(0).text mustBe
           "The accounting period is the period covered by the consolidated financial statements of the Ultimate Parent Entity."
 
-        organisationView.getElementsByClass("govuk-body").get(1).text mustBe
+        organisationView().getElementsByClass("govuk-body").get(1).text mustBe
           "Accounting periods are usually 12 months, but can be longer or shorter."
 
       }
 
       "have start and end date legends" in {
-        val datesFieldsets:    Elements = organisationView.getElementsByClass("govuk-fieldset")
+        val datesFieldsets:    Elements = organisationView().getElementsByClass("govuk-fieldset")
         val startDateFieldset: Element  = datesFieldsets.get(0)
         val endDateFieldset:   Element  = datesFieldsets.get(1)
 
@@ -128,11 +144,11 @@ class NewAccountingPeriodViewSpec extends ViewSpecBase {
           val chosenAccountingPeriod =
             ChosenAccountingPeriod(selectedAccountingPeriod = accountingPeriod, startDateBoundary = None, endDateBoundary = None)
 
-          view(chosenAccountingPeriod = chosenAccountingPeriod)
+          organisationView(chosenAccountingPeriod = chosenAccountingPeriod)
             .getElementById("startDate-hint")
             .text mustBe s"Enter a date after 30 December 2023, for example 16 3 2026"
 
-          view(chosenAccountingPeriod = chosenAccountingPeriod)
+          organisationView(chosenAccountingPeriod = chosenAccountingPeriod)
             .getElementById("endDate-hint")
             .text mustBe s"Enter a date, for example 15 3 2027"
         }
@@ -145,52 +161,52 @@ class NewAccountingPeriodViewSpec extends ViewSpecBase {
               endDateBoundary = Some(LocalDate.of(2025, 12, 31))
             )
 
-          view(chosenAccountingPeriod = chosenAccountingPeriod)
+          organisationView(chosenAccountingPeriod = chosenAccountingPeriod)
             .getElementById("startDate-hint")
             .text mustBe s"Enter a date after 31 December 2023, for example 16 3 2024"
 
-          view(chosenAccountingPeriod = chosenAccountingPeriod)
+          organisationView(chosenAccountingPeriod = chosenAccountingPeriod)
             .getElementById("endDate-hint")
             .text mustBe s"Enter a date before 1 January 2026, for example 15 3 2025"
         }
       }
 
       "have a 'Continue' button" in {
-        organisationView.getElementsByClass("govuk-button").text mustBe "Continue"
+        organisationView().getElementsByClass("govuk-button").text mustBe "Continue"
       }
     }
 
     "it's an agent" must {
       "have a title" in {
-        agentView.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+        agentView().title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
       }
 
       "have a caption" in {
-        agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
-        agentViewNoOrg.getElementsByClass("govuk-caption-m") mustBe empty
+        agentView().getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
+        agentNoOrgView().getElementsByClass("govuk-caption-m").text mustBe "ID: XMPLR0123456789"
       }
 
       "have a unique H1 heading" in {
-        val h1Elements: Elements = agentView.getElementsByTag("h1")
+        val h1Elements: Elements = agentView().getElementsByTag("h1")
         h1Elements.size() mustBe 1
         h1Elements.text() mustBe pageTitle
       }
 
       "have a banner with a link to the Homepage" in {
         val className: String = "govuk-header__link govuk-header__service-name"
-        agentView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        agentView().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "have the following paragraph content" in {
-        agentView.getElementsByClass("govuk-body").get(0).text mustBe
+        agentView().getElementsByClass("govuk-body").get(0).text mustBe
           "The accounting period is the period covered by the consolidated financial statements of the Ultimate Parent Entity."
 
-        agentView.getElementsByClass("govuk-body").get(1).text mustBe
+        agentView().getElementsByClass("govuk-body").get(1).text mustBe
           "Accounting periods are usually 12 months, but can be longer or shorter."
       }
 
       "have start and end date legends" in {
-        val datesFieldsets:    Elements = agentView.getElementsByClass("govuk-fieldset")
+        val datesFieldsets:    Elements = agentView().getElementsByClass("govuk-fieldset")
         val startDateFieldset: Element  = datesFieldsets.get(0)
         val endDateFieldset:   Element  = datesFieldsets.get(1)
 
@@ -224,11 +240,11 @@ class NewAccountingPeriodViewSpec extends ViewSpecBase {
           val chosenAccountingPeriod =
             ChosenAccountingPeriod(selectedAccountingPeriod = accountingPeriod, startDateBoundary = None, endDateBoundary = None)
 
-          view(chosenAccountingPeriod = chosenAccountingPeriod, isAgent = true)
+          agentView(chosenAccountingPeriod = chosenAccountingPeriod)
             .getElementById("startDate-hint")
             .text mustBe s"Enter a date after 30 December 2023, for example 16 3 2026"
 
-          view(chosenAccountingPeriod = chosenAccountingPeriod, isAgent = true)
+          agentView(chosenAccountingPeriod = chosenAccountingPeriod)
             .getElementById("endDate-hint")
             .text mustBe s"Enter a date, for example 15 3 2027"
         }
@@ -241,26 +257,26 @@ class NewAccountingPeriodViewSpec extends ViewSpecBase {
               endDateBoundary = Some(LocalDate.of(2025, 12, 31))
             )
 
-          view(chosenAccountingPeriod = chosenAccountingPeriod, isAgent = true)
+          agentView(chosenAccountingPeriod = chosenAccountingPeriod)
             .getElementById("startDate-hint")
             .text mustBe s"Enter a date after 31 December 2023, for example 16 3 2024"
 
-          view(chosenAccountingPeriod = chosenAccountingPeriod, isAgent = true)
+          agentView(chosenAccountingPeriod = chosenAccountingPeriod)
             .getElementById("endDate-hint")
             .text mustBe s"Enter a date before 1 January 2026, for example 15 3 2025"
         }
       }
 
       "have a 'Continue' button" in {
-        agentView.getElementsByClass("govuk-button").text mustBe "Continue"
+        agentView().getElementsByClass("govuk-button").text mustBe "Continue"
       }
     }
 
     val viewScenarios: Seq[ViewScenario] =
       Seq(
-        ViewScenario("view", organisationView),
-        ViewScenario("agentView", agentView),
-        ViewScenario("agentViewNoOrg", agentViewNoOrg)
+        ViewScenario("view", organisationView()),
+        ViewScenario("agentView", agentView()),
+        ViewScenario("agentViewNoOrg", agentNoOrgView())
       )
 
     behaveLikeAccessiblePage(viewScenarios)


### PR DESCRIPTION
Added group name and ID for agent views in the BTN journey and corrected implementation on two other pages (new accounting period / stoodover charges)