### PR TITLE
PIL-2888 Add group name and PLR ID to agent submission history

### DIFF
--- a/app/controllers/submissionhistory/SubmissionHistoryController.scala
+++ b/app/controllers/submissionhistory/SubmissionHistoryController.scala
@@ -25,7 +25,7 @@ import play.api.i18n.I18nSupport
 import play.api.i18n.Lang.logger
 import play.api.mvc.*
 import repositories.SessionRepository
-import services.{ObligationsAndSubmissionsService, ReferenceNumberService}
+import services.{ObligationsAndSubmissionsService, ReferenceNumberService, SubscriptionService}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.Constants.SubmissionAccountingPeriods
 import views.html.submissionhistory.{SubmissionHistoryNoSubmissionsView, SubmissionHistoryView}
@@ -38,6 +38,7 @@ class SubmissionHistoryController @Inject() (
   @Named("EnrolmentIdentifier") identify: IdentifierAction,
   val controllerComponents:               MessagesControllerComponents,
   referenceNumberService:                 ReferenceNumberService,
+  subscriptionService:                    SubscriptionService,
   obligationsAndSubmissionsService:       ObligationsAndSubmissionsService,
   getData:                                DataRetrievalAction,
   requireData:                            DataRequiredAction,
@@ -56,19 +57,21 @@ class SubmissionHistoryController @Inject() (
       referenceNumber <- OptionT
                            .fromOption[Future](userAnswers.get(AgentClientPillar2ReferencePage))
                            .orElse(OptionT.fromOption[Future](referenceNumberService.get(Some(userAnswers), request.enrolments)))
+      subscriptionData <- OptionT.liftF(subscriptionService.readSubscription(referenceNumber))
+      orgName = subscriptionData.upeDetails.organisationName
 
       fromDate = LocalDate.now().minusYears(SubmissionAccountingPeriods)
       toDate   = LocalDate.now()
       data <- OptionT.liftF(obligationsAndSubmissionsService.handleData(referenceNumber, fromDate, toDate))
     } yield
       if data.accountingPeriodDetails.exists(_.obligations.exists(_.submissions.nonEmpty)) then {
-        Ok(view(data.accountingPeriodDetails, request.isAgent))
+        Ok(view(orgName, referenceNumber, data.accountingPeriodDetails, request.isAgent))
       } else {
-        Ok(viewNoSubmissions(request.isAgent))
+        Ok(viewNoSubmissions(orgName, referenceNumber, request.isAgent))
       }).value
       .map(_.getOrElse(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad(None))))
       .recover { case e =>
-        logger.error(s"Error calling obligationsAndSubmissionsService.handleData: ${e.getMessage}", e)
+        logger.error(s"Error loading submission history: ${e.getMessage}", e)
         Redirect(controllers.routes.JourneyRecoveryController.onPageLoad(None))
       }
   }

--- a/app/views/submissionhistory/SubmissionHistoryNoSubmissionsView.scala.html
+++ b/app/views/submissionhistory/SubmissionHistoryNoSubmissionsView.scala.html
@@ -32,11 +32,14 @@
     pageTitle = titleNoForm(messages("submissionHistoryNoSubmissions.title")),
     bannerUrl = Some(routes.HomepageController.onPageLoad().url)
 ) {
-    @if(isAgent) {
+    @if(isAgent && orgName.trim.nonEmpty) {
         <div class="govuk-caption-m">
-            @if(orgName.trim.nonEmpty) {
-                <span><strong>@{messages("homepage.group")}:</strong> @orgName</span>
-            }
+            <span><strong>@{messages("homepage.group")}:</strong> @orgName</span>
+            <span><strong>@{messages("homepage.id")}:</strong> @plrRef</span>
+        </div>
+    }
+    @if(isAgent && orgName.trim.isEmpty) {
+        <div class="govuk-caption-m">
             <span><strong>@{messages("homepage.id")}:</strong> @plrRef</span>
         </div>
     }

--- a/app/views/submissionhistory/SubmissionHistoryNoSubmissionsView.scala.html
+++ b/app/views/submissionhistory/SubmissionHistoryNoSubmissionsView.scala.html
@@ -27,11 +27,19 @@
         h2: HeadingH2
 )
 
-@(isAgent: Boolean)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(orgName: String, plrRef: String, isAgent: Boolean)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 @layout(
     pageTitle = titleNoForm(messages("submissionHistoryNoSubmissions.title")),
     bannerUrl = Some(routes.HomepageController.onPageLoad().url)
 ) {
+    @if(isAgent) {
+        <div class="govuk-caption-m">
+            @if(orgName.trim.nonEmpty) {
+                <span><strong>@{messages("homepage.group")}:</strong> @orgName</span>
+            }
+            <span><strong>@{messages("homepage.id")}:</strong> @plrRef</span>
+        </div>
+    }
     @heading(messages("submissionHistoryNoSubmissions.heading"), classes = "govuk-heading-l")
     @if(isAgent) {
     @p(messages("submissionHistoryNoSubmissions.agent.p1"))

--- a/app/views/submissionhistory/SubmissionHistoryView.scala.html
+++ b/app/views/submissionhistory/SubmissionHistoryView.scala.html
@@ -33,11 +33,19 @@
         govukTable: GovukTable
 )
 
-@(accountPeriods: Seq[AccountingPeriodDetails],isAgent: Boolean)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(orgName: String, plrRef: String, accountPeriods: Seq[AccountingPeriodDetails], isAgent: Boolean)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 @layout(
     pageTitle = titleNoForm(messages("submissionHistory.title")),
     bannerUrl = Some(routes.HomepageController.onPageLoad().url)
 ) {
+    @if(isAgent) {
+        <div class="govuk-caption-m">
+            @if(orgName.trim.nonEmpty) {
+                <span><strong>@{messages("homepage.group")}:</strong> @orgName</span>
+            }
+            <span><strong>@{messages("homepage.id")}:</strong> @plrRef</span>
+        </div>
+    }
     @heading(messages("submissionHistory.heading"), classes = "govuk-heading-l")
     @if(isAgent) {
     @p(messages("submissionHistory.agent.p1"))

--- a/app/views/submissionhistory/SubmissionHistoryView.scala.html
+++ b/app/views/submissionhistory/SubmissionHistoryView.scala.html
@@ -38,11 +38,14 @@
     pageTitle = titleNoForm(messages("submissionHistory.title")),
     bannerUrl = Some(routes.HomepageController.onPageLoad().url)
 ) {
-    @if(isAgent) {
+    @if(isAgent && orgName.trim.nonEmpty) {
         <div class="govuk-caption-m">
-            @if(orgName.trim.nonEmpty) {
-                <span><strong>@{messages("homepage.group")}:</strong> @orgName</span>
-            }
+            <span><strong>@{messages("homepage.group")}:</strong> @orgName</span>
+            <span><strong>@{messages("homepage.id")}:</strong> @plrRef</span>
+        </div>
+    }
+    @if(isAgent && orgName.trim.isEmpty) {
+        <div class="govuk-caption-m">
             <span><strong>@{messages("homepage.id")}:</strong> @plrRef</span>
         </div>
     }

--- a/test/controllers/submissionhistory/SubmissionHistoryControllerSpec.scala
+++ b/test/controllers/submissionhistory/SubmissionHistoryControllerSpec.scala
@@ -24,7 +24,7 @@ import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
 import repositories.SessionRepository
-import services.ObligationsAndSubmissionsService
+import services.{ObligationsAndSubmissionsService, SubscriptionService}
 import uk.gov.hmrc.auth.core.{Enrolment, EnrolmentIdentifier}
 import uk.gov.hmrc.http.HeaderCarrier
 import views.html.submissionhistory.{SubmissionHistoryNoSubmissionsView, SubmissionHistoryView}
@@ -42,11 +42,13 @@ class SubmissionHistoryControllerSpec extends SpecBase with ObligationsAndSubmis
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswers), enrolments)
         .overrides(
           bind[SessionRepository].toInstance(mockSessionRepository),
-          bind[ObligationsAndSubmissionsService].toInstance(mockObligationsAndSubmissionsService)
+          bind[ObligationsAndSubmissionsService].toInstance(mockObligationsAndSubmissionsService),
+          bind[SubscriptionService].toInstance(mockSubscriptionService)
         )
         .build()
 
       running(application) {
+        when(mockSubscriptionService.readSubscription(any())(using any())).thenReturn(Future.successful(subscriptionData))
         when(mockObligationsAndSubmissionsService.handleData(any(), any(), any())(using any[HeaderCarrier]))
           .thenReturn(Future.successful(emptyResponse))
         when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(emptyUserAnswers)))
@@ -56,7 +58,7 @@ class SubmissionHistoryControllerSpec extends SpecBase with ObligationsAndSubmis
         val viewNoSubmissions = application.injector.instanceOf[SubmissionHistoryNoSubmissionsView]
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual viewNoSubmissions(false)(
+        contentAsString(result) mustEqual viewNoSubmissions(subscriptionData.upeDetails.organisationName, PlrReference, false)(
           request,
           applicationConfig,
           messages(application)
@@ -68,11 +70,13 @@ class SubmissionHistoryControllerSpec extends SpecBase with ObligationsAndSubmis
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswers), enrolments)
         .overrides(
           bind[SessionRepository].toInstance(mockSessionRepository),
-          bind[ObligationsAndSubmissionsService].toInstance(mockObligationsAndSubmissionsService)
+          bind[ObligationsAndSubmissionsService].toInstance(mockObligationsAndSubmissionsService),
+          bind[SubscriptionService].toInstance(mockSubscriptionService)
         )
         .build()
 
       running(application) {
+        when(mockSubscriptionService.readSubscription(any())(using any())).thenReturn(Future.successful(subscriptionData))
         when(mockObligationsAndSubmissionsService.handleData(any(), any(), any())(using any[HeaderCarrier]))
           .thenReturn(Future.successful(allFulfilledResponse))
         when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(emptyUserAnswers)))
@@ -82,7 +86,12 @@ class SubmissionHistoryControllerSpec extends SpecBase with ObligationsAndSubmis
         val view    = application.injector.instanceOf[SubmissionHistoryView]
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(allFulfilledResponse.accountingPeriodDetails, false)(
+        contentAsString(result) mustEqual view(
+          subscriptionData.upeDetails.organisationName,
+          PlrReference,
+          allFulfilledResponse.accountingPeriodDetails,
+          false
+        )(
           request,
           applicationConfig,
           messages(application)

--- a/test/views/submissionhistory/SubmissionHistoryNoSubmissionsViewSpec.scala
+++ b/test/views/submissionhistory/SubmissionHistoryNoSubmissionsViewSpec.scala
@@ -23,14 +23,19 @@ import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
 import views.behaviours.ViewScenario
 import views.html.submissionhistory.SubmissionHistoryNoSubmissionsView
+import views.submissionhistory.SubmissionHistoryViewSpec.{orgName, plrRef}
 
 class SubmissionHistoryNoSubmissionsViewSpec extends ViewSpecBase {
 
   lazy val page:             SubmissionHistoryNoSubmissionsView = inject[SubmissionHistoryNoSubmissionsView]
-  lazy val organisationView: Document                           = Jsoup.parse(page(isAgent = false)(request, appConfig, messages).toString())
-  lazy val agentView:        Document                           = Jsoup.parse(page(isAgent = true)(request, appConfig, messages).toString())
-  lazy val pageTitle:        String                             = "Submission history"
-  lazy val bannerClassName:  String                             = "govuk-header__link govuk-header__service-name"
+  lazy val organisationView: Document                           =
+    Jsoup.parse(page(orgName, plrRef, isAgent = false)(request, appConfig, messages).toString())
+  lazy val agentView: Document =
+    Jsoup.parse(page(orgName, plrRef, isAgent = true)(request, appConfig, messages).toString())
+  lazy val agentViewIdOnly: Document =
+    Jsoup.parse(page("", plrRef, isAgent = true)(request, appConfig, messages).toString())
+  lazy val pageTitle:       String = "Submission history"
+  lazy val bannerClassName: String = "govuk-header__link govuk-header__service-name"
 
   "Submission History with no submission organisation view" should {
     val organisationViewParagraphs: Elements = organisationView.getElementsByTag("p")
@@ -75,6 +80,14 @@ class SubmissionHistoryNoSubmissionsViewSpec extends ViewSpecBase {
 
     "have a banner with a link to the Homepage" in {
       agentView.getElementsByClass(bannerClassName).attr("href") mustBe routes.HomepageController.onPageLoad().url
+    }
+
+    "have correct text for agents at the top of the page" in {
+      agentView.getElementsByClass("govuk-caption-m").get(0).text mustBe s"Group: $orgName ID: $plrRef"
+    }
+
+    "show only group ID in the caption when the organisation name is empty" in {
+      agentViewIdOnly.getElementsByClass("govuk-caption-m").get(0).text mustBe s"ID: $plrRef"
     }
 
     "have a first paragraph" in {

--- a/test/views/submissionhistory/SubmissionHistoryViewSpec.scala
+++ b/test/views/submissionhistory/SubmissionHistoryViewSpec.scala
@@ -32,9 +32,26 @@ class SubmissionHistoryViewSpec extends ViewSpecBase with ObligationsAndSubmissi
 
   lazy val page:             SubmissionHistoryView = inject[SubmissionHistoryView]
   lazy val organisationView: Document              =
-    Jsoup.parse(page(allFulfilledResponse.accountingPeriodDetails, isAgent = false)(request, appConfig, messages).toString())
+    Jsoup.parse(
+      page(SubmissionHistoryViewSpec.orgName, SubmissionHistoryViewSpec.plrRef, allFulfilledResponse.accountingPeriodDetails, isAgent = false)(
+        request,
+        appConfig,
+        messages
+      ).toString()
+    )
   lazy val agentView: Document =
-    Jsoup.parse(page(allFulfilledResponse.accountingPeriodDetails, isAgent = true)(request, appConfig, messages).toString())
+    Jsoup.parse(
+      page(SubmissionHistoryViewSpec.orgName, SubmissionHistoryViewSpec.plrRef, allFulfilledResponse.accountingPeriodDetails, isAgent = true)(
+        request,
+        appConfig,
+        messages
+      ).toString()
+    )
+  lazy val agentViewIdOnly: Document =
+    Jsoup.parse(
+      page("", SubmissionHistoryViewSpec.plrRef, allFulfilledResponse.accountingPeriodDetails, isAgent = true)(request, appConfig, messages)
+        .toString()
+    )
   lazy val pageTitle:       String = "Submission history"
   lazy val bannerClassName: String = "govuk-header__link govuk-header__service-name"
 
@@ -111,6 +128,17 @@ class SubmissionHistoryViewSpec extends ViewSpecBase with ObligationsAndSubmissi
       agentView.getElementsByClass(bannerClassName).attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
+    "have correct text for agents at the top of the page" in {
+      agentView
+        .getElementsByClass("govuk-caption-m")
+        .get(0)
+        .text mustBe s"Group: ${SubmissionHistoryViewSpec.orgName} ID: ${SubmissionHistoryViewSpec.plrRef}"
+    }
+
+    "show only group ID in the caption when the organisation name is empty" in {
+      agentViewIdOnly.getElementsByClass("govuk-caption-m").get(0).text mustBe s"ID: ${SubmissionHistoryViewSpec.plrRef}"
+    }
+
     "have a paragraph detailing submission details" in {
       agentViewParagraphs.get(1).text() mustBe
         "Submission and amendment dates for your client's returns over the last 7 years from today's date."
@@ -133,4 +161,9 @@ class SubmissionHistoryViewSpec extends ViewSpecBase with ObligationsAndSubmissi
 
     behaveLikeAccessiblePage(viewScenarios)
   }
+}
+
+object SubmissionHistoryViewSpec {
+  val orgName: String = "Company Inc"
+  val plrRef:  String = "somePillar2Ref"
 }


### PR DESCRIPTION
## Summary

Adds the agent caption (group name and PLR reference) above the H1 on submission history pages, consistent with transaction history (PIL-2889 pattern).

- Loads subscription data to obtain the organisation name and passes it with the PLR reference into both submission history views.
- Renders `govuk-caption-m` for agents only; if the organisation name is empty, only the group ID line is shown.