### PR TITLE
[NOJIRA] - fix contact phone fields being overwritten when multiperiod flag is set to true after being set to false

### DIFF
--- a/app/models/subscription/AmendSubscription.scala
+++ b/app/models/subscription/AmendSubscription.scala
@@ -48,7 +48,7 @@ final case class ContactDetailsType(
 )
 
 object ContactDetailsType {
-  val reads: Reads[ContactDetailsType] = (
+  given reads: Reads[ContactDetailsType] = (
     (__ \ "name").read[String] and
       (__ \ "telephone")
         .readNullable[String]
@@ -56,7 +56,7 @@ object ContactDetailsType {
       (__ \ "emailAddress").read[String]
   )(ContactDetailsType.apply _)
 
-  val writes: OWrites[ContactDetailsType] = (
+  given writes: OWrites[ContactDetailsType] = (
     (__ \ "name").write[String] and
       (__ \ "telephone").writeNullable[String] and
       (__ \ "emailAddress").write[String]

--- a/app/models/subscription/AmendSubscription.scala
+++ b/app/models/subscription/AmendSubscription.scala
@@ -16,7 +16,8 @@
 
 package models.subscription
 
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
+import play.api.libs.json.{Json, OFormat, OWrites, Reads, __}
 
 import java.time.LocalDate
 
@@ -46,6 +47,24 @@ final case class ContactDetailsType(
   emailAddress: String
 )
 
+object ContactDetailsType {
+  val reads: Reads[ContactDetailsType] = (
+    (__ \ "name").read[String] and
+      (__ \ "telephone")
+        .readNullable[String]
+        .orElse((__ \ "phone").readNullable[String]) and
+      (__ \ "emailAddress").read[String]
+  )(ContactDetailsType.apply _)
+
+  val writes: OWrites[ContactDetailsType] = (
+    (__ \ "name").write[String] and
+      (__ \ "telephone").writeNullable[String] and
+      (__ \ "emailAddress").write[String]
+  )(c => (c.name, c.phone, c.emailAddress))
+
+  given format: OFormat[ContactDetailsType] = OFormat(reads, writes)
+}
+
 final case class FilingMemberAmendDetails(
   addNewFilingMember:      Boolean = false,
   safeId:                  String,
@@ -58,9 +77,6 @@ object AmendSubscription {
 }
 object UpeDetailsAmend {
   given format: OFormat[UpeDetailsAmend] = Json.format[UpeDetailsAmend]
-}
-object ContactDetailsType {
-  given format: OFormat[ContactDetailsType] = Json.format[ContactDetailsType]
 }
 
 object FilingMemberAmendDetails {

--- a/app/models/subscription/AmendSubscription.scala
+++ b/app/models/subscription/AmendSubscription.scala
@@ -17,7 +17,7 @@
 package models.subscription
 
 import play.api.libs.functional.syntax.toFunctionalBuilderOps
-import play.api.libs.json.{Json, OFormat, OWrites, Reads, __}
+import play.api.libs.json.*
 
 import java.time.LocalDate
 

--- a/app/services/SubscriptionService.scala
+++ b/app/services/SubscriptionService.scala
@@ -87,15 +87,29 @@ class SubscriptionService @Inject() (
         Future.failed(InternalIssueError)
     }
 
-  /** Call Read Subscription V2, convert to SubscriptionLocalData, and save to user-cache. */
+  /** Call Read Subscription V2, convert to SubscriptionLocalData, and save to user-cache, also does not overwrite phone related fields on flag
+    * alternation.
+    */
   def readSubscriptionV2AndSave(
     userId:       String,
     plrReference: String
   )(using hc: HeaderCarrier): Future[SubscriptionLocalData] =
-    subscriptionConnector.readSubscriptionV2(userId, plrReference).flatMap { v2 =>
-      val local = subscriptionDataV2ToLocalData(plrReference, v2)
-      subscriptionConnector.save(userId, Json.toJson(local)).map(_ => local)
-    }
+    for {
+      existingOpt <- subscriptionConnector.getSubscriptionCache(userId)
+      v2          <- subscriptionConnector.readSubscriptionV2(userId, plrReference)
+      fresh  = subscriptionDataV2ToLocalData(plrReference, v2)
+      merged = existingOpt match {
+                 case Some(existing) =>
+                   fresh.copy(
+                     subPrimaryPhonePreference = existing.subPrimaryPhonePreference,
+                     subPrimaryCapturePhone = existing.subPrimaryCapturePhone,
+                     subSecondaryPhonePreference = existing.subSecondaryPhonePreference,
+                     subSecondaryCapturePhone = existing.subSecondaryCapturePhone
+                   )
+                 case None => fresh
+               }
+      _ <- subscriptionConnector.save(userId, Json.toJson(merged))
+    } yield merged
 
   private def subscriptionDataV2ToLocalData(plrReference: String, v2: SubscriptionDataV2): SubscriptionLocalData = {
     val address = v2.upeCorrespAddressDetails

--- a/test/services/SubscriptionServiceSpec.scala
+++ b/test/services/SubscriptionServiceSpec.scala
@@ -953,6 +953,8 @@ class SubscriptionServiceSpec extends SpecBase {
             .thenReturn(Future.successful(v2Data))
           when(mockSubscriptionConnector.save(eqTo("id"), any())(using any()))
             .thenReturn(Future.successful(play.api.libs.json.Json.obj()))
+          when(mockSubscriptionConnector.getSubscriptionCache(eqTo("id"))(using any(), any()))
+            .thenReturn(Future.successful(None))
 
           val result = service.readSubscriptionV2AndSave("id", plrRef).futureValue
           result.plrReference mustBe plrRef
@@ -982,6 +984,8 @@ class SubscriptionServiceSpec extends SpecBase {
             .thenReturn(Future.successful(v2DataWithDetails))
           when(mockSubscriptionConnector.save(eqTo("id"), any())(using any()))
             .thenReturn(Future.successful(play.api.libs.json.Json.obj()))
+          when(mockSubscriptionConnector.getSubscriptionCache(eqTo("id"))(using any(), any()))
+            .thenReturn(Future.successful(None))
 
           val result = service.readSubscriptionV2AndSave("id", plrRef).futureValue
           result.upeCustomerIdentification1 mustBe Some("CRN123")
@@ -999,6 +1003,8 @@ class SubscriptionServiceSpec extends SpecBase {
             .thenReturn(Future.successful(v2Data))
           when(mockSubscriptionConnector.save(eqTo("id"), any())(using any()))
             .thenReturn(Future.failed(InternalIssueError))
+          when(mockSubscriptionConnector.getSubscriptionCache(eqTo("id"))(using any(), any()))
+            .thenReturn(Future.successful(None))
 
           service.readSubscriptionV2AndSave("id", plrRef).failed.futureValue mustBe InternalIssueError
         }
@@ -1007,6 +1013,8 @@ class SubscriptionServiceSpec extends SpecBase {
         running(application) {
           when(mockSubscriptionConnector.readSubscriptionV2(any(), any())(using any(), any()))
             .thenReturn(Future.failed(InternalIssueError))
+          when(mockSubscriptionConnector.getSubscriptionCache(eqTo("id"))(using any(), any()))
+            .thenReturn(Future.successful(None))
 
           service.readSubscriptionV2AndSave("id", plrRef).failed.futureValue mustBe InternalIssueError
         }


### PR DESCRIPTION
This nojira fixes a bug where when the multi period flag is false and then alternated to true, the phone related contact fields would get wiped. This caused failing ATs and also could cause issues with real users once we flip the flag for real