### PR TITLE
PIL-2925: Add Pillar 2 team email details on the Org and Agent Homepage

### DIFF
--- a/app/views/components/gds/HomepageCard.scala.html
+++ b/app/views/components/gds/HomepageCard.scala.html
@@ -14,14 +14,17 @@
  * limitations under the License.
  *@
 
-@this()
+@import config.FrontendAppConfig
+@import views.html.components.gds._
+
+@this(paragraphMessageWithLink: ParagraphMessageWithLink)
 
 @(
   title: String,
   links: Seq[(String, String, Option[String])],
   extraContent: Option[Html] = None,
   cardClass: String = "card-half-width"
-)(implicit messages: Messages)
+)(implicit messages: Messages, appConfig: FrontendAppConfig)
 
 @isManageAccountCard = @{cardClass == "card-full-width"}
 
@@ -36,5 +39,14 @@
      </li>
     }
    </ul>
+   @if(isManageAccountCard) {
+     <div style="clear: both;">
+       @paragraphMessageWithLink(
+         message1 = Some(messages("homepage.manageAccount.pillar2Email.p1")),
+         linkMessage = appConfig.pillar2mailbox,
+         linkUrl = s"mailto:${appConfig.pillar2mailbox}"
+       )
+     </div>
+   }
   </div>
 </div>

--- a/app/views/outstandingpayments/OutstandingPaymentsView.scala.html
+++ b/app/views/outstandingpayments/OutstandingPaymentsView.scala.html
@@ -127,7 +127,7 @@
     @if(useAccountActivity) {
         @paragraphBody(messages("payments.outstanding.details.p2"))
         @paragraphMessageWithLink(
-            linkMessage = messages("payments.outstanding.stoodoverCharges.linkText"),
+            linkMessage = messages("homepage.payments.stoodoverCharges.linkText"),
             linkUrl = payments.routes.StoodoverChargesController.onPageLoad.url
         )
     }
@@ -161,7 +161,7 @@
                 @h2(messages("payments.stoodoverCharges.title"), size = "m")
                 @paragraphBody(messages("payments.outstanding.stoodoverCharges.p1"))
                 @paragraphMessageWithLink(
-                    linkMessage = messages("payments.outstanding.stoodoverCharges.linkText"),
+                    linkMessage = messages("homepage.payments.stoodoverCharges.linkText"),
                     linkUrl = payments.routes.StoodoverChargesController.onPageLoad.url
                 )
             }

--- a/app/views/outstandingpayments/OutstandingPaymentsView.scala.html
+++ b/app/views/outstandingpayments/OutstandingPaymentsView.scala.html
@@ -127,7 +127,7 @@
     @if(useAccountActivity) {
         @paragraphBody(messages("payments.outstanding.details.p2"))
         @paragraphMessageWithLink(
-            linkMessage = messages("homepage.payments.stoodoverCharges.linkText"),
+            linkMessage = messages("payments.outstanding.stoodoverCharges.linkText"),
             linkUrl = payments.routes.StoodoverChargesController.onPageLoad.url
         )
     }
@@ -161,7 +161,7 @@
                 @h2(messages("payments.stoodoverCharges.title"), size = "m")
                 @paragraphBody(messages("payments.outstanding.stoodoverCharges.p1"))
                 @paragraphMessageWithLink(
-                    linkMessage = messages("homepage.payments.stoodoverCharges.linkText"),
+                    linkMessage = messages("payments.outstanding.stoodoverCharges.linkText"),
                     linkUrl = payments.routes.StoodoverChargesController.onPageLoad.url
                 )
             }

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -951,7 +951,7 @@ homepage.payments.title = Payments
 homepage.payments.transactionHistory.linkText = View transaction history
 homepage.payments.outstandingPayments.linkText = View outstanding payments
 homepage.payments.tags.outstanding = Outstanding
-homepage.payments.stoodoverCharges.linkText = Stoodover charges
+homepage.payments.stoodoverCharges.linkText = View stoodover charges
 homepage.payments.repayments.linkText = Request a repayment
 homepage.payments.tags.paid = Paid
 
@@ -1888,7 +1888,6 @@ payments.outstanding.abbreviation.orngir = ORN/GIR - Overseas Return Notificatio
 payments.outstanding.abbreviation.gaar = GAAR - General Anti Abuse Rule penalty
 
 payments.outstanding.stoodoverCharges.p1 = Details of appealed charges and other standover payments.
-payments.outstanding.stoodoverCharges.linkText = View stoodover charges
 
 payments.outstanding.transactionHistory.p1 = Find details on payments and refunds. It may take up to 5 working days for transactions to appear.
 payments.outstanding.activity.transactionHistory.p2 = Find details on payments and refunds. It may take up to 5 working days for transactions to appear.

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -969,6 +969,7 @@ homepage.manageAccount.agent.rfm.body = As an agent, you cannot replace a filing
 homepage.manageAccount.btn.linkText = Submit a Below-Threshold Notification
 homepage.manageAccount.btn.body = If your group does not expect to meet the annual revenue threshold, you may be able to submit a Below-Threshold Notification.
 homepage.manageAccount.agent.btn.body = Submit a Below-Threshold Notification if your client does not expect to meet the annual revenue threshold.
+homepage.manageAccount.pillar2Email.p1 = You can contact the Pillar 2 team at
 
 homepage.btnActiveBanner.title = {0} has a Below-Threshold Notification.
 homepage.btnActiveBanner.body = You have told us you do not need to submit a UK Tax Return. You must submit a UK Tax Return if you meet the Pillar 2 Top-up Taxes criteria in the future.

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1889,6 +1889,7 @@ payments.outstanding.abbreviation.orngir = ORN/GIR - Overseas Return Notificatio
 payments.outstanding.abbreviation.gaar = GAAR - General Anti Abuse Rule penalty
 
 payments.outstanding.stoodoverCharges.p1 = Details of appealed charges and other standover payments.
+payments.outstanding.stoodoverCharges.linkText = View stoodover charges
 
 payments.outstanding.transactionHistory.p1 = Find details on payments and refunds. It may take up to 5 working days for transactions to appear.
 payments.outstanding.activity.transactionHistory.p2 = Find details on payments and refunds. It may take up to 5 working days for transactions to appear.

--- a/test/helpers/ViewInstances.scala
+++ b/test/helpers/ViewInstances.scala
@@ -109,7 +109,7 @@ trait ViewInstances extends StubMessageControllerComponents {
   val sectionHeader            = new sectionHeader
   val sectionBreak             = new SectionBreak
   val bulletList               = new bulletList
-  val card                     = new HomepageCard
+  val card                     = new HomepageCard(paragraphMessageWithLink)
   val link                     = new link
   val dynamicNotificationArea  = new DynamicNotificationAreaView(h2, link, paragraphBody, paragraphBodyLink, sectionBreak)
 

--- a/test/views/HomepageViewSpec.scala
+++ b/test/views/HomepageViewSpec.scala
@@ -185,7 +185,7 @@ class HomepageViewSpec extends ViewSpecBase {
         paymentsCardLinks.get(1).attr("href") mustBe
           controllers.payments.routes.OutstandingPaymentsController.onPageLoad.url
 
-        paymentsCardLinks.get(2).text() mustBe "Stoodover charges"
+        paymentsCardLinks.get(2).text() mustBe "View stoodover charges"
         paymentsCardLinks.get(2).attr("href") mustBe
           controllers.payments.routes.StoodoverChargesController.onPageLoad.url
 
@@ -513,7 +513,7 @@ class HomepageViewSpec extends ViewSpecBase {
         paymentsCardLinks.get(1).attr("href") mustBe
           controllers.payments.routes.OutstandingPaymentsController.onPageLoad.url
 
-        paymentsCardLinks.get(2).text() mustBe "Stoodover charges"
+        paymentsCardLinks.get(2).text() mustBe "View stoodover charges"
         paymentsCardLinks.get(2).attr("href") mustBe
           controllers.payments.routes.StoodoverChargesController.onPageLoad.url
 
@@ -685,7 +685,7 @@ class HomepageViewSpec extends ViewSpecBase {
         paymentsCard.getElementsByTag("a").get(1).attr("href") mustBe
           controllers.payments.routes.OutstandingPaymentsController.onPageLoad.url
 
-        paymentsCardLinks.get(2).text() mustBe "Stoodover charges"
+        paymentsCardLinks.get(2).text() mustBe "View stoodover charges"
         paymentsCard.getElementsByTag("a").get(2).attr("href") mustBe
           controllers.payments.routes.StoodoverChargesController.onPageLoad.url
 

--- a/test/views/HomepageViewSpec.scala
+++ b/test/views/HomepageViewSpec.scala
@@ -220,6 +220,14 @@ class HomepageViewSpec extends ViewSpecBase {
         controllers.btn.routes.BTNBeforeStartController.onPageLoad().url
       manageCardHelpTexts.get(2).text() mustBe
         "If your group does not expect to meet the annual revenue threshold, you may be able to submit a Below-Threshold Notification."
+
+      manageCard
+        .getElementsByClass("govuk-body")
+        .last()
+        .text() mustBe "You can contact the Pillar 2 team at pillar2mailbox@hmrc.gov.uk"
+
+      manageCardLinks.get(3).text() mustBe "pillar2mailbox@hmrc.gov.uk"
+      manageCardLinks.get(3).attr("href") mustBe "mailto:pillar2mailbox@hmrc.gov.uk"
     }
 
     "have correct structure" in {
@@ -739,6 +747,14 @@ class HomepageViewSpec extends ViewSpecBase {
         controllers.btn.routes.BTNBeforeStartController.onPageLoad().url
       manageCardHelpTexts.get(2).text() mustBe
         "Submit a Below-Threshold Notification if your client does not expect to meet the annual revenue threshold."
+
+      manageCard
+        .getElementsByClass("govuk-body")
+        .last()
+        .text() mustBe "You can contact the Pillar 2 team at pillar2mailbox@hmrc.gov.uk"
+
+      manageCardLinks.get(3).text() mustBe "pillar2mailbox@hmrc.gov.uk"
+      manageCardLinks.get(3).attr("href") mustBe "mailto:pillar2mailbox@hmrc.gov.uk"
     }
 
     "have correct structure" in {


### PR DESCRIPTION
Add the following: 'You can contact the Pillar 2 team at pillar2mailbox@hmrc.gov.uk'

Also corrected "Stoodover charges" homepage link to be "View stoodover charges"