### PR TITLE
PIL-2890: Added group name and ID for agent views in repayment journey

### DIFF
--- a/app/controllers/repayments/BankAccountDetailsController.scala
+++ b/app/controllers/repayments/BankAccountDetailsController.scala
@@ -22,7 +22,7 @@ import controllers.actions.*
 import forms.BankAccountDetailsFormProvider
 import models.Mode
 import models.repayments.BankAccountDetails
-import pages.{BankAccountDetailsPage, BarsAccountNamePartialPage, RepaymentAccountNameConfirmationPage}
+import pages.{AgentClientOrganisationNamePage, BankAccountDetailsPage, BarsAccountNamePartialPage, RepaymentAccountNameConfirmationPage}
 import play.api.Logging
 import play.api.data.Form
 import play.api.i18n.{I18nSupport, MessagesApi}
@@ -65,7 +65,9 @@ class BankAccountDetailsController @Inject() (
         updatedUserAnswer  <- Future.fromTry(request.userAnswers.remove(BarsAccountNamePartialPage))
         updatedUserAnswer1 <- Future.fromTry(updatedUserAnswer.remove(RepaymentAccountNameConfirmationPage))
         _                  <- sessionRepository.set(updatedUserAnswer1)
-      } yield Ok(view(preparedForm, mode))
+      } yield Ok(
+        view(preparedForm, mode, request.request.isAgent, request.request.clientPillar2Id, request.userAnswers.get(AgentClientOrganisationNamePage))
+      )
     }
 
   def onSubmit(mode: Mode): Action[AnyContent] =
@@ -74,14 +76,33 @@ class BankAccountDetailsController @Inject() (
       form
         .bindFromRequest()
         .fold(
-          formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode))),
+          formWithErrors =>
+            Future.successful(
+              BadRequest(
+                view(
+                  formWithErrors,
+                  mode,
+                  request.request.isAgent,
+                  request.request.clientPillar2Id,
+                  request.userAnswers.get(AgentClientOrganisationNamePage)
+                )
+              )
+            ),
           bankAccountDetails =>
             for {
               updatedAnswers <- Future.fromTry(request.userAnswers.set(BankAccountDetailsPage, bankAccountDetails))
               _              <- sessionRepository.set(updatedAnswers)
               result         <-
                 barsService
-                  .verifyBusinessAccount(bankAccountDetails, updatedAnswers, form, mode)
+                  .verifyBusinessAccount(
+                    bankAccountDetails,
+                    updatedAnswers,
+                    form,
+                    mode,
+                    request.request.isAgent,
+                    request.request.clientPillar2Id,
+                    request.userAnswers.get(AgentClientOrganisationNamePage)
+                  )
             } yield result
         )
     }

--- a/app/controllers/repayments/BankAccountDetailsController.scala
+++ b/app/controllers/repayments/BankAccountDetailsController.scala
@@ -22,7 +22,7 @@ import controllers.actions.*
 import forms.BankAccountDetailsFormProvider
 import models.Mode
 import models.repayments.BankAccountDetails
-import pages.{AgentClientOrganisationNamePage, BankAccountDetailsPage, BarsAccountNamePartialPage, RepaymentAccountNameConfirmationPage}
+import pages.*
 import play.api.Logging
 import play.api.data.Form
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/repayments/NonUKBankController.scala
+++ b/app/controllers/repayments/NonUKBankController.scala
@@ -22,7 +22,7 @@ import forms.NonUKBankFormProvider
 import models.Mode
 import models.repayments.NonUKBank
 import navigation.RepaymentNavigator
-import pages.NonUKBankPage
+import pages.{AgentClientOrganisationNamePage, NonUKBankPage}
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.libs.json.Format.GenericFormat
@@ -57,7 +57,7 @@ class NonUKBankController @Inject() (
         case None        => form
         case Some(value) => form.fill(value)
       }
-      Ok(view(preparedForm, mode))
+      Ok(view(preparedForm, mode, request.request.isAgent, request.request.clientPillar2Id, request.userAnswers.get(AgentClientOrganisationNamePage)))
     }
 
   def onSubmit(mode: Mode): Action[AnyContent] =
@@ -66,7 +66,18 @@ class NonUKBankController @Inject() (
       form
         .bindFromRequest()
         .fold(
-          formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode))),
+          formWithErrors =>
+            Future.successful(
+              BadRequest(
+                view(
+                  formWithErrors,
+                  mode,
+                  request.request.isAgent,
+                  request.request.clientPillar2Id,
+                  request.userAnswers.get(AgentClientOrganisationNamePage)
+                )
+              )
+            ),
           value =>
             for {
               updatedAnswers <- Future.fromTry(request.userAnswers.set(NonUKBankPage, value))

--- a/app/controllers/repayments/ReasonForRequestingRepaymentController.scala
+++ b/app/controllers/repayments/ReasonForRequestingRepaymentController.scala
@@ -21,7 +21,7 @@ import controllers.actions.*
 import forms.ReasonForRequestingRepaymentFormProvider
 import models.Mode
 import navigation.RepaymentNavigator
-import pages.ReasonForRequestingRefundPage
+import pages.{AgentClientOrganisationNamePage, ReasonForRequestingRefundPage}
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.libs.json.Format.GenericFormat
@@ -53,7 +53,15 @@ class ReasonForRequestingRepaymentController @Inject() (
     (identify andThen getData andThen requireData andThen journeyGuard) { request =>
       given Request[AnyContent] = request
       val preparedForm          = request.userAnswers.get(ReasonForRequestingRefundPage).map(form.fill).getOrElse(form)
-      Ok(view(preparedForm, mode))
+      Ok(
+        view(
+          preparedForm,
+          mode,
+          request.request.isAgent,
+          request.request.clientPillar2Id,
+          request.userAnswers.get(AgentClientOrganisationNamePage)
+        )
+      )
     }
 
   def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async { request =>
@@ -61,7 +69,18 @@ class ReasonForRequestingRepaymentController @Inject() (
     form
       .bindFromRequest()
       .fold(
-        formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode))),
+        formWithErrors =>
+          Future.successful(
+            BadRequest(
+              view(
+                formWithErrors,
+                mode,
+                request.request.isAgent,
+                request.request.clientPillar2Id,
+                request.userAnswers.get(AgentClientOrganisationNamePage)
+              )
+            )
+          ),
         value =>
           for {
             updatedAnswers <- Future.fromTry(request.userAnswers.set(ReasonForRequestingRefundPage, value))

--- a/app/controllers/repayments/RepaymentsCheckYourAnswersController.scala
+++ b/app/controllers/repayments/RepaymentsCheckYourAnswersController.scala
@@ -67,7 +67,17 @@ class RepaymentsCheckYourAnswersController @Inject() (
           Redirect(controllers.routes.WaitingRoomController.onPageLoad(Repayments))
         case Some(SuccessfullyCompleted) =>
           Redirect(controllers.repayments.routes.RepaymentErrorReturnController.onPageLoad())
-        case _ => Ok(view(listRefund(), listBankAccountDetails(), contactDetailsList()))
+        case _ =>
+          Ok(
+            view(
+              listRefund(),
+              listBankAccountDetails(),
+              contactDetailsList(),
+              request.request.isAgent,
+              request.request.clientPillar2Id,
+              request.userAnswers.get(AgentClientOrganisationNamePage)
+            )
+          )
       }
     }
 

--- a/app/controllers/repayments/RepaymentsContactByPhoneController.scala
+++ b/app/controllers/repayments/RepaymentsContactByPhoneController.scala
@@ -21,7 +21,7 @@ import controllers.actions.*
 import forms.RepaymentsContactByPhoneFormProvider
 import models.Mode
 import navigation.RepaymentNavigator
-import pages.{RepaymentsContactByPhonePage, RepaymentsContactNamePage}
+import pages.{AgentClientOrganisationNamePage, RepaymentsContactByPhonePage, RepaymentsContactNamePage}
 import play.api.i18n.I18nSupport
 import play.api.libs.json.Format.GenericFormat
 import play.api.mvc.*
@@ -57,7 +57,16 @@ class RepaymentsContactByPhoneController @Inject() (
             case None        => form
             case Some(value) => form.fill(value)
           }
-          Ok(view(preparedForm, mode, contactName))
+          Ok(
+            view(
+              preparedForm,
+              mode,
+              contactName,
+              request.request.isAgent,
+              request.request.clientPillar2Id,
+              request.userAnswers.get(AgentClientOrganisationNamePage)
+            )
+          )
         }
         .getOrElse(Redirect(controllers.repayments.routes.RepaymentsJourneyRecoveryController.onPageLoad))
     }
@@ -71,7 +80,19 @@ class RepaymentsContactByPhoneController @Inject() (
           formProvider(name)
             .bindFromRequest()
             .fold(
-              formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, name))),
+              formWithErrors =>
+                Future.successful(
+                  BadRequest(
+                    view(
+                      formWithErrors,
+                      mode,
+                      name,
+                      request.request.isAgent,
+                      request.request.clientPillar2Id,
+                      request.userAnswers.get(AgentClientOrganisationNamePage)
+                    )
+                  )
+                ),
               value =>
                 for {
                   updatedAnswers <- Future.fromTry(request.userAnswers.set(RepaymentsContactByPhonePage, value))

--- a/app/controllers/repayments/RepaymentsContactEmailController.scala
+++ b/app/controllers/repayments/RepaymentsContactEmailController.scala
@@ -21,7 +21,7 @@ import controllers.actions.*
 import forms.RepaymentsContactEmailFormProvider
 import models.Mode
 import navigation.RepaymentNavigator
-import pages.{RepaymentsContactEmailPage, RepaymentsContactNamePage}
+import pages.{AgentClientOrganisationNamePage, RepaymentsContactEmailPage, RepaymentsContactNamePage}
 import play.api.i18n.I18nSupport
 import play.api.libs.json.Format.GenericFormat
 import play.api.mvc.*
@@ -57,7 +57,16 @@ class RepaymentsContactEmailController @Inject() (
             case Some(value) => form.fill(value)
             case None        => form
           }
-          Ok(view(preparedForm, mode, username))
+          Ok(
+            view(
+              preparedForm,
+              mode,
+              username,
+              request.request.isAgent,
+              request.request.clientPillar2Id,
+              request.userAnswers.get(AgentClientOrganisationNamePage)
+            )
+          )
         }
         .getOrElse(Redirect(controllers.repayments.routes.RepaymentsJourneyRecoveryController.onPageLoad))
     }
@@ -71,7 +80,19 @@ class RepaymentsContactEmailController @Inject() (
           formProvider(name)
             .bindFromRequest()
             .fold(
-              formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, name))),
+              formWithErrors =>
+                Future.successful(
+                  BadRequest(
+                    view(
+                      formWithErrors,
+                      mode,
+                      name,
+                      request.request.isAgent,
+                      request.request.clientPillar2Id,
+                      request.userAnswers.get(AgentClientOrganisationNamePage)
+                    )
+                  )
+                ),
               value =>
                 for {
                   updatedAnswers <- Future.fromTry(request.userAnswers.set(RepaymentsContactEmailPage, value))

--- a/app/controllers/repayments/RepaymentsContactNameController.scala
+++ b/app/controllers/repayments/RepaymentsContactNameController.scala
@@ -21,7 +21,7 @@ import controllers.actions.*
 import forms.RepaymentsContactNameFormProvider
 import models.Mode
 import navigation.RepaymentNavigator
-import pages.RepaymentsContactNamePage
+import pages.{AgentClientOrganisationNamePage, RepaymentsContactNamePage}
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.libs.json.Format.GenericFormat
@@ -56,7 +56,7 @@ class RepaymentsContactNameController @Inject() (
         case None        => form
         case Some(value) => form.fill(value)
       }
-      Ok(view(preparedForm, mode))
+      Ok(view(preparedForm, mode, request.request.isAgent, request.request.clientPillar2Id, request.userAnswers.get(AgentClientOrganisationNamePage)))
     }
 
   def onSubmit(mode: Mode): Action[AnyContent] =
@@ -65,7 +65,18 @@ class RepaymentsContactNameController @Inject() (
       form
         .bindFromRequest()
         .fold(
-          formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode))),
+          formWithErrors =>
+            Future.successful(
+              BadRequest(
+                view(
+                  formWithErrors,
+                  mode,
+                  request.request.isAgent,
+                  request.request.clientPillar2Id,
+                  request.userAnswers.get(AgentClientOrganisationNamePage)
+                )
+              )
+            ),
           value =>
             for {
               updatedAnswers <- Future.fromTry(request.userAnswers.set(RepaymentsContactNamePage, value))

--- a/app/controllers/repayments/RepaymentsPhoneDetailsController.scala
+++ b/app/controllers/repayments/RepaymentsPhoneDetailsController.scala
@@ -21,7 +21,7 @@ import controllers.actions.*
 import forms.CapturePhoneDetailsFormProvider
 import models.Mode
 import navigation.RepaymentNavigator
-import pages.{AgentClientOrganisationNamePage, RepaymentsContactByPhonePage, RepaymentsContactNamePage, RepaymentsPhoneDetailsPage}
+import pages.*
 import play.api.i18n.I18nSupport
 import play.api.libs.json.Format.GenericFormat
 import play.api.mvc.*

--- a/app/controllers/repayments/RepaymentsPhoneDetailsController.scala
+++ b/app/controllers/repayments/RepaymentsPhoneDetailsController.scala
@@ -21,7 +21,7 @@ import controllers.actions.*
 import forms.CapturePhoneDetailsFormProvider
 import models.Mode
 import navigation.RepaymentNavigator
-import pages.{RepaymentsContactByPhonePage, RepaymentsContactNamePage, RepaymentsPhoneDetailsPage}
+import pages.{AgentClientOrganisationNamePage, RepaymentsContactByPhonePage, RepaymentsContactNamePage, RepaymentsPhoneDetailsPage}
 import play.api.i18n.I18nSupport
 import play.api.libs.json.Format.GenericFormat
 import play.api.mvc.*
@@ -59,7 +59,16 @@ class RepaymentsPhoneDetailsController @Inject() (
           case Some(value) => form.fill(value)
         }
 
-        Ok(view(preparedForm, mode, contactName))
+        Ok(
+          view(
+            preparedForm,
+            mode,
+            contactName,
+            request.request.isAgent,
+            request.request.clientPillar2Id,
+            request.userAnswers.get(AgentClientOrganisationNamePage)
+          )
+        )
       })
         .getOrElse(Redirect(controllers.repayments.routes.RepaymentsJourneyRecoveryController.onPageLoad))
     }
@@ -73,7 +82,19 @@ class RepaymentsPhoneDetailsController @Inject() (
           formProvider(name)
             .bindFromRequest()
             .fold(
-              formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, name))),
+              formWithErrors =>
+                Future.successful(
+                  BadRequest(
+                    view(
+                      formWithErrors,
+                      mode,
+                      name,
+                      request.request.isAgent,
+                      request.request.clientPillar2Id,
+                      request.userAnswers.get(AgentClientOrganisationNamePage)
+                    )
+                  )
+                ),
               phoneNumber =>
                 for {
                   updatedAnswers <- Future.fromTry(request.userAnswers.set(RepaymentsPhoneDetailsPage, phoneNumber))

--- a/app/controllers/repayments/RequestRepaymentAmountController.scala
+++ b/app/controllers/repayments/RequestRepaymentAmountController.scala
@@ -21,7 +21,7 @@ import controllers.actions.*
 import forms.RequestRepaymentAmountFormProvider
 import models.{Mode, NormalMode}
 import navigation.RepaymentNavigator
-import pages.RepaymentsRefundAmountPage
+import pages.{AgentClientOrganisationNamePage, RepaymentsRefundAmountPage}
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.libs.json.Format.GenericFormat
@@ -55,7 +55,15 @@ class RequestRepaymentAmountController @Inject() (
         case None        => form
         case Some(value) => form.fill(value.setScale(2))
       }
-      Ok(view(preparedForm, mode))
+      Ok(
+        view(
+          preparedForm,
+          mode,
+          request.request.isAgent,
+          request.request.clientPillar2Id,
+          request.userAnswers.get(AgentClientOrganisationNamePage)
+        )
+      )
     }
 
   def onSubmit(mode: Mode = NormalMode): Action[AnyContent] =
@@ -64,7 +72,18 @@ class RequestRepaymentAmountController @Inject() (
       form
         .bindFromRequest()
         .fold(
-          formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode))),
+          formWithErrors =>
+            Future.successful(
+              BadRequest(
+                view(
+                  formWithErrors,
+                  mode,
+                  request.request.isAgent,
+                  request.request.clientPillar2Id,
+                  request.userAnswers.get(AgentClientOrganisationNamePage)
+                )
+              )
+            ),
           value =>
             for {
               updatedAnswers <- Future.fromTry(request.userAnswers.set(RepaymentsRefundAmountPage, value))

--- a/app/controllers/repayments/RequestRepaymentBeforeStartController.scala
+++ b/app/controllers/repayments/RequestRepaymentBeforeStartController.scala
@@ -18,7 +18,7 @@ package controllers.repayments
 
 import config.FrontendAppConfig
 import controllers.actions.*
-import pages.RepaymentsStatusPage
+import pages.{AgentClientOrganisationNamePage, RepaymentsStatusPage}
 import play.api.i18n.I18nSupport
 import play.api.mvc.*
 import repositories.SessionRepository
@@ -45,7 +45,15 @@ class RequestRepaymentBeforeStartController @Inject() (
       Future
         .fromTry(request.userAnswers.remove(RepaymentsStatusPage))
         .flatMap(sessionRepository.set)
-        .map(_ => Ok(view(agentView = request.request.isAgent)))
+        .map(_ =>
+          Ok(
+            view(
+              agentView = request.request.isAgent,
+              plrReference = request.request.clientPillar2Id,
+              organisationName = request.userAnswers.get(AgentClientOrganisationNamePage)
+            )
+          )
+        )
         .recover { case _ =>
           Redirect(controllers.routes.JourneyRecoveryController.onPageLoad())
         }

--- a/app/controllers/repayments/UkOrAbroadBankAccountController.scala
+++ b/app/controllers/repayments/UkOrAbroadBankAccountController.scala
@@ -21,7 +21,7 @@ import controllers.actions.*
 import forms.UkOrAbroadBankAccountFormProvider
 import models.{Mode, UkOrAbroadBankAccount}
 import navigation.RepaymentNavigator
-import pages.UkOrAbroadBankAccountPage
+import pages.{AgentClientOrganisationNamePage, UkOrAbroadBankAccountPage}
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.libs.json.Format.GenericFormat
@@ -53,7 +53,15 @@ class UkOrAbroadBankAccountController @Inject() (
     (identify andThen getData andThen requireData andThen journeyGuard) { request =>
       given Request[AnyContent] = request
       val preparedForm          = request.userAnswers.get(UkOrAbroadBankAccountPage).map(form.fill).getOrElse(form)
-      Ok(view(preparedForm, mode))
+      Ok(
+        view(
+          preparedForm,
+          mode,
+          request.request.isAgent,
+          request.request.clientPillar2Id,
+          request.userAnswers.get(AgentClientOrganisationNamePage)
+        )
+      )
     }
 
   def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async { request =>
@@ -61,7 +69,18 @@ class UkOrAbroadBankAccountController @Inject() (
     form
       .bindFromRequest()
       .fold(
-        formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode))),
+        formWithErrors =>
+          Future.successful(
+            BadRequest(
+              view(
+                formWithErrors,
+                mode,
+                request.request.isAgent,
+                request.request.clientPillar2Id,
+                request.userAnswers.get(AgentClientOrganisationNamePage)
+              )
+            )
+          ),
         value =>
           for {
             updatedAnswers <- Future.fromTry(request.userAnswers.set(UkOrAbroadBankAccountPage, value))

--- a/app/services/BarsService.scala
+++ b/app/services/BarsService.scala
@@ -50,10 +50,13 @@ class BarsService @Inject() (
 ) extends Logging {
 
   def verifyBusinessAccount(
-    details:     BankAccountDetails,
-    userAnswers: UserAnswers,
-    form:        Form[BankAccountDetails],
-    mode:        Mode
+    details:          BankAccountDetails,
+    userAnswers:      UserAnswers,
+    form:             Form[BankAccountDetails],
+    mode:             Mode,
+    isAgent:          Boolean,
+    plrReference:     Option[String],
+    organisationName: Option[String]
   )(using
     hc:       HeaderCarrier,
     request:  Request[?],
@@ -64,7 +67,7 @@ class BarsService @Inject() (
     for {
       barsResponse <- barsConnector.verify(Business(details.nameOnBankAccount), Account(details.sortCode, details.accountNumber), trackingId)
       _ = logger.info(s"Request has been sent to BARS with trackingId=$trackingId")
-      result <- handleBarsResponse(barsResponse, userAnswers, mode, form)
+      result <- handleBarsResponse(barsResponse, userAnswers, mode, isAgent, plrReference, organisationName, form)
     } yield result
   }
 
@@ -72,6 +75,9 @@ class BarsService @Inject() (
     barsAccountResponse: BarsAccountResponse,
     userAnswers:         UserAnswers,
     mode:                Mode,
+    isAgent:             Boolean,
+    plrReference:        Option[String],
+    organisationName:    Option[String],
     form:                Form[BankAccountDetails]
   )(using request: Request[?], messages: Messages): Future[Result] = {
     import barsAccountResponse.*
@@ -112,6 +118,9 @@ class BarsService @Inject() (
           sortCodeIsPresentOnEISCD,
           userAnswers,
           mode,
+          isAgent,
+          plrReference,
+          organisationName,
           form
         )
 
@@ -123,6 +132,9 @@ class BarsService @Inject() (
           sortCodeIsPresentOnEISCD,
           userAnswers,
           mode,
+          isAgent,
+          plrReference,
+          organisationName,
           form
         )
 
@@ -140,6 +152,9 @@ class BarsService @Inject() (
           sortCodeIsPresentOnEISCD,
           userAnswers,
           mode,
+          isAgent,
+          plrReference,
+          organisationName,
           form
         )
 
@@ -163,6 +178,9 @@ class BarsService @Inject() (
     sortCodeIsPresentOnEISCD:     SortCodeIsPresentOnEISCD,
     userAnswers:                  UserAnswers,
     mode:                         Mode,
+    isAgent:                      Boolean,
+    plrReference:                 Option[String],
+    organisationName:             Option[String],
     form:                         Form[BankAccountDetails]
   )(using request: Request[?], messages: Messages): Result =
     accountExists match {
@@ -176,6 +194,9 @@ class BarsService @Inject() (
           sortCodeIsPresentOnEISCD,
           userAnswers,
           mode,
+          isAgent,
+          plrReference,
+          organisationName,
           form
         )
       case _ => Redirect(routes.RepaymentErrorController.onPageLoadError())
@@ -188,6 +209,9 @@ class BarsService @Inject() (
     sortCodeIsPresentOnEISCD:     SortCodeIsPresentOnEISCD,
     userAnswers:                  UserAnswers,
     mode:                         Mode,
+    isAgent:                      Boolean,
+    plrReference:                 Option[String],
+    organisationName:             Option[String],
     form:                         Form[BankAccountDetails]
   )(using request: Request[?], messages: Messages): Result =
     nameMatches match {
@@ -201,6 +225,9 @@ class BarsService @Inject() (
           sortCodeIsPresentOnEISCD,
           userAnswers,
           mode,
+          isAgent,
+          plrReference,
+          organisationName,
           form
         )
       case _ => Redirect(routes.RepaymentErrorController.onPageLoadError())
@@ -225,6 +252,9 @@ class BarsService @Inject() (
     sortCodeIsPresentOnEISCD:     SortCodeIsPresentOnEISCD,
     userAnswers:                  UserAnswers,
     mode:                         Mode,
+    isAgent:                      Boolean,
+    plrReference:                 Option[String],
+    organisationName:             Option[String],
     form:                         Form[BankAccountDetails]
   )(using request: Request[?], messages: Messages): Result = {
     val preparedForm = userAnswers.get(BankAccountDetailsPage).map(ua => form.fill(ua)).getOrElse(form)
@@ -247,6 +277,6 @@ class BarsService @Inject() (
       }
     }
 
-    BadRequest(view(bankAccountFormWithErrors, mode))
+    BadRequest(view(bankAccountFormWithErrors, mode, isAgent, plrReference, organisationName))
   }
 }

--- a/app/views/repayments/BankAccountDetailsView.scala.html
+++ b/app/views/repayments/BankAccountDetailsView.scala.html
@@ -27,7 +27,7 @@
         govukInput: GovukInput
 )
 
-@(form: Form[_], mode: Mode)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(form: Form[_], mode: Mode, isAgent: Boolean, plrReference: Option[String], organisationName: Option[String])(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
     @layout(pageTitle = title(form, messages("repayments.bankAccountDetails.title")), bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
@@ -36,6 +36,11 @@
             @if(form.errors.nonEmpty) {
                 @govukErrorSummary(ErrorSummaryViewModel(form))
             }
+
+            @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
+                <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
+            }
+
             @heading(messages("repayments.bankAccountDetails.heading"), Some(messages("repayments.bankAccountDetails.hint")))
             @govukInput(
                 InputViewModel(

--- a/app/views/repayments/NonUKBankView.scala.html
+++ b/app/views/repayments/NonUKBankView.scala.html
@@ -28,7 +28,7 @@
     p: paragraphBody
 )
 
-@(form: Form[_], mode: Mode)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(form: Form[_], mode: Mode, isAgent: Boolean, plrReference: Option[String], organisationName: Option[String])(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @layout(pageTitle = title(form, messages("repayments.nonUKBank.title")), bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
@@ -36,6 +36,10 @@
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
+            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
         }
 
         @heading(messages("repayments.nonUKBank.heading"), Some(messages("repayments.nonUKBank.hint")))

--- a/app/views/repayments/ReasonForRequestingRefundView.scala.html
+++ b/app/views/repayments/ReasonForRequestingRefundView.scala.html
@@ -25,7 +25,7 @@
     govukButton: GovukButton
 )
 
-@(form: Form[_], mode: Mode)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(form: Form[_], mode: Mode, isAgent: Boolean, plrReference: Option[String], organisationName: Option[String])(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @layout(pageTitle = title(form, messages("reasonForRequestingRepayment.title")), bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
@@ -33,6 +33,10 @@
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
+            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
         }
 
         @govukCharacterCount(CharacterCount(

--- a/app/views/repayments/RepaymentsCheckYourAnswersView.scala.html
+++ b/app/views/repayments/RepaymentsCheckYourAnswersView.scala.html
@@ -30,12 +30,16 @@
         bulletList: bulletList
 )
 
-@(listRefund: SummaryList, listBankAccountDetails: SummaryList, contactDetailsList: SummaryList)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(listRefund: SummaryList, listBankAccountDetails: SummaryList, contactDetailsList: SummaryList, isAgent: Boolean, plrReference: Option[String], organisationName: Option[String])(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @layout(pageTitle = titleNoForm(messages("repaymentsCheckYourAnswers.title")), bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
 
     @formHelper(action = controllers.repayments.routes.RepaymentsCheckYourAnswersController.onSubmit()) {
+
+        @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
+            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
+        }
 
         @heading(messages("repaymentsCheckYourAnswers.heading"), classes = "govuk-heading-l")
 

--- a/app/views/repayments/RepaymentsConfirmationView.scala.html
+++ b/app/views/repayments/RepaymentsConfirmationView.scala.html
@@ -41,7 +41,7 @@
   bannerUrl = Some(routes.HomepageController.onPageLoad().url)
 ) {
   @if(isAgent) {
-      <div class="govuk-hint govuk-!-margin-top-0">
+      <div class="govuk-caption-m">
           <span><strong>@{messages("homepage.group")}:</strong> @orgName</span>
           <span><strong>@{messages("homepage.id")}:</strong> @plrRef</span>
       </div>

--- a/app/views/repayments/RepaymentsContactByPhoneView.scala.html
+++ b/app/views/repayments/RepaymentsContactByPhoneView.scala.html
@@ -26,7 +26,7 @@
 )
 
 
-@(form: Form[_], mode: Mode, contactName:String)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(form: Form[_], mode: Mode, contactName: String, isAgent: Boolean, plrReference: Option[String], organisationName: Option[String])(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @layout(pageTitle = title(form, messages("repayments.contactByPhone.title")), bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
@@ -35,6 +35,11 @@
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form,  errorLinkOverrides = Map("value" -> "value_0")))
         }
+
+        @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
+            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
+        }
+
         @govukRadios(
             RadiosViewModel.yesNo(
                 field  = form("value"),

--- a/app/views/repayments/RepaymentsContactEmailView.scala.html
+++ b/app/views/repayments/RepaymentsContactEmailView.scala.html
@@ -26,7 +26,7 @@
     govukButton: GovukButton
 )
 
-@(form: Form[_], mode: Mode, contactName:String)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(form: Form[_], mode: Mode, contactName: String, isAgent: Boolean, plrReference: Option[String], organisationName: Option[String])(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @layout(pageTitle = title(form, messages("repayments.contactEmail.title")), bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
@@ -34,6 +34,10 @@
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
+            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
         }
 
         @govukInput(

--- a/app/views/repayments/RepaymentsContactNameView.scala.html
+++ b/app/views/repayments/RepaymentsContactNameView.scala.html
@@ -26,7 +26,7 @@
     govukButton: GovukButton
 )
 
-@(form: Form[_], mode: Mode)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(form: Form[_], mode: Mode, isAgent: Boolean, plrReference: Option[String], organisationName: Option[String])(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @layout(pageTitle = title(form, messages("repayments.contactName.title")), bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
@@ -34,6 +34,10 @@
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
+            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
         }
 
         @govukInput(

--- a/app/views/repayments/RepaymentsPhoneDetailsView.scala.html
+++ b/app/views/repayments/RepaymentsPhoneDetailsView.scala.html
@@ -29,7 +29,7 @@
 )
 
 
-@(form: Form[_], mode: Mode, contactName:String)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(form: Form[_], mode: Mode, contactName: String, isAgent: Boolean, plrReference: Option[String], organisationName: Option[String])(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @layout(pageTitle = title(form, messages("capturePhoneDetails.title")), bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
@@ -39,7 +39,10 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @sectionHeader(messages("repayments.phoneDetails.heading.caption"))
+        @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
+            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
+        }
+
         @govukInput(
             InputViewModel(
                 field = form("phoneNumber"),

--- a/app/views/repayments/RequestRefundAmountView.scala.html
+++ b/app/views/repayments/RequestRefundAmountView.scala.html
@@ -28,7 +28,7 @@
         govukButton: GovukButton
 )
 
-@(form: Form[_], mode: Mode)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(form: Form[_], mode: Mode, isAgent: Boolean, plrReference: Option[String], organisationName: Option[String])(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @layout(pageTitle = title(form, messages("repayment.requestRepaymentAmount.title")), bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
@@ -36,6 +36,10 @@
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
+            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
         }
 
         @govukInput(

--- a/app/views/repayments/RequestRefundBeforeStartView.scala.html
+++ b/app/views/repayments/RequestRefundBeforeStartView.scala.html
@@ -30,12 +30,15 @@
     bulletList: bulletList,
 )
 
-@(agentView: Boolean)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(agentView: Boolean, plrReference: Option[String], organisationName: Option[String])(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @layout(
     pageTitle = titleNoForm(messages("repayment.requestRepaymentBeforeStart.title")),
     bannerUrl = Some(routes.HomepageController.onPageLoad().url)
 ) {
+    @if(agentView && plrReference.isDefined && organisationName.isDefined) {
+        <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
+    }
     @heading(messages("repayment.requestRepaymentBeforeStart.header"), classes = "govuk-heading-l")
     @if(agentView) {
         @p(messages("repayment.requestRepaymentBeforeStart.agentView.p1"))

--- a/app/views/repayments/UkOrAbroadBankAccountView.scala.html
+++ b/app/views/repayments/UkOrAbroadBankAccountView.scala.html
@@ -24,7 +24,7 @@
     govukButton: GovukButton
 )
 
-@(form: Form[_], mode: Mode)(implicit request: Request[_], appConfig: FrontendAppConfig,messages: Messages)
+@(form: Form[_], mode: Mode, isAgent: Boolean, plrReference: Option[String], organisationName: Option[String])(implicit request: Request[_], appConfig: FrontendAppConfig,messages: Messages)
 
 @layout(pageTitle = title(form, messages("ukOrAbroadBankAccount.title")), bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
@@ -32,6 +32,10 @@
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form,  errorLinkOverrides = Map("value" -> "value_0")))
+        }
+
+        @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
+            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
         }
 
         @govukRadios(

--- a/test/controllers/repayments/BankAccountDetailsControllerSpec.scala
+++ b/test/controllers/repayments/BankAccountDetailsControllerSpec.scala
@@ -47,7 +47,11 @@ class BankAccountDetailsControllerSpec extends SpecBase {
         val view    = application.injector.instanceOf[BankAccountDetailsView]
         val result  = route(application, request).value
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(formProvider(), NormalMode)(request, applicationConfig, messages(application)).toString
+        contentAsString(result) mustEqual view(formProvider(), NormalMode, isAgent = false, None, None)(
+          request,
+          applicationConfig,
+          messages(application)
+        ).toString
       }
     }
 
@@ -65,7 +69,7 @@ class BankAccountDetailsControllerSpec extends SpecBase {
         val result  = route(application, request).value
         status(result) mustEqual OK
         contentAsString(result) mustEqual
-          view(formProvider().fill(testBankAccountDetails), NormalMode)(
+          view(formProvider().fill(testBankAccountDetails), NormalMode, isAgent = false, None, None)(
             request,
             applicationConfig,
             messages(application)
@@ -87,7 +91,7 @@ class BankAccountDetailsControllerSpec extends SpecBase {
 
       running(application) {
 
-        when(mockBarsService.verifyBusinessAccount(any(), any(), any(), any())(using any(), any(), any()))
+        when(mockBarsService.verifyBusinessAccount(any(), any(), any(), any(), any(), any(), any())(using any(), any(), any()))
           .thenReturn(Future successful Redirect(controllers.repayments.routes.RepaymentsContactNameController.onPageLoad(NormalMode)))
 
         when(mockSessionRepository.set(any())).thenReturn(Future.successful(true))
@@ -116,7 +120,11 @@ class BankAccountDetailsControllerSpec extends SpecBase {
         val view      = application.injector.instanceOf[BankAccountDetailsView]
         val result    = route(application, request).value
         status(result) mustEqual BAD_REQUEST
-        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, applicationConfig, messages(application)).toString
+        contentAsString(result) mustEqual view(boundForm, NormalMode, isAgent = false, None, None)(
+          request,
+          applicationConfig,
+          messages(application)
+        ).toString
       }
     }
 

--- a/test/controllers/repayments/NonUKBankControllerSpec.scala
+++ b/test/controllers/repayments/NonUKBankControllerSpec.scala
@@ -44,7 +44,11 @@ class NonUKBankControllerSpec extends SpecBase {
         val view    = application.injector.instanceOf[NonUKBankView]
         val result  = route(application, request).value
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(formProvider(), NormalMode)(request, applicationConfig, messages(application)).toString
+        contentAsString(result) mustEqual view(formProvider(), NormalMode, isAgent = false, None, None)(
+          request,
+          applicationConfig,
+          messages(application)
+        ).toString
       }
     }
 
@@ -60,7 +64,13 @@ class NonUKBankControllerSpec extends SpecBase {
         val result  = route(application, request).value
         status(result) mustEqual OK
         contentAsString(result) mustEqual
-          view(formProvider().fill(NonUKBank("BankName", "Name", Some("HBUKGB4B"), Some("GB29NWBK60161331926819"))), NormalMode)(
+          view(
+            formProvider().fill(NonUKBank("BankName", "Name", Some("HBUKGB4B"), Some("GB29NWBK60161331926819"))),
+            NormalMode,
+            isAgent = false,
+            None,
+            None
+          )(
             request,
             applicationConfig,
             messages(application)
@@ -98,7 +108,11 @@ class NonUKBankControllerSpec extends SpecBase {
         val view      = application.injector.instanceOf[NonUKBankView]
         val result    = route(application, request).value
         status(result) mustEqual BAD_REQUEST
-        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, applicationConfig, messages(application)).toString
+        contentAsString(result) mustEqual view(boundForm, NormalMode, isAgent = false, None, None)(
+          request,
+          applicationConfig,
+          messages(application)
+        ).toString
       }
     }
 

--- a/test/controllers/repayments/ReasonForRequestingRepaymentControllerSpec.scala
+++ b/test/controllers/repayments/ReasonForRequestingRepaymentControllerSpec.scala
@@ -50,7 +50,11 @@ class ReasonForRequestingRepaymentControllerSpec extends SpecBase {
         val view    = application.injector.instanceOf[ReasonForRequestingRefundView]
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(formProvider(), NormalMode)(request, applicationConfig, messages(application)).toString
+        contentAsString(result) mustEqual view(formProvider(), NormalMode, isAgent = false, None, None)(
+          request,
+          applicationConfig,
+          messages(application)
+        ).toString
       }
     }
 
@@ -64,7 +68,7 @@ class ReasonForRequestingRepaymentControllerSpec extends SpecBase {
         val result  = route(application, request).value
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(formProvider().fill("answer"), NormalMode)(
+        contentAsString(result) mustEqual view(formProvider().fill("answer"), NormalMode, isAgent = false, None, None)(
           request,
           applicationConfig,
           messages(application)
@@ -82,7 +86,11 @@ class ReasonForRequestingRepaymentControllerSpec extends SpecBase {
         val result    = route(application, request).value
 
         status(result) mustEqual BAD_REQUEST
-        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, applicationConfig, messages(application)).toString
+        contentAsString(result) mustEqual view(boundForm, NormalMode, isAgent = false, None, None)(
+          request,
+          applicationConfig,
+          messages(application)
+        ).toString
       }
     }
 

--- a/test/controllers/repayments/RepaymentsContactByPhoneControllerSpec.scala
+++ b/test/controllers/repayments/RepaymentsContactByPhoneControllerSpec.scala
@@ -53,7 +53,7 @@ class RepaymentsContactByPhoneControllerSpec extends SpecBase {
         val view   = application.injector.instanceOf[RepaymentsContactByPhoneView]
         val result = route(application, request).value
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(form, NormalMode, "ABC Limited")(
+        contentAsString(result) mustEqual view(form, NormalMode, "ABC Limited", isAgent = false, None, None)(
           request,
           applicationConfig,
           messages(application)
@@ -85,7 +85,7 @@ class RepaymentsContactByPhoneControllerSpec extends SpecBase {
         val result = route(application, request).value
         status(result) mustEqual OK
         contentAsString(result) mustEqual
-          view(form.fill(true), NormalMode, "ABC Limited")(
+          view(form.fill(true), NormalMode, "ABC Limited", isAgent = false, None, None)(
             request,
             applicationConfig,
             messages(application)
@@ -143,7 +143,7 @@ class RepaymentsContactByPhoneControllerSpec extends SpecBase {
         val view      = application.injector.instanceOf[RepaymentsContactByPhoneView]
         val result    = route(application, request).value
         status(result) mustEqual BAD_REQUEST
-        contentAsString(result) mustEqual view(boundForm, NormalMode, "ABC Limited")(
+        contentAsString(result) mustEqual view(boundForm, NormalMode, "ABC Limited", isAgent = false, None, None)(
           request,
           applicationConfig,
           messages(application)

--- a/test/controllers/repayments/RepaymentsContactEmailControllerSpec.scala
+++ b/test/controllers/repayments/RepaymentsContactEmailControllerSpec.scala
@@ -58,7 +58,7 @@ class RepaymentsContactEmailControllerSpec extends SpecBase {
         val view   = application.injector.instanceOf[RepaymentsContactEmailView]
         val result = route(application, request).value
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(form, NormalMode, "ABC Limited")(
+        contentAsString(result) mustEqual view(form, NormalMode, "ABC Limited", isAgent = false, None, None)(
           request,
           applicationConfig,
           messages(application)
@@ -91,7 +91,7 @@ class RepaymentsContactEmailControllerSpec extends SpecBase {
         val result = route(application, request).value
         status(result) mustEqual OK
         contentAsString(result) mustEqual
-          view(form.fill("hello@bye.com"), NormalMode, "ABC Limited")(
+          view(form.fill("hello@bye.com"), NormalMode, "ABC Limited", isAgent = false, None, None)(
             request,
             applicationConfig,
             messages(application)
@@ -131,7 +131,7 @@ class RepaymentsContactEmailControllerSpec extends SpecBase {
         val view      = application.injector.instanceOf[RepaymentsContactEmailView]
         val result    = route(application, request).value
         status(result) mustEqual BAD_REQUEST
-        contentAsString(result) mustEqual view(boundForm, NormalMode, "ABC Limited")(
+        contentAsString(result) mustEqual view(boundForm, NormalMode, "ABC Limited", isAgent = false, None, None)(
           request,
           applicationConfig,
           messages(application)

--- a/test/controllers/repayments/RepaymentsContactNameControllerSpec.scala
+++ b/test/controllers/repayments/RepaymentsContactNameControllerSpec.scala
@@ -44,7 +44,11 @@ class RepaymentsContactNameControllerSpec extends SpecBase {
         val view   = application.injector.instanceOf[RepaymentsContactNameView]
         val result = route(application, request).value
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(formProvider(), NormalMode)(request, applicationConfig, messages(application)).toString
+        contentAsString(result) mustEqual view(formProvider(), NormalMode, isAgent = false, None, None)(
+          request,
+          applicationConfig,
+          messages(application)
+        ).toString
       }
     }
 
@@ -67,7 +71,7 @@ class RepaymentsContactNameControllerSpec extends SpecBase {
         val result = route(application, request).value
         status(result) mustEqual OK
         contentAsString(result) mustEqual
-          view(formProvider().fill("ABC Limited"), NormalMode)(
+          view(formProvider().fill("ABC Limited"), NormalMode, isAgent = false, None, None)(
             request,
             applicationConfig,
             messages(application)

--- a/test/controllers/repayments/RepaymentsPhoneDetailsControllerSpec.scala
+++ b/test/controllers/repayments/RepaymentsPhoneDetailsControllerSpec.scala
@@ -59,7 +59,7 @@ class RepaymentsPhoneDetailsControllerSpec extends SpecBase {
         val view   = application.injector.instanceOf[RepaymentsPhoneDetailsView]
         val result = route(application, request).value
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(form, NormalMode, "ABC Limited")(
+        contentAsString(result) mustEqual view(form, NormalMode, "ABC Limited", isAgent = false, None, None)(
           request,
           applicationConfig,
           messages(application)
@@ -94,7 +94,7 @@ class RepaymentsPhoneDetailsControllerSpec extends SpecBase {
         val result = route(application, request).value
         status(result) mustEqual OK
         contentAsString(result) mustEqual
-          view(form.fill("12345"), NormalMode, "ABC Limited")(
+          view(form.fill("12345"), NormalMode, "ABC Limited", isAgent = false, None, None)(
             request,
             applicationConfig,
             messages(application)
@@ -134,7 +134,7 @@ class RepaymentsPhoneDetailsControllerSpec extends SpecBase {
         val view      = application.injector.instanceOf[RepaymentsPhoneDetailsView]
         val result    = route(application, request).value
         status(result) mustEqual BAD_REQUEST
-        contentAsString(result) mustEqual view(boundForm, NormalMode, "ABC Limited")(
+        contentAsString(result) mustEqual view(boundForm, NormalMode, "ABC Limited", isAgent = false, None, None)(
           request,
           applicationConfig,
           messages(application)

--- a/test/controllers/repayments/RequestRepaymentAmountControllerSpec.scala
+++ b/test/controllers/repayments/RequestRepaymentAmountControllerSpec.scala
@@ -43,7 +43,7 @@ class RequestRepaymentAmountControllerSpec extends SpecBase {
         val view    = application.injector.instanceOf[RequestRefundAmountView]
         val result  = route(application, request).value
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(formProvider(), NormalMode)(
+        contentAsString(result) mustEqual view(formProvider(), NormalMode, isAgent = false, None, None)(
           request,
           applicationConfig,
           messages(application)
@@ -64,7 +64,7 @@ class RequestRepaymentAmountControllerSpec extends SpecBase {
         val result  = route(application, request).value
         val view    = application.injector.instanceOf[RequestRefundAmountView]
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(formProvider().fill(amount), NormalMode)(
+        contentAsString(result) mustEqual view(formProvider().fill(amount), NormalMode, isAgent = false, None, None)(
           request,
           applicationConfig,
           messages(application)
@@ -98,7 +98,7 @@ class RequestRepaymentAmountControllerSpec extends SpecBase {
         val view      = application.injector.instanceOf[RequestRefundAmountView]
         val result    = route(application, request).value
         status(result) mustEqual BAD_REQUEST
-        contentAsString(result) mustEqual view(boundForm, NormalMode)(
+        contentAsString(result) mustEqual view(boundForm, NormalMode, isAgent = false, None, None)(
           request,
           applicationConfig,
           messages(application)
@@ -115,7 +115,7 @@ class RequestRepaymentAmountControllerSpec extends SpecBase {
         val view      = application.injector.instanceOf[RequestRefundAmountView]
         val result    = route(application, request).value
         status(result) mustEqual BAD_REQUEST
-        contentAsString(result) mustEqual view(boundForm, NormalMode)(
+        contentAsString(result) mustEqual view(boundForm, NormalMode, isAgent = false, None, None)(
           request,
           applicationConfig,
           messages(application)
@@ -133,7 +133,7 @@ class RequestRepaymentAmountControllerSpec extends SpecBase {
         val view      = application.injector.instanceOf[RequestRefundAmountView]
         val result    = route(application, request).value
         status(result) mustEqual BAD_REQUEST
-        contentAsString(result) mustEqual view(boundForm, NormalMode)(
+        contentAsString(result) mustEqual view(boundForm, NormalMode, isAgent = false, None, None)(
           request,
           applicationConfig,
           messages(application)

--- a/test/controllers/repayments/RequestRepaymentBeforeStartControllerSpec.scala
+++ b/test/controllers/repayments/RequestRepaymentBeforeStartControllerSpec.scala
@@ -64,7 +64,7 @@ class RequestRepaymentBeforeStartControllerSpec extends SpecBase {
         val view    = application.injector.instanceOf[RequestRefundBeforeStartView]
         status(result) mustEqual OK
         contentAsString(result) must include("Request a repayment")
-        contentAsString(result) mustEqual view(agentView = false)(
+        contentAsString(result) mustEqual view(agentView = false, None, None)(
           request,
           applicationConfig,
           messages(application)

--- a/test/controllers/repayments/UkOrAbroadBankAccountControllerSpec.scala
+++ b/test/controllers/repayments/UkOrAbroadBankAccountControllerSpec.scala
@@ -51,7 +51,11 @@ class UkOrAbroadBankAccountControllerSpec extends SpecBase {
         val view = application.injector.instanceOf[UkOrAbroadBankAccountView]
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(formProvider(), NormalMode)(request, applicationConfig, messages(application)).toString
+        contentAsString(result) mustEqual view(formProvider(), NormalMode, isAgent = false, None, None)(
+          request,
+          applicationConfig,
+          messages(application)
+        ).toString
       }
     }
 
@@ -70,7 +74,7 @@ class UkOrAbroadBankAccountControllerSpec extends SpecBase {
         val result = route(application, request).value
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(formProvider().fill(UkOrAbroadBankAccount.values.head), NormalMode)(
+        contentAsString(result) mustEqual view(formProvider().fill(UkOrAbroadBankAccount.values.head), NormalMode, isAgent = false, None, None)(
           request,
           applicationConfig,
           messages(application)
@@ -94,7 +98,11 @@ class UkOrAbroadBankAccountControllerSpec extends SpecBase {
         val result = route(application, request).value
 
         status(result) mustEqual BAD_REQUEST
-        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, applicationConfig, messages(application)).toString
+        contentAsString(result) mustEqual view(boundForm, NormalMode, isAgent = false, None, None)(
+          request,
+          applicationConfig,
+          messages(application)
+        ).toString
       }
     }
 

--- a/test/services/BarsServiceSpec.scala
+++ b/test/services/BarsServiceSpec.scala
@@ -54,7 +54,7 @@ class BarsServiceSpec extends SpecBase with ViewInstances {
       running(application) {
         when(mockBarsConnector.verify(any(), any(), any())(using any())).thenReturn(Future successful barsAccountResponse())
 
-        val result = service.verifyBusinessAccount(bankAccountDetails, userAnswer, formProvider(), NormalMode)
+        val result = service.verifyBusinessAccount(bankAccountDetails, userAnswer, formProvider(), NormalMode, isAgent = false, None, None)
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result) mustBe Some("/report-pillar2-top-up-taxes/repayment/contact-details/input-name")
@@ -76,7 +76,7 @@ class BarsServiceSpec extends SpecBase with ViewInstances {
         when(mockBarsConnector.verify(any(), any(), any())(using any()))
           .thenReturn(Future successful barsAccountResponse(nameMatches = NameMatches.Partial, accountName = Some("Epic Adv")))
 
-        val result = service.verifyBusinessAccount(bankAccountDetails, userAnswer, formProvider(), NormalMode)
+        val result = service.verifyBusinessAccount(bankAccountDetails, userAnswer, formProvider(), NormalMode, isAgent = false, None, None)
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result) mustBe Some("/report-pillar2-top-up-taxes/repayment/error/partial-name")
@@ -106,14 +106,20 @@ class BarsServiceSpec extends SpecBase with ViewInstances {
           bankAccountDetails,
           userAnswer,
           formProvider().fill(bankAccountDetails),
-          NormalMode
+          NormalMode,
+          isAgent = false,
+          None,
+          None
         )(using hc, request, messages(application))
 
         status(result) mustBe BAD_REQUEST
         contentAsString(result) mustBe
           view(
             formWithError,
-            NormalMode
+            NormalMode,
+            isAgent = false,
+            None,
+            None
           )(
             request,
             applicationConfig,
@@ -145,14 +151,20 @@ class BarsServiceSpec extends SpecBase with ViewInstances {
           bankAccountDetails,
           userAnswer,
           formProvider().fill(bankAccountDetails),
-          NormalMode
+          NormalMode,
+          isAgent = false,
+          None,
+          None
         )(using hc, request, messages(application))
 
         status(result) mustBe BAD_REQUEST
         contentAsString(result) mustBe
           view(
             formWithError,
-            NormalMode
+            NormalMode,
+            isAgent = false,
+            None,
+            None
           )(
             request,
             applicationConfig,
@@ -176,7 +188,7 @@ class BarsServiceSpec extends SpecBase with ViewInstances {
         when(mockBarsConnector.verify(any(), any(), any())(using any()))
           .thenReturn(Future successful barsAccountResponse(accountExists = AccountExists.Inapplicable))
 
-        val result = service.verifyBusinessAccount(bankAccountDetails, userAnswer, formProvider(), NormalMode)
+        val result = service.verifyBusinessAccount(bankAccountDetails, userAnswer, formProvider(), NormalMode, isAgent = false, None, None)
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result) mustBe Some("/report-pillar2-top-up-taxes/repayment/error/bank-details")
@@ -198,7 +210,7 @@ class BarsServiceSpec extends SpecBase with ViewInstances {
         when(mockBarsConnector.verify(any(), any(), any())(using any()))
           .thenReturn(Future successful barsAccountResponse(accountExists = AccountExists.Indeterminate))
 
-        val result = service.verifyBusinessAccount(bankAccountDetails, userAnswer, formProvider(), NormalMode)
+        val result = service.verifyBusinessAccount(bankAccountDetails, userAnswer, formProvider(), NormalMode, isAgent = false, None, None)
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result) mustBe Some("/report-pillar2-top-up-taxes/repayment/error/could-not-confirm")
@@ -220,7 +232,7 @@ class BarsServiceSpec extends SpecBase with ViewInstances {
         when(mockBarsConnector.verify(any(), any(), any())(using any()))
           .thenReturn(Future successful barsAccountResponse(accountExists = AccountExists.Error))
 
-        val result = service.verifyBusinessAccount(bankAccountDetails, userAnswer, formProvider(), NormalMode)
+        val result = service.verifyBusinessAccount(bankAccountDetails, userAnswer, formProvider(), NormalMode, isAgent = false, None, None)
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result) mustBe Some("/report-pillar2-top-up-taxes/repayment/error/view")
@@ -250,14 +262,20 @@ class BarsServiceSpec extends SpecBase with ViewInstances {
           bankAccountDetails,
           userAnswer,
           formProvider().fill(bankAccountDetails),
-          NormalMode
+          NormalMode,
+          isAgent = false,
+          None,
+          None
         )(using hc, request, messages(application))
 
         status(result) mustBe BAD_REQUEST
         contentAsString(result) mustBe
           view(
             formWithError,
-            NormalMode
+            NormalMode,
+            isAgent = false,
+            None,
+            None
           )(
             request,
             applicationConfig,
@@ -281,7 +299,7 @@ class BarsServiceSpec extends SpecBase with ViewInstances {
         when(mockBarsConnector.verify(any(), any(), any())(using any()))
           .thenReturn(Future successful barsAccountResponse(nameMatches = NameMatches.Inapplicable))
 
-        val result = service.verifyBusinessAccount(bankAccountDetails, userAnswer, formProvider(), NormalMode)
+        val result = service.verifyBusinessAccount(bankAccountDetails, userAnswer, formProvider(), NormalMode, isAgent = false, None, None)
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result) mustBe Some("/report-pillar2-top-up-taxes/repayment/error/could-not-confirm")
@@ -303,7 +321,7 @@ class BarsServiceSpec extends SpecBase with ViewInstances {
         when(mockBarsConnector.verify(any(), any(), any())(using any()))
           .thenReturn(Future successful barsAccountResponse(nameMatches = NameMatches.Indeterminate))
 
-        val result = service.verifyBusinessAccount(bankAccountDetails, userAnswer, formProvider(), NormalMode)
+        val result = service.verifyBusinessAccount(bankAccountDetails, userAnswer, formProvider(), NormalMode, isAgent = false, None, None)
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result) mustBe Some("/report-pillar2-top-up-taxes/repayment/error/could-not-confirm")
@@ -325,7 +343,7 @@ class BarsServiceSpec extends SpecBase with ViewInstances {
         when(mockBarsConnector.verify(any(), any(), any())(using any()))
           .thenReturn(Future successful barsAccountResponse(nameMatches = NameMatches.Error))
 
-        val result = service.verifyBusinessAccount(bankAccountDetails, userAnswer, formProvider(), NormalMode)
+        val result = service.verifyBusinessAccount(bankAccountDetails, userAnswer, formProvider(), NormalMode, isAgent = false, None, None)
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result) mustBe Some("/report-pillar2-top-up-taxes/repayment/error/view")
@@ -355,14 +373,20 @@ class BarsServiceSpec extends SpecBase with ViewInstances {
           bankAccountDetails,
           userAnswer,
           formProvider().fill(bankAccountDetails),
-          NormalMode
+          NormalMode,
+          isAgent = false,
+          None,
+          None
         )(using hc, request, messages(application))
 
         status(result) mustBe BAD_REQUEST
         contentAsString(result) mustBe
           view(
             formWithError,
-            NormalMode
+            NormalMode,
+            isAgent = false,
+            None,
+            None
           )(
             request,
             applicationConfig,
@@ -386,7 +410,7 @@ class BarsServiceSpec extends SpecBase with ViewInstances {
         when(mockBarsConnector.verify(any(), any(), any())(using any()))
           .thenReturn(Future successful barsAccountResponse(sortCodeIsPresentOnEISCD = SortCodeIsPresentOnEISCD.Error))
 
-        val result = service.verifyBusinessAccount(bankAccountDetails, userAnswer, formProvider(), NormalMode)
+        val result = service.verifyBusinessAccount(bankAccountDetails, userAnswer, formProvider(), NormalMode, isAgent = false, None, None)
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result) mustBe Some("/report-pillar2-top-up-taxes/repayment/error/view")
@@ -408,7 +432,7 @@ class BarsServiceSpec extends SpecBase with ViewInstances {
         when(mockBarsConnector.verify(any(), any(), any())(using any()))
           .thenReturn(Future successful barsAccountResponse(nonStandardAccountDetailsRequiredForBacs = NonStandardAccountDetailsRequiredForBacs.Yes))
 
-        val result = service.verifyBusinessAccount(bankAccountDetails, userAnswer, formProvider(), NormalMode)
+        val result = service.verifyBusinessAccount(bankAccountDetails, userAnswer, formProvider(), NormalMode, isAgent = false, None, None)
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result) mustBe Some("/report-pillar2-top-up-taxes/repayment/error/bank-details")
@@ -430,7 +454,7 @@ class BarsServiceSpec extends SpecBase with ViewInstances {
         when(mockBarsConnector.verify(any(), any(), any())(using any()))
           .thenReturn(Future successful barsAccountResponse(sortCodeSupportsDirectCredit = SortCodeSupportsDirectCredit.Error))
 
-        val result = service.verifyBusinessAccount(bankAccountDetails, userAnswer, formProvider(), NormalMode)
+        val result = service.verifyBusinessAccount(bankAccountDetails, userAnswer, formProvider(), NormalMode, isAgent = false, None, None)
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result) mustBe Some("/report-pillar2-top-up-taxes/repayment/error/view")
@@ -452,7 +476,8 @@ class BarsServiceSpec extends SpecBase with ViewInstances {
         when(mockBarsConnector.verify(any(), any(), any())(using any()))
           .thenReturn(Future successful barsAccountResponse(nameMatches = NameMatches.Partial))
 
-        val result: Future[Result] = service.verifyBusinessAccount(bankAccountDetails, userAnswer, formProvider(), NormalMode)
+        val result: Future[Result] =
+          service.verifyBusinessAccount(bankAccountDetails, userAnswer, formProvider(), NormalMode, isAgent = false, None, None)
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result) mustBe Some("/report-pillar2-top-up-taxes/repayment/error/view")
@@ -492,14 +517,20 @@ class BarsServiceSpec extends SpecBase with ViewInstances {
           bankAccountDetails,
           userAnswer,
           formProvider().fill(bankAccountDetails),
-          NormalMode
+          NormalMode,
+          isAgent = false,
+          None,
+          None
         )(using hc, request, messages(application))
 
         status(result) mustBe BAD_REQUEST
         contentAsString(result) mustBe
           view(
             formWithError,
-            NormalMode
+            NormalMode,
+            isAgent = false,
+            None,
+            None
           )(
             request,
             applicationConfig,
@@ -529,7 +560,7 @@ class BarsServiceSpec extends SpecBase with ViewInstances {
             )
           )
 
-        val result = service.verifyBusinessAccount(bankAccountDetails, userAnswer, formProvider(), NormalMode)
+        val result = service.verifyBusinessAccount(bankAccountDetails, userAnswer, formProvider(), NormalMode, isAgent = false, None, None)
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result) mustBe Some("/report-pillar2-top-up-taxes/repayment/error/view")

--- a/test/views/repayments/BankAccountDetailsViewSpec.scala
+++ b/test/views/repayments/BankAccountDetailsViewSpec.scala
@@ -32,18 +32,32 @@ class BankAccountDetailsViewSpec extends ViewSpecBase with StringGenerators {
   lazy val formProvider: BankAccountDetailsFormProvider = new BankAccountDetailsFormProvider
   lazy val page:         BankAccountDetailsView         = inject[BankAccountDetailsView]
   lazy val pageTitle:    String                         = "Bank account details"
+  lazy val plrReference: String                         = "XMPLR0123456789"
+
+  lazy val view: Document = Jsoup.parse(
+    page(formProvider(), NormalMode, isAgent = false, None, None)(
+      request,
+      appConfig,
+      messages
+    ).toString()
+  )
+
+  lazy val agentView: Document = Jsoup.parse(
+    page(formProvider(), NormalMode, isAgent = true, Some(plrReference), Some("orgName"))(
+      request,
+      appConfig,
+      messages
+    ).toString()
+  )
 
   "Bank Account Details View" should {
-    val view: Document = Jsoup.parse(
-      page(formProvider(), NormalMode)(
-        request,
-        appConfig,
-        messages
-      ).toString()
-    )
 
     "have a title" in {
       view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+    }
+
+    "have a caption for an agent view" in {
+      agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
     }
 
     "have a unique H1 heading" in {
@@ -90,7 +104,10 @@ class BankAccountDetailsViewSpec extends ViewSpecBase with StringGenerators {
               "accountNumber"     -> ""
             )
           ),
-          NormalMode
+          NormalMode,
+          isAgent = false,
+          None,
+          None
         )(request, appConfig, messages).toString()
       )
 
@@ -131,7 +148,10 @@ class BankAccountDetailsViewSpec extends ViewSpecBase with StringGenerators {
             "accountNumber"     -> "12345678901234567890"
           )
         ),
-        NormalMode
+        NormalMode,
+        isAgent = false,
+        None,
+        None
       )(request, appConfig, messages).toString()
     )
 
@@ -169,7 +189,7 @@ class BankAccountDetailsViewSpec extends ViewSpecBase with StringGenerators {
     )
 
     val errorView: Document = Jsoup.parse(
-      page(formProvider().bind(xssInput), NormalMode)(request, appConfig, messages).toString()
+      page(formProvider().bind(xssInput), NormalMode, isAgent = false, None, None)(request, appConfig, messages).toString()
     )
 
     "show XSS validation error summary" in {
@@ -195,16 +215,8 @@ class BankAccountDetailsViewSpec extends ViewSpecBase with StringGenerators {
 
   val viewScenarios: Seq[ViewScenario] =
     Seq(
-      ViewScenario(
-        "view",
-        Jsoup.parse(
-          page(formProvider(), NormalMode)(
-            request,
-            appConfig,
-            messages
-          ).toString()
-        )
-      )
+      ViewScenario("view", view),
+      ViewScenario("agentView", agentView)
     )
 
   behaveLikeAccessiblePage(viewScenarios)

--- a/test/views/repayments/NonUKBankViewSpec.scala
+++ b/test/views/repayments/NonUKBankViewSpec.scala
@@ -32,15 +32,25 @@ class NonUKBankViewSpec extends ViewSpecBase with StringGenerators {
   lazy val formProvider: NonUKBankFormProvider = new NonUKBankFormProvider
   lazy val page:         NonUKBankView         = inject[NonUKBankView]
   lazy val pageTitle:    String                = "Bank account details"
+  lazy val plrReference: String                = "XMPLR0123456789"
+
+  lazy val view: Document = Jsoup.parse(
+    page(formProvider(), NormalMode, isAgent = false, None, None)(request, appConfig, messages).toString()
+  )
+
+  lazy val agentView: Document = Jsoup.parse(
+    page(formProvider(), NormalMode, isAgent = true, Some(plrReference), Some("orgName"))(request, appConfig, messages).toString()
+  )
 
   "Non UK Bank View" when {
     "page loaded" should {
-      val view: Document = Jsoup.parse(
-        page(formProvider(), NormalMode)(request, appConfig, messages).toString()
-      )
 
       "have a title" in {
         view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+      }
+
+      "have a caption for an agent view" in {
+        agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
       }
 
       "have a unique H1 heading" in {
@@ -95,7 +105,10 @@ class NonUKBankViewSpec extends ViewSpecBase with StringGenerators {
             "iban"              -> ""
           )
         ),
-        NormalMode
+        NormalMode,
+        isAgent = false,
+        None,
+        None
       )(request, appConfig, messages).toString()
     )
 
@@ -136,7 +149,10 @@ class NonUKBankViewSpec extends ViewSpecBase with StringGenerators {
             "iban"              -> "GB82WEST12345698765432"
           )
         ),
-        NormalMode
+        NormalMode,
+        isAgent = false,
+        None,
+        None
       )(request, appConfig, messages).toString()
     )
 
@@ -172,7 +188,7 @@ class NonUKBankViewSpec extends ViewSpecBase with StringGenerators {
     )
 
     val errorView: Document = Jsoup.parse(
-      page(formProvider().bind(xssInput), NormalMode)(request, appConfig, messages).toString()
+      page(formProvider().bind(xssInput), NormalMode, isAgent = false, None, None)(request, appConfig, messages).toString()
     )
 
     "show XSS validation error summary" in {
@@ -202,12 +218,8 @@ class NonUKBankViewSpec extends ViewSpecBase with StringGenerators {
 
   val viewScenarios: Seq[ViewScenario] =
     Seq(
-      ViewScenario(
-        "view",
-        Jsoup.parse(
-          page(formProvider(), NormalMode)(request, appConfig, messages).toString()
-        )
-      )
+      ViewScenario("view", view),
+      ViewScenario("agentView", agentView)
     )
 
   behaveLikeAccessiblePage(viewScenarios)

--- a/test/views/repayments/ReasonForRequestingRefundViewSpec.scala
+++ b/test/views/repayments/ReasonForRequestingRefundViewSpec.scala
@@ -32,14 +32,24 @@ class ReasonForRequestingRefundViewSpec extends ViewSpecBase with Generators wit
   lazy val formProvider: ReasonForRequestingRepaymentFormProvider = new ReasonForRequestingRepaymentFormProvider
   lazy val page:         ReasonForRequestingRefundView            = inject[ReasonForRequestingRefundView]
   lazy val pageTitle:    String                                   = "Why are you requesting a repayment?"
+  lazy val plrReference: String                                   = "XMPLR0123456789"
+
+  lazy val view:      Document = Jsoup.parse(page(formProvider(), NormalMode, isAgent = false, None, None)(request, appConfig, messages).toString())
+  lazy val agentView: Document =
+    Jsoup.parse(
+      page(formProvider(), NormalMode, isAgent = true, Some(plrReference), Some("orgName"))(request, appConfig, messages).toString()
+    )
 
   "Reason For Requesting Repayment View" when {
 
     "page loaded" should {
-      val view: Document = Jsoup.parse(page(formProvider(), NormalMode)(request, appConfig, messages).toString())
 
       "have a title" in {
         view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+      }
+
+      "have a caption for an agent view" in {
+        agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
       }
 
       "have a unique H1 heading" in {
@@ -69,7 +79,7 @@ class ReasonForRequestingRefundViewSpec extends ViewSpecBase with Generators wit
 
     "form is submitted with missing value" should {
       val errorView: Document = Jsoup.parse(
-        page(formProvider().bind(Map("value" -> "")), NormalMode)(request, appConfig, messages).toString()
+        page(formProvider().bind(Map("value" -> "")), NormalMode, isAgent = false, None, None)(request, appConfig, messages).toString()
       )
 
       "show a missing value error summary" in {
@@ -93,7 +103,7 @@ class ReasonForRequestingRefundViewSpec extends ViewSpecBase with Generators wit
     "form is submitted with value exceeding maximum length" should {
       val longInput: String   = randomAlphaNumericStringGenerator(299)
       val errorView: Document = Jsoup.parse(
-        page(formProvider().bind(Map("value" -> longInput)), NormalMode)(request, appConfig, messages).toString()
+        page(formProvider().bind(Map("value" -> longInput)), NormalMode, isAgent = false, None, None)(request, appConfig, messages).toString()
       )
 
       "show length validation error summary" in {
@@ -120,7 +130,7 @@ class ReasonForRequestingRefundViewSpec extends ViewSpecBase with Generators wit
       )
 
       val errorView: Document = Jsoup.parse(
-        page(formProvider().bind(xssInput), NormalMode)(request, appConfig, messages).toString()
+        page(formProvider().bind(xssInput), NormalMode, isAgent = false, None, None)(request, appConfig, messages).toString()
       )
 
       "show XSS validation error summary" in {
@@ -145,12 +155,8 @@ class ReasonForRequestingRefundViewSpec extends ViewSpecBase with Generators wit
 
     val viewScenarios: Seq[ViewScenario] =
       Seq(
-        ViewScenario(
-          "view",
-          Jsoup.parse(
-            page(formProvider(), NormalMode)(request, appConfig, messages).toString()
-          )
-        )
+        ViewScenario("view", view),
+        ViewScenario("agentView", agentView)
       )
 
     behaveLikeAccessiblePage(viewScenarios)

--- a/test/views/repayments/RepaymentsCheckYourAnswersViewSpec.scala
+++ b/test/views/repayments/RepaymentsCheckYourAnswersViewSpec.scala
@@ -68,14 +68,26 @@ class RepaymentsCheckYourAnswersViewSpec extends ViewSpecBase {
     ).flatten
   )
 
-  lazy val page: RepaymentsCheckYourAnswersView = inject[RepaymentsCheckYourAnswersView]
-  lazy val view: Document                       =
-    Jsoup.parse(page(listRefund, listBankAccountDetails, contactDetailsList)(request, appConfig, messages).toString())
-  lazy val pageTitle: String = "Check your answers before submitting your repayment request"
+  lazy val page:         RepaymentsCheckYourAnswersView = inject[RepaymentsCheckYourAnswersView]
+  lazy val pageTitle:    String                         = "Check your answers before submitting your repayment request"
+  lazy val plrReference: String                         = "XMPLR0123456789"
+
+  lazy val view: Document =
+    Jsoup.parse(page(listRefund, listBankAccountDetails, contactDetailsList, isAgent = false, None, None)(request, appConfig, messages).toString())
+
+  lazy val agentView: Document =
+    Jsoup.parse(
+      page(listRefund, listBankAccountDetails, contactDetailsList, isAgent = true, Some(plrReference), Some("orgName"))(request, appConfig, messages)
+        .toString()
+    )
 
   "Repayments Check Your Answers View" should {
     "have a title" in {
       view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+    }
+
+    "have a caption for an agent view" in {
+      agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
     }
 
     "have a unique H1 heading" in {
@@ -156,7 +168,8 @@ class RepaymentsCheckYourAnswersViewSpec extends ViewSpecBase {
 
     val viewScenarios: Seq[ViewScenario] =
       Seq(
-        ViewScenario("view", view)
+        ViewScenario("view", view),
+        ViewScenario("agentView", agentView)
       )
 
     behaveLikeAccessiblePage(viewScenarios)

--- a/test/views/repayments/RepaymentsConfirmationViewSpec.scala
+++ b/test/views/repayments/RepaymentsConfirmationViewSpec.scala
@@ -85,7 +85,7 @@ class RepaymentsConfirmationViewSpec extends ViewSpecBase {
 
   "Agent view" should {
     "show the correct hint text above the confirmation panel" in {
-      agentView.getElementsByClass("govuk-hint").get(0).text mustBe s"Group: $testOrgName ID: $testPillar2Ref"
+      agentView.getElementsByClass("govuk-caption-m").text mustBe s"Group: $testOrgName ID: $testPillar2Ref"
     }
 
     "show the extended confirmation message below the existing text" in {

--- a/test/views/repayments/RepaymentsContactByPhoneViewSpec.scala
+++ b/test/views/repayments/RepaymentsContactByPhoneViewSpec.scala
@@ -34,17 +34,26 @@ class RepaymentsContactByPhoneViewSpec extends ViewSpecBase with StringGenerator
   lazy val page:         RepaymentsContactByPhoneView         = inject[RepaymentsContactByPhoneView]
   lazy val pageTitle:    String                               = "Can we contact by phone"
   lazy val contactName:  String                               = "John Doe"
+  lazy val plrReference: String                               = "XMPLR0123456789"
+
+  lazy val view: Document = Jsoup.parse(
+    page(formProvider(contactName), mode, contactName, isAgent = false, None, None)(request, appConfig, messages).toString()
+  )
+
+  lazy val agentView: Document = Jsoup.parse(
+    page(formProvider(contactName), mode, contactName, isAgent = true, Some(plrReference), Some("orgName"))(request, appConfig, messages).toString()
+  )
 
   "Repayments Contact By Phone View" when {
 
     "page loaded" should {
 
-      val view: Document = Jsoup.parse(
-        page(formProvider(contactName), mode, contactName)(request, appConfig, messages).toString()
-      )
-
       "have a title" in {
         view.title() mustBe s"$pageTitle? - Report Pillar 2 Top-up Taxes - GOV.UK"
+      }
+
+      "have a caption for an agent view" in {
+        agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
       }
 
       "have a unique H1 heading" in {
@@ -83,7 +92,10 @@ class RepaymentsContactByPhoneViewSpec extends ViewSpecBase with StringGenerator
           Map("value" -> "")
         ),
         mode,
-        contactName
+        contactName,
+        isAgent = false,
+        None,
+        None
       )(request, appConfig, messages).toString()
     )
 
@@ -107,12 +119,8 @@ class RepaymentsContactByPhoneViewSpec extends ViewSpecBase with StringGenerator
 
   val viewScenarios: Seq[ViewScenario] =
     Seq(
-      ViewScenario(
-        "view",
-        Jsoup.parse(
-          page(formProvider(contactName), mode, contactName)(request, appConfig, messages).toString()
-        )
-      )
+      ViewScenario("view", view),
+      ViewScenario("agentView", agentView)
     )
 
   behaveLikeAccessiblePage(viewScenarios)

--- a/test/views/repayments/RepaymentsContactEmailViewSpec.scala
+++ b/test/views/repayments/RepaymentsContactEmailViewSpec.scala
@@ -34,16 +34,26 @@ class RepaymentsContactEmailViewSpec extends ViewSpecBase with StringGenerators 
   lazy val page:         RepaymentsContactEmailView         = inject[RepaymentsContactEmailView]
   lazy val contactName:  String                             = "ABC Limited"
   lazy val pageTitle:    String                             = "What is the email address"
+  lazy val plrReference: String                             = "XMPLR0123456789"
+
+  lazy val view: Document =
+    Jsoup.parse(page(formProvider(contactName), mode, contactName, isAgent = false, None, None)(request, appConfig, messages).toString())
+
+  lazy val agentView: Document =
+    Jsoup.parse(
+      page(formProvider(contactName), mode, contactName, isAgent = true, Some(plrReference), Some("orgName"))(request, appConfig, messages).toString()
+    )
 
   "Repayments Contact Email View" when {
 
     "page loaded" should {
 
-      val view: Document =
-        Jsoup.parse(page(formProvider(contactName), mode, contactName)(request, appConfig, messages).toString())
-
       "have a title" in {
         view.title() mustBe s"$pageTitle? - Report Pillar 2 Top-up Taxes - GOV.UK"
+      }
+
+      "have a caption for an agent view" in {
+        agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
       }
 
       "have a unique H1 heading" in {
@@ -72,7 +82,10 @@ class RepaymentsContactEmailViewSpec extends ViewSpecBase with StringGenerators 
         page(
           formProvider(contactName).bind(Map("contactEmail" -> "")),
           mode,
-          contactName
+          contactName,
+          isAgent = false,
+          None,
+          None
         )(request, appConfig, messages).toString()
       )
 
@@ -100,7 +113,10 @@ class RepaymentsContactEmailViewSpec extends ViewSpecBase with StringGenerators 
         page(
           formProvider(contactName).bind(Map("contactEmail" -> longContactEmail)),
           mode,
-          contactName
+          contactName,
+          isAgent = false,
+          None,
+          None
         )(request, appConfig, messages).toString()
       )
 
@@ -128,7 +144,7 @@ class RepaymentsContactEmailViewSpec extends ViewSpecBase with StringGenerators 
       )
 
       val errorView: Document = Jsoup.parse(
-        page(formProvider(contactName).bind(xssInput), mode, contactName)(request, appConfig, messages).toString()
+        page(formProvider(contactName).bind(xssInput), mode, contactName, isAgent = false, None, None)(request, appConfig, messages).toString()
       )
 
       "show XSS validation error summary" in {
@@ -151,12 +167,8 @@ class RepaymentsContactEmailViewSpec extends ViewSpecBase with StringGenerators 
 
     val viewScenarios: Seq[ViewScenario] =
       Seq(
-        ViewScenario(
-          "view",
-          Jsoup.parse(
-            page(formProvider(contactName), mode, contactName)(request, appConfig, messages).toString()
-          )
-        )
+        ViewScenario("view", view),
+        ViewScenario("agentView", agentView)
       )
 
     behaveLikeAccessiblePage(viewScenarios)

--- a/test/views/repayments/RepaymentsContactNameViewSpec.scala
+++ b/test/views/repayments/RepaymentsContactNameViewSpec.scala
@@ -33,14 +33,23 @@ class RepaymentsContactNameViewSpec extends ViewSpecBase with StringGenerators {
   lazy val mode:         Mode                              = NormalMode
   lazy val page:         RepaymentsContactNameView         = inject[RepaymentsContactNameView]
   lazy val pageTitle:    String                            = "What is the name of the person or team we should contact about the repayment request?"
+  lazy val plrReference: String                            = "XMPLR0123456789"
+
+  lazy val view: Document = Jsoup.parse(page(formProvider(), mode, isAgent = false, None, None)(request, appConfig, messages).toString())
+
+  lazy val agentView: Document =
+    Jsoup.parse(page(formProvider(), mode, isAgent = true, Some(plrReference), Some("orgName"))(request, appConfig, messages).toString())
 
   "Repayments Contact Name View" when {
 
     "page loaded" should {
-      val view: Document = Jsoup.parse(page(formProvider(), mode)(request, appConfig, messages).toString())
 
       "have a title" in {
         view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+      }
+
+      "have a caption for an agent view" in {
+        agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
       }
 
       "have a unique H1 heading" in {
@@ -70,7 +79,10 @@ class RepaymentsContactNameViewSpec extends ViewSpecBase with StringGenerators {
           formProvider().bind(
             Map("contactName" -> "")
           ),
-          mode
+          mode,
+          isAgent = false,
+          None,
+          None
         )(request, appConfig, messages).toString()
       )
 
@@ -99,7 +111,10 @@ class RepaymentsContactNameViewSpec extends ViewSpecBase with StringGenerators {
           formProvider().bind(
             Map("contactName" -> longInput)
           ),
-          mode
+          mode,
+          isAgent = false,
+          None,
+          None
         )(request, appConfig, messages).toString()
       )
 
@@ -127,7 +142,7 @@ class RepaymentsContactNameViewSpec extends ViewSpecBase with StringGenerators {
       )
 
       val errorView: Document = Jsoup.parse(
-        page(formProvider().bind(xssInput), mode)(request, appConfig, messages).toString()
+        page(formProvider().bind(xssInput), mode, isAgent = false, None, None)(request, appConfig, messages).toString()
       )
 
       "show XSS validation error summary" in {
@@ -150,7 +165,8 @@ class RepaymentsContactNameViewSpec extends ViewSpecBase with StringGenerators {
 
     val viewScenarios: Seq[ViewScenario] =
       Seq(
-        ViewScenario("view", Jsoup.parse(page(formProvider(), mode)(request, appConfig, messages).toString()))
+        ViewScenario("view", view),
+        ViewScenario("agentView", agentView)
       )
 
     behaveLikeAccessiblePage(viewScenarios)

--- a/test/views/repayments/RepaymentsPhoneDetailsViewSpec.scala
+++ b/test/views/repayments/RepaymentsPhoneDetailsViewSpec.scala
@@ -29,24 +29,30 @@ import views.html.repayments.RepaymentsPhoneDetailsView
 class RepaymentsPhoneDetailsViewSpec extends ViewSpecBase {
 
   lazy val formProvider = new CapturePhoneDetailsFormProvider
-  lazy val page:        RepaymentsPhoneDetailsView = inject[RepaymentsPhoneDetailsView]
-  lazy val mode:        Mode                       = NormalMode
-  lazy val contactName: String                     = "ABC Limited"
-  lazy val pageTitle:   String                     = "What is the phone number"
+  lazy val page:         RepaymentsPhoneDetailsView = inject[RepaymentsPhoneDetailsView]
+  lazy val mode:         Mode                       = NormalMode
+  lazy val contactName:  String                     = "ABC Limited"
+  lazy val pageTitle:    String                     = "What is the phone number"
+  lazy val plrReference: String                     = "XMPLR0123456789"
+
+  lazy val view: Document =
+    Jsoup.parse(page(formProvider(contactName), mode, contactName, isAgent = false, None, None)(request, appConfig, messages).toString())
+
+  lazy val agentView: Document =
+    Jsoup.parse(
+      page(formProvider(contactName), mode, contactName, isAgent = true, Some(plrReference), Some("orgName"))(request, appConfig, messages).toString()
+    )
 
   "Repayments Phone Details View" should {
 
     "page loaded" should {
 
-      val view: Document =
-        Jsoup.parse(page(formProvider(contactName), mode, contactName)(request, appConfig, messages).toString())
-
       "have a title" in {
         view.title() mustBe s"$pageTitle? - Report Pillar 2 Top-up Taxes - GOV.UK"
       }
 
-      "have a caption" in {
-        view.getElementsByClass("govuk-caption-l").text mustBe "Contact details"
+      "have a caption for an agent view" in {
+        agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
       }
 
       "have a unique H1 heading" in {
@@ -76,7 +82,7 @@ class RepaymentsPhoneDetailsViewSpec extends ViewSpecBase {
   "form is submitted with missing value" should {
     val errorView: Document =
       Jsoup.parse(
-        page(formProvider(contactName).bind(Map("phoneNumber" -> "")), mode, contactName)(request, appConfig, messages)
+        page(formProvider(contactName).bind(Map("phoneNumber" -> "")), mode, contactName, isAgent = false, None, None)(request, appConfig, messages)
           .toString()
       )
 
@@ -102,7 +108,7 @@ class RepaymentsPhoneDetailsViewSpec extends ViewSpecBase {
     val phoneNumber = "+".padTo(51, '1')
     val errorView: Document =
       Jsoup.parse(
-        page(formProvider(contactName).bind(Map("phoneNumber" -> phoneNumber)), mode, contactName)(
+        page(formProvider(contactName).bind(Map("phoneNumber" -> phoneNumber)), mode, contactName, isAgent = false, None, None)(
           request,
           appConfig,
           messages
@@ -137,7 +143,10 @@ class RepaymentsPhoneDetailsViewSpec extends ViewSpecBase {
         page(
           formProvider(contactName).bind(xssInput),
           mode,
-          contactName
+          contactName,
+          isAgent = false,
+          None,
+          None
         )(request, appConfig, messages).toString()
       )
 
@@ -161,7 +170,8 @@ class RepaymentsPhoneDetailsViewSpec extends ViewSpecBase {
 
   val viewScenarios: Seq[ViewScenario] =
     Seq(
-      ViewScenario("view", Jsoup.parse(page(formProvider(contactName), mode, contactName)(request, appConfig, messages).toString()))
+      ViewScenario("view", view),
+      ViewScenario("agentView", agentView)
     )
 
   behaveLikeAccessiblePage(viewScenarios)

--- a/test/views/repayments/RequestRefundAmountViewSpec.scala
+++ b/test/views/repayments/RequestRefundAmountViewSpec.scala
@@ -32,7 +32,10 @@ class RequestRefundAmountViewSpec extends ViewSpecBase {
   lazy val mode:         Mode                               = NormalMode
   lazy val page:         RequestRefundAmountView            = inject[RequestRefundAmountView]
   lazy val pageTitle:    String                             = "Enter your requested repayment amount in pounds"
-  lazy val view:         Document                           = Jsoup.parse(page(formProvider(), mode)(request, appConfig, messages).toString())
+  lazy val plrReference: String                             = "XMPLR0123456789"
+  lazy val view:      Document = Jsoup.parse(page(formProvider(), mode, isAgent = false, None, None)(request, appConfig, messages).toString())
+  lazy val agentView: Document =
+    Jsoup.parse(page(formProvider(), mode, isAgent = true, Some(plrReference), Some("orgName"))(request, appConfig, messages).toString())
 
   "Request Repayment Amount View" should {
 
@@ -40,6 +43,10 @@ class RequestRefundAmountViewSpec extends ViewSpecBase {
 
       "have a title" in {
         view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+      }
+
+      "have a caption for an agent view" in {
+        agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
       }
 
       "have a h1 heading" in {
@@ -64,7 +71,10 @@ class RequestRefundAmountViewSpec extends ViewSpecBase {
           formProvider().bind(
             Map("value" -> "")
           ),
-          mode
+          mode,
+          isAgent = false,
+          None,
+          None
         )(request, appConfig, messages).toString()
       )
 
@@ -92,7 +102,10 @@ class RequestRefundAmountViewSpec extends ViewSpecBase {
           formProvider().bind(
             Map("value" -> "£-1.0")
           ),
-          mode
+          mode,
+          isAgent = false,
+          None,
+          None
         )(request, appConfig, messages).toString()
       )
 
@@ -120,7 +133,10 @@ class RequestRefundAmountViewSpec extends ViewSpecBase {
           formProvider().bind(
             Map("value" -> "£100,000,000,000.00")
           ),
-          mode
+          mode,
+          isAgent = false,
+          None,
+          None
         )(request, appConfig, messages).toString()
       )
 
@@ -148,7 +164,10 @@ class RequestRefundAmountViewSpec extends ViewSpecBase {
           formProvider().bind(
             Map("value" -> "$100.00")
           ),
-          mode
+          mode,
+          isAgent = false,
+          None,
+          None
         )(request, appConfig, messages).toString()
       )
 
@@ -172,7 +191,8 @@ class RequestRefundAmountViewSpec extends ViewSpecBase {
 
     val viewScenarios: Seq[ViewScenario] =
       Seq(
-        ViewScenario("view", view)
+        ViewScenario("view", view),
+        ViewScenario("agentView", agentView)
       )
 
     behaveLikeAccessiblePage(viewScenarios)

--- a/test/views/repayments/RequestRefundBeforeStartViewSpec.scala
+++ b/test/views/repayments/RequestRefundBeforeStartViewSpec.scala
@@ -26,15 +26,20 @@ import views.html.repayments.RequestRefundBeforeStartView
 
 class RequestRefundBeforeStartViewSpec extends ViewSpecBase {
 
-  lazy val page:      RequestRefundBeforeStartView = inject[RequestRefundBeforeStartView]
-  lazy val view:      Document                     = Jsoup.parse(page(agentView = false)(request, appConfig, messages).toString())
-  lazy val agentView: Document                     = Jsoup.parse(page(agentView = true)(request, appConfig, messages).toString())
-  lazy val pageTitle: String                       = "Request a repayment"
+  lazy val page:         RequestRefundBeforeStartView = inject[RequestRefundBeforeStartView]
+  lazy val plrReference: String                       = "XMPLR0123456789"
+  lazy val view:         Document                     = Jsoup.parse(page(agentView = false, None, None)(request, appConfig, messages).toString())
+  lazy val agentView: Document = Jsoup.parse(page(agentView = true, Some(plrReference), Some("orgName"))(request, appConfig, messages).toString())
+  lazy val pageTitle: String   = "Request a repayment"
 
   "Request Repayment Before Start View" should {
 
     "have a title" in {
       view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+    }
+
+    "have a caption for an agent view" in {
+      agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
     }
 
     "have a h1 heading" in {

--- a/test/views/repayments/UkOrAbroadBankAccountViewSpec.scala
+++ b/test/views/repayments/UkOrAbroadBankAccountViewSpec.scala
@@ -33,11 +33,15 @@ class UkOrAbroadBankAccountViewSpec extends ViewSpecBase {
   lazy val ukOrAbroadBankAccountForm: Form[UkOrAbroadBankAccount]       = formProvider()
   lazy val page:                      UkOrAbroadBankAccountView         = inject[UkOrAbroadBankAccountView]
   lazy val pageTitle:                 String                            = "What type of account will the repayment be sent to?"
+  lazy val plrReference:              String                            = "XMPLR0123456789"
+
+  lazy val view:      Document = Jsoup.parse(page(formProvider(), NormalMode, isAgent = false, None, None)(request, appConfig, messages).toString())
+  lazy val agentView: Document =
+    Jsoup.parse(page(formProvider(), NormalMode, isAgent = true, Some(plrReference), Some("orgName"))(request, appConfig, messages).toString())
 
   "UK or Abroad Bank Account View" when {
 
     "page loaded" should {
-      val view: Document = Jsoup.parse(page(formProvider(), NormalMode)(request, appConfig, messages).toString())
 
       "have a title" in {
         view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
@@ -73,7 +77,10 @@ class UkOrAbroadBankAccountViewSpec extends ViewSpecBase {
           ukOrAbroadBankAccountForm.bind(
             Map("value" -> "")
           ),
-          NormalMode
+          NormalMode,
+          isAgent = false,
+          None,
+          None
         )(request, appConfig, messages).toString()
       )
 
@@ -97,7 +104,8 @@ class UkOrAbroadBankAccountViewSpec extends ViewSpecBase {
 
     val viewScenarios: Seq[ViewScenario] =
       Seq(
-        ViewScenario("view", Jsoup.parse(page(formProvider(), NormalMode)(request, appConfig, messages).toString()))
+        ViewScenario("view", view),
+        ViewScenario("agentView", agentView)
       )
 
     behaveLikeAccessiblePage(viewScenarios)


### PR DESCRIPTION
Add [Group name] and [Group ID] on each Agent version of the page in the Request repayment journey. There are 12 journey pages.
Journey pages
Start page
https://pillar2-prototype.herokuapp.com/current/repayment/agent/before-you-start
Amount
https://pillar2-prototype.herokuapp.com/current/repayment/agent/amount
Why
https://pillar2-prototype.herokuapp.com/current/repayment/agent/reason
Method
https://pillar2-prototype.herokuapp.com/current/repayment/agent/method
UK Bank Details
https://pillar2-prototype.herokuapp.com/current/repayment/agent/uk-details
Non-UK Bank Account
https://pillar2-prototype.herokuapp.com/current/repayment/agent/non-uk-details
What is the name of the person or team we can contact about this repayment request
https://pillar2-prototype.herokuapp.com/current/repayment/agent/contact-details/input-name
What is the email address for [users name?]
https://pillar2-prototype.herokuapp.com/current/repayment/agent/contact-details/input-email
Can we contact [user name] by phone?
https://pillar2-prototype.herokuapp.com/current/repayment/agent/contact-details/phone
If yes, What is the phone number for [user name] ?
https://pillar2-prototype.herokuapp.com/current/repayment/agent/contact-details/input-phone
Check your Answers
https://pillar2-prototype.herokuapp.com/current/repayment/agent/check-answers-uk
Confirmation page
https://pillar2-prototype.herokuapp.com/current/repayment/agent/confirmation