### PR TITLE
PIL-2957: Implemented changes to StoodoverCharges and OutstandingPayments views to resolve accessibility issues

### DIFF
--- a/app/views/outstandingpayments/OutstandingPaymentsView.scala.html
+++ b/app/views/outstandingpayments/OutstandingPaymentsView.scala.html
@@ -33,9 +33,10 @@
 @import _root_.utils.DateTimeUtils._
 @import config.FrontendAppConfig
 @import models.OutstandingPaymentsTable
-@import views.ViewUtils._
 @import views.html.components.gds._
+@import views.html.styles.tableScrollStyles
 @import views.html.templates.Layout
+@import views.ViewUtils._
 
 @this(
         layout: Layout,
@@ -52,6 +53,8 @@
 @(tableContent: Html, orgName: String, plrReference: String, amountDue: BigDecimal, hasOverdueReturnPayment: Boolean, useAccountActivity: Boolean = false, accruedInterest: BigDecimal = 0)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages, isAgent: Boolean)
 
 @layout(pageTitle = titleNoForm(messages("payments.outstanding.title")), twoThirdsPagelayout = false, bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
+    @tableScrollStyles()
+
     @if(isAgent) {
         <div class="govuk-hint govuk-!-margin-top-0">
             <span><strong>@{

--- a/app/views/outstandingpayments/_OutstandingPaymentsActivityTable.scala.html
+++ b/app/views/outstandingpayments/_OutstandingPaymentsActivityTable.scala.html
@@ -14,8 +14,9 @@
  * limitations under the License.
  *@
 
-@import views.ViewUtils._
 @import uk.gov.hmrc.govukfrontend.views.html.components._
+@import views.html.components.gds.ScrollWrapper
+@import views.ViewUtils._
 @import _root_.utils.DateTimeUtils._
 
 @this(govukTable: GovukTable)
@@ -23,48 +24,54 @@
 @(data: Seq[OutstandingPaymentsTableForActivity], penalties: Seq[OutstandingPaymentsRowForActivity])(implicit messages: Messages)
 
 @if(penalties.nonEmpty) {
-    @govukTable(Table(
-        head = Some(Seq(
-            HeadCell(Text(messages("payments.outstanding.table.heading.description")), classes = "govuk-!-width-one-third"),
-            HeadCell(Text(messages("payments.outstanding.table.heading.chargeAmount")), format = Some("numeric"), classes = "govuk-!-width-one-quarter"),
-            HeadCell(Text(messages("payments.outstanding.table.heading.amountDue")), format = Some("numeric"), classes = "govuk-!-width-one-quarter"),
-            HeadCell(Text(messages("payments.outstanding.table.heading.dueDate")), classes = "govuk-!-width-one-sixth")
-        )),
-        rows = penalties.map { row =>
-            Seq(
-                TableRow(content = Text(row.description)),
-                TableRow(content = Text(formatCurrencyAmount(row.chargeAmount)), format = Some("numeric")),
-                TableRow(content = Text(formatCurrencyAmount(row.outstandingAmount)), format = Some("numeric")),
-                TableRow(content = Text(row.dueDate.toDateFormat))
-            )
-        },
-        caption = Some(messages("payments.outstanding.table.caption")),
-        captionClasses = "govuk-table__caption--m"
-    ))
+    @ScrollWrapper(
+        govukTable(Table(
+            head = Some(Seq(
+                HeadCell(Text(messages("payments.outstanding.table.heading.description")), classes = "govuk-table__header govuk-!-width-one-third", attributes = Map("scope" -> "col")),
+                HeadCell(Text(messages("payments.outstanding.table.heading.chargeAmount")), format = Some("numeric"), classes = "govuk-table__header govuk-!-width-one-quarter", attributes = Map("scope" -> "col")),
+                HeadCell(Text(messages("payments.outstanding.table.heading.amountDue")), format = Some("numeric"), classes = "govuk-table__header govuk-!-width-one-quarter", attributes = Map("scope" -> "col")),
+                HeadCell(Text(messages("payments.outstanding.table.heading.dueDate")), classes = "govuk-table__header govuk-!-width-one-sixth", attributes = Map("scope" -> "col"))
+            )),
+            rows = penalties.map { row =>
+                Seq(
+                    TableRow(content = Text(row.description)),
+                    TableRow(content = Text(formatCurrencyAmount(row.chargeAmount)), format = Some("numeric")),
+                    TableRow(content = Text(formatCurrencyAmount(row.outstandingAmount)), format = Some("numeric")),
+                    TableRow(content = Text(row.dueDate.toDateFormat))
+                )
+            },
+            caption = Some(messages("payments.outstanding.table.caption")),
+            captionClasses = "govuk-table__caption--m",
+            attributes = Map("style" -> "overflow-wrap: normal;")
+        ))
+    )
 }
 
 @data.map { summary =>
-  @govukTable(Table(
-    head = Some(Seq(
-      HeadCell(messages("payments.outstanding.table.heading.description"), classes = "govuk-!-width-one-third"),
-      HeadCell(messages("payments.outstanding.table.heading.chargeAmount"), format = Some("numeric"), classes = "govuk-!-width-one-quarter"),
-      HeadCell(messages("payments.outstanding.table.heading.amountDue"), format = Some("numeric"), classes = "govuk-!-width-one-quarter"),
-      HeadCell(messages("payments.outstanding.table.heading.dueDate"), classes = "govuk-!-width-one-sixth"),
-    )),
-    rows = summary.rows.map { row =>
-      Seq(
-        TableRow(
-            content = if(row.appealFlag.contains(true)) {
-                HtmlContent(s"""${row.description} <br> <strong class="govuk-tag govuk-tag--red">Appealed</strong>""")
-        } else {
-                Text(row.description)
-        }),
-        TableRow(content = Text(formatCurrencyAmount(row.chargeAmount)), format = Some("numeric")),
-        TableRow(content = Text(formatCurrencyAmount(row.outstandingAmount)), format = Some("numeric")),
-        TableRow(content = Text(row.dueDate.toDateFormat))
-      )
-    },
-      caption = Some(s"Accounting period: ${summary.accountingPeriod.startDate.toDateFormat} to ${summary.accountingPeriod.endDate.toDateFormat}"),
-      captionClasses = "govuk-table__caption--m"
-  ))
+  @ScrollWrapper(
+    govukTable(Table(
+      head = Some(Seq(
+        HeadCell(messages("payments.outstanding.table.heading.description"), classes = "govuk-table__header govuk-!-width-one-third", attributes = Map("scope" -> "col")),
+        HeadCell(messages("payments.outstanding.table.heading.chargeAmount"), format = Some("numeric"), classes = "govuk-table__header govuk-!-width-one-quarter", attributes = Map("scope" -> "col")),
+        HeadCell(messages("payments.outstanding.table.heading.amountDue"), format = Some("numeric"), classes = "govuk-table__header govuk-!-width-one-quarter", attributes = Map("scope" -> "col")),
+        HeadCell(messages("payments.outstanding.table.heading.dueDate"), classes = "govuk-table__header govuk-!-width-one-sixth", attributes = Map("scope" -> "col")),
+      )),
+      rows = summary.rows.map { row =>
+        Seq(
+          TableRow(
+              content = if(row.appealFlag.contains(true)) {
+                  HtmlContent(s"""${row.description} <br> <strong class="govuk-tag govuk-tag--red">Appealed</strong>""")
+          } else {
+                  Text(row.description)
+          }),
+          TableRow(content = Text(formatCurrencyAmount(row.chargeAmount)), format = Some("numeric")),
+          TableRow(content = Text(formatCurrencyAmount(row.outstandingAmount)), format = Some("numeric")),
+          TableRow(content = Text(row.dueDate.toDateFormat))
+        )
+      },
+        caption = Some(s"Accounting period: ${summary.accountingPeriod.startDate.toDateFormat} to ${summary.accountingPeriod.endDate.toDateFormat}"),
+        captionClasses = "govuk-table__caption--m",
+        attributes = Map("style" -> "overflow-wrap: normal;")
+    ))
+  )
 }

--- a/app/views/outstandingpayments/_OutstandingPaymentsTable.scala.html
+++ b/app/views/outstandingpayments/_OutstandingPaymentsTable.scala.html
@@ -15,8 +15,9 @@
  *@
 
 @import models.OutstandingPaymentsTable
-@import views.ViewUtils._
 @import uk.gov.hmrc.govukfrontend.views.html.components._
+@import views.html.components.gds.ScrollWrapper
+@import views.ViewUtils._
 @import _root_.utils.DateTimeUtils._
 
 @this(govukTable: GovukTable)
@@ -24,20 +25,23 @@
 @(data: Seq[OutstandingPaymentsTable])(implicit messages: Messages)
 
 @data.map { summary =>
-  @govukTable(Table(
-    head = Some(Seq(
-      HeadCell(Text(messages("payments.outstanding.table.heading.description")), classes = "govuk-!-width-one-half"),
-      HeadCell(Text(messages("payments.outstanding.table.heading.amount")), format = Some("numeric"), classes = "govuk-!-width-one-quarter"),
-      HeadCell(Text(messages("payments.outstanding.table.heading.dueDate")), classes = "govuk-!-width-one-quarter")
-    )),
-    rows = summary.rows.map { row =>
-      Seq(
-        TableRow(content = Text(row.description)),
-        TableRow(content = Text(formatCurrencyAmount(row.outstandingAmount)), format = Some("numeric")),
-        TableRow(content = Text(row.dueDate.toDateFormat))
-      )
-    },
-    caption = Some(s"Accounting period: ${summary.accountingPeriod.startDate.toDateFormat} to ${summary.accountingPeriod.endDate.toDateFormat}"),
-    captionClasses = "govuk-table__caption--s"
-  ))
+  @ScrollWrapper(
+    govukTable(Table(
+      head = Some(Seq(
+        HeadCell(Text(messages("payments.outstanding.table.heading.description")), classes = "govuk-table__header govuk-!-width-one-half", attributes = Map("scope" -> "col")),
+        HeadCell(Text(messages("payments.outstanding.table.heading.amount")), format = Some("numeric"), classes = "govuk-table__header govuk-!-width-one-quarter", attributes = Map("scope" -> "col")),
+        HeadCell(Text(messages("payments.outstanding.table.heading.dueDate")), classes = "govuk-table__header govuk-!-width-one-quarter", attributes = Map("scope" -> "col"))
+      )),
+      rows = summary.rows.map { row =>
+        Seq(
+          TableRow(content = Text(row.description)),
+          TableRow(content = Text(formatCurrencyAmount(row.outstandingAmount)), format = Some("numeric")),
+          TableRow(content = Text(row.dueDate.toDateFormat))
+        )
+      },
+      caption = Some(s"Accounting period: ${summary.accountingPeriod.startDate.toDateFormat} to ${summary.accountingPeriod.endDate.toDateFormat}"),
+      captionClasses = "govuk-table__caption--s",
+      attributes = Map("style" -> "overflow-wrap: normal;")
+    ))
+  )
 }

--- a/app/views/stoodoverCharges/StoodoverChargesView.scala.html
+++ b/app/views/stoodoverCharges/StoodoverChargesView.scala.html
@@ -18,6 +18,7 @@
 @import utils.DateTimeUtils._
 @import views.ViewUtils._
 @import views.html.components.gds._
+@import views.html.styles.tableScrollStyles
 @import views.html.templates.Layout
 
 @this(
@@ -34,6 +35,8 @@
 @(plrReference: String, data: Seq[StoodoverChargesTable], stoodoverTotal: BigDecimal, organisationName: String)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages, isAgent: Boolean)
 
 @layout(pageTitle = titleNoForm(messages("payments.stoodoverCharges.title")), twoThirdsPagelayout = false, bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
+
+    @tableScrollStyles()
 
     @if(isAgent) {
         <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
@@ -69,22 +72,25 @@
             paragraphBody(messages("payments.stoodoverCharges.details.noStoodoverCharges"), classes = "govuk-body govuk-!-margin-bottom-8 govuk-!-margin-top-7")
         } else {
             data.map { summary =>
-                govukTable(Table(
-                    head = Some(
-                        Seq(
-                            HeadCell(Text("Description"), classes = "govuk-table__header govuk-!-width-one-half"),
-                            HeadCell(Text("Stoodover amount"), format = Some("numeric"), classes = "govuk-table__header govuk-table__header--numeric"),
-                        )
-                    ),
-                    rows =  summary.rows.map { row =>
-                        Seq(
-                            TableRow(content = Text(row.description)),
-                            TableRow(content = Text(formatCurrencyAmount(row.stoodoverAmount)), format = Some("numeric"))
-                        )
-                    },
-                    caption = Some(s"Accounting period: ${summary.accountingPeriod.startDate.toDateFormat} to ${summary.accountingPeriod.endDate.toDateFormat}"),
-                    captionClasses = "govuk-table__caption govuk-table__caption--m"
-                ))
+                ScrollWrapper(
+                    govukTable(Table(
+                        head = Some(
+                            Seq(
+                                HeadCell(Text("Description"), classes = "govuk-table__header govuk-!-width-one-half", attributes = Map("scope" -> "col")),
+                                HeadCell(Text("Stoodover amount"), format = Some("numeric"), classes = "govuk-table__header govuk-table__header--numeric", attributes = Map("scope" -> "col")),
+                            )
+                        ),
+                        rows =  summary.rows.map { row =>
+                            Seq(
+                                TableRow(content = Text(row.description)),
+                                TableRow(content = Text(formatCurrencyAmount(row.stoodoverAmount)), format = Some("numeric"))
+                            )
+                        },
+                        caption = Some(s"Accounting period: ${summary.accountingPeriod.startDate.toDateFormat} to ${summary.accountingPeriod.endDate.toDateFormat}"),
+                        captionClasses = "govuk-table__caption govuk-table__caption--m",
+                        attributes = Map("style" -> "overflow-wrap: normal;")
+                    ))
+                )
             }
         }
     }


### PR DESCRIPTION
Issue 1 - Stoodover charges page in staging: https://www.staging.tax.service.gov.uk/report-pillar2-top-up-taxes/payment/stoodover-charges
When in most resolutions in responsive mode, the Stoodover Amount heading is rendered as:
Stoodove
r amount

Issue 2 - Table not correctly fitting into screens when in responsive mode (in the service) - Outstanding payment page
Page in staging: https://www.staging.tax.service.gov.uk/report-pillar2-top-up-taxes/payment/outstanding

Issue 3 -table caption not wrapping correctly on mobile - Outstanding payment page
Outstanding payment page in staging: https://www.staging.tax.service.gov.uk/report-pillar2-top-up-taxes/payment/outstanding