### PR TITLE
PIL-2926: Added dynamic content for when the same dates are entered as account period being changed

### DIFF
--- a/app/controllers/subscription/manageAccount/AmendAccountingPeriodCYAController.scala
+++ b/app/controllers/subscription/manageAccount/AmendAccountingPeriodCYAController.scala
@@ -62,15 +62,18 @@ class AmendAccountingPeriodCYAController @Inject() (
         given Messages = request.messages
         (
           maybeUserAnswers.flatMap(_.get(NewAccountingPeriodPage)),
+          request.subscriptionLocalData.get(SubAccountingPeriodPage),
           request.subscriptionLocalData.accountingPeriods
         ) match {
-          case (Some(newPeriod), Some(allPeriods)) =>
+          case (Some(newPeriod), Some(existingPeriod), Some(allPeriods)) =>
             val affected              = findAffectedPeriods(newPeriod.startDate, newPeriod.endDate, allPeriods)
             val predicted             = predictMicroPeriods(newPeriod, affected)
             val newDurationText       = AmendAccountingPeriodDurationFormatter.formatInclusivePeriod(newPeriod.startDate, newPeriod.endDate)
             val predictedWithDuration = predicted.map { p =>
               (p, AmendAccountingPeriodDurationFormatter.formatInclusivePeriod(p.startDate, p.endDate))
             }
+            val sameDateEntered: Boolean = (existingPeriod.startDate, existingPeriod.endDate) == (newPeriod.startDate, newPeriod.endDate)
+
             Ok(
               view(
                 newPeriod,
@@ -78,7 +81,8 @@ class AmendAccountingPeriodCYAController @Inject() (
                 predictedWithDuration,
                 request.isAgent,
                 request.subscriptionLocalData.organisationName,
-                request.subscriptionLocalData.plrReference
+                request.subscriptionLocalData.plrReference,
+                sameDateEntered
               )
             )
           case _ =>

--- a/app/controllers/subscription/manageAccount/AmendAccountingPeriodCYAController.scala
+++ b/app/controllers/subscription/manageAccount/AmendAccountingPeriodCYAController.scala
@@ -72,7 +72,7 @@ class AmendAccountingPeriodCYAController @Inject() (
             val predictedWithDuration = predicted.map { p =>
               (p, AmendAccountingPeriodDurationFormatter.formatInclusivePeriod(p.startDate, p.endDate))
             }
-            val sameDateEntered: Boolean = (existingPeriod.startDate, existingPeriod.endDate) == (newPeriod.startDate, newPeriod.endDate)
+            val sameDatesEntered: Boolean = (existingPeriod.startDate, existingPeriod.endDate) == (newPeriod.startDate, newPeriod.endDate)
 
             Ok(
               view(
@@ -82,7 +82,7 @@ class AmendAccountingPeriodCYAController @Inject() (
                 request.isAgent,
                 request.subscriptionLocalData.organisationName,
                 request.subscriptionLocalData.plrReference,
-                sameDateEntered
+                sameDatesEntered
               )
             )
           case _ =>

--- a/app/views/subscriptionview/manageAccount/AmendAccountingPeriodCYAView.scala.html
+++ b/app/views/subscriptionview/manageAccount/AmendAccountingPeriodCYAView.scala.html
@@ -28,14 +28,16 @@
     govukButton:      GovukButton
 )
 
-@(newPeriod: AccountingPeriod, newDurationText: String, predictedPeriods: Seq[(AccountingPeriod, String)], isAgent: Boolean, organisationName: Option[String], plrReference: String)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(newPeriod: AccountingPeriod, newDurationText: String, predictedPeriods: Seq[(AccountingPeriod, String)], isAgent: Boolean, organisationName: Option[String], plrReference: String, sameDateEntered: Boolean)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @layout(pageTitle = titleNoForm(messages("amendAccountingPeriodCYA.title")), showBackLink = true, bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
     @formHelper(action = controllers.subscription.manageAccount.routes.AmendAccountingPeriodCYAController.onSubmit()) {
 
-        @if(organisationName.isDefined) {
-            <h2 class="govuk-caption-m hmrc-caption-m"><span id="section-header"><strong>Group:</strong> @organisationName.get <strong>ID:</strong> @plrReference</span></h2>
+        @if(isAgent && organisationName.isDefined) {
+            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}: </strong>@plrReference</span>
+        } else if(isAgent) {
+            <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
         }
 
         @heading(messages("amendAccountingPeriodCYA.heading"), "govuk-heading-l")
@@ -67,9 +69,13 @@
         </div>
 
         @defining(
-            Seq(messages("amendAccountingPeriodCYA.warning", newDurationText)) ++
-            predictedPeriods.map { case (period, durationText) =>
-                messages("amendAccountingPeriodCYA.predictedPeriod.duration", durationText, period.startDate.toDateFormat, period.endDate.toDateFormat)
+            if(sameDateEntered) {
+                Seq(messages("amendAccountingPeriodCYA.sameDateEntered.warning"), messages("amendAccountingPeriodCYA.sameDateEntered.duration", newDurationText))
+            } else {
+                Seq(messages("amendAccountingPeriodCYA.warning", newDurationText)) ++
+                predictedPeriods.map { case (period, durationText) =>
+                    messages("amendAccountingPeriodCYA.predictedPeriod.duration", durationText, period.startDate.toDateFormat, period.endDate.toDateFormat)
+                }
             }
         ) { warningLines =>
             @govukWarningText(WarningText(

--- a/app/views/subscriptionview/manageAccount/AmendAccountingPeriodCYAView.scala.html
+++ b/app/views/subscriptionview/manageAccount/AmendAccountingPeriodCYAView.scala.html
@@ -28,7 +28,7 @@
     govukButton:      GovukButton
 )
 
-@(newPeriod: AccountingPeriod, newDurationText: String, predictedPeriods: Seq[(AccountingPeriod, String)], isAgent: Boolean, organisationName: Option[String], plrReference: String, sameDateEntered: Boolean)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
+@(newPeriod: AccountingPeriod, newDurationText: String, predictedPeriods: Seq[(AccountingPeriod, String)], isAgent: Boolean, organisationName: Option[String], plrReference: String, sameDatesEntered: Boolean)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
 @layout(pageTitle = titleNoForm(messages("amendAccountingPeriodCYA.title")), showBackLink = true, bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
@@ -69,8 +69,8 @@
         </div>
 
         @defining(
-            if(sameDateEntered) {
-                Seq(messages("amendAccountingPeriodCYA.sameDateEntered.warning"), messages("amendAccountingPeriodCYA.sameDateEntered.duration", newDurationText))
+            if(sameDatesEntered) {
+                Seq(messages("amendAccountingPeriodCYA.sameDatesEntered.warning"), messages("amendAccountingPeriodCYA.sameDatesEntered.duration", newDurationText))
             } else {
                 Seq(messages("amendAccountingPeriodCYA.warning", newDurationText)) ++
                 predictedPeriods.map { case (period, durationText) =>

--- a/app/views/subscriptionview/manageAccount/AmendAccountingPeriodCYAView.scala.html
+++ b/app/views/subscriptionview/manageAccount/AmendAccountingPeriodCYAView.scala.html
@@ -84,6 +84,13 @@
             ))
         }
 
-        @govukButton(ButtonViewModel(messages("amendAccountingPeriodCYA.confirm")).withAttribute("id" -> "submit"))
+        <div class="govuk-button-group">
+            <button type="submit" class="govuk-button" data-module="govuk-button">
+                @messages("amendAccountingPeriodCYA.confirm")
+            </button>
+            <a class="govuk-link" href="@controllers.routes.HomepageController.onPageLoad()">
+                @messages("amendAccountingPeriodCYA.cancel")
+            </a>
+        </div>
     }
 }

--- a/app/views/subscriptionview/manageAccount/AmendAccountingPeriodCYAView.scala.html
+++ b/app/views/subscriptionview/manageAccount/AmendAccountingPeriodCYAView.scala.html
@@ -35,9 +35,9 @@
     @formHelper(action = controllers.subscription.manageAccount.routes.AmendAccountingPeriodCYAController.onSubmit()) {
 
         @if(isAgent && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}: </strong>@plrReference</span>
+            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName <strong>@{messages("homepage.id")}:</strong> @plrReference</span>
         } else if(isAgent) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
+            <span class="govuk-caption-m"><strong>@{messages("homepage.id")}:</strong> @plrReference</span>
         }
 
         @heading(messages("amendAccountingPeriodCYA.heading"), "govuk-heading-l")

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -904,6 +904,7 @@ amendAccountingPeriodCYA.predictedPeriod.duration = This will create an accounti
 amendAccountingPeriodCYA.sameDatesEntered.warning = The dates you entered are the same as the accounting period you requested to change.
 amendAccountingPeriodCYA.sameDatesEntered.duration = Your accounting period will remain as {0}.
 amendAccountingPeriodCYA.confirm = Confirm
+amendAccountingPeriodCYA.cancel = Cancel and return to homepage
 
 ###############################################
 #

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -901,8 +901,8 @@ amendAccountingPeriodCYA.duration.days = {0} days
 amendAccountingPeriodCYA.warning = This change will create an accounting period of {0}.
 amendAccountingPeriodCYA.predictedPeriod.title = Period that will be created
 amendAccountingPeriodCYA.predictedPeriod.duration = This will create an accounting period of {0} from {1} to {2}.
-amendAccountingPeriodCYA.sameDateEntered.warning = The dates you entered are the same as the accounting period you requested to change.
-amendAccountingPeriodCYA.sameDateEntered.duration = Your accounting period will remain as {0}.
+amendAccountingPeriodCYA.sameDatesEntered.warning = The dates you entered are the same as the accounting period you requested to change.
+amendAccountingPeriodCYA.sameDatesEntered.duration = Your accounting period will remain as {0}.
 amendAccountingPeriodCYA.confirm = Confirm
 
 ###############################################

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -901,6 +901,8 @@ amendAccountingPeriodCYA.duration.days = {0} days
 amendAccountingPeriodCYA.warning = This change will create an accounting period of {0}.
 amendAccountingPeriodCYA.predictedPeriod.title = Period that will be created
 amendAccountingPeriodCYA.predictedPeriod.duration = This will create an accounting period of {0} from {1} to {2}.
+amendAccountingPeriodCYA.sameDateEntered.warning = The dates you entered are the same as the accounting period you requested to change.
+amendAccountingPeriodCYA.sameDateEntered.duration = Your accounting period will remain as {0}.
 amendAccountingPeriodCYA.confirm = Confirm
 
 ###############################################

--- a/test/views/subscriptionview/manageAccount/AmendAccountingPeriodCYAViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/AmendAccountingPeriodCYAViewSpec.scala
@@ -122,8 +122,13 @@ class AmendAccountingPeriodCYAViewSpec extends ViewSpecBase with SubscriptionLoc
       }
     }
 
-    "have a button" in {
-      view().getElementsByClass("govuk-button").text mustBe "Confirm"
+    "have a button group" in {
+      val buttonGroup = view().getElementsByClass("govuk-button-group").first()
+      buttonGroup.getElementsByClass("govuk-button").text mustBe "Confirm"
+
+      val link = buttonGroup.getElementsByClass("govuk-link").first()
+      link.text mustBe "Cancel and return to homepage"
+      link.attr("href") mustBe controllers.routes.HomepageController.onPageLoad().url
     }
 
     val viewScenarios: Seq[ViewScenario] =

--- a/test/views/subscriptionview/manageAccount/AmendAccountingPeriodCYAViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/AmendAccountingPeriodCYAViewSpec.scala
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.subscriptionview.manageAccount
+
+import base.ViewSpecBase
+import controllers.routes
+import helpers.SubscriptionLocalDataFixture
+import models.subscription.AccountingPeriod
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.select.Elements
+import views.behaviours.ViewScenario
+import views.html.subscriptionview.manageAccount.AmendAccountingPeriodCYAView
+
+import java.time.LocalDate
+
+class AmendAccountingPeriodCYAViewSpec extends ViewSpecBase with SubscriptionLocalDataFixture {
+
+  lazy val page:             AmendAccountingPeriodCYAView = inject[AmendAccountingPeriodCYAView]
+  lazy val pageTitle:        String                       = "Confirm new accounting period"
+  lazy val plrReference:     String                       = "XMPLR0123456789"
+  lazy val accountingPeriod: AccountingPeriod             = AccountingPeriod(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), None)
+  lazy val durationText:     String                       = "1 year"
+
+  def view(
+    newPeriod:        AccountingPeriod = accountingPeriod,
+    newDurationText:  String = durationText,
+    predictedPeriods: Seq[(AccountingPeriod, String)] = Seq.empty,
+    isAgent:          Boolean = false,
+    sameDatesEntered: Boolean = false
+  ): Document = Jsoup.parse(
+    page(newPeriod, newDurationText, predictedPeriods, isAgent, Some("orgName"), plrReference, sameDatesEntered)(
+      request,
+      appConfig,
+      messages
+    )
+      .toString()
+  )
+
+  "Amend Accounting Period CYA View" must {
+    "have a title" in {
+      view().title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
+    }
+
+    "display back link" in {
+      view().getElementsByClass("govuk-back-link").size() mustBe 1
+    }
+
+    "caption for agent view" in {
+      view(isAgent = true).getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
+    }
+
+    "have a unique H1 heading" in {
+      val h1Elements: Elements = view().getElementsByTag("h1")
+      h1Elements.size() mustBe 1
+      h1Elements.text() mustBe pageTitle
+    }
+
+    "have a banner with a link to the Homepage" in {
+      val className: String = "govuk-header__link govuk-header__service-name"
+      view().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+    }
+
+    "have summary card with correct content" in {
+      val summaryCard = view().getElementsByClass("govuk-summary-card").first()
+      summaryCard.getElementsByClass("govuk-summary-card__title").text() mustBe "New accounting period"
+      summaryCard.getElementsByClass("govuk-summary-card__actions").text() mustBe "Change new accounting period"
+
+      val summaryCardRows = summaryCard.getElementsByClass("govuk-summary-list__row")
+      summaryCardRows.first().getElementsByClass("govuk-summary-list__key").text() mustBe "Start date"
+      summaryCardRows.first().getElementsByClass("govuk-summary-list__value").text() mustBe "1 January 2024"
+
+      summaryCardRows.get(1).getElementsByClass("govuk-summary-list__key").text() mustBe "End date"
+      summaryCardRows.get(1).getElementsByClass("govuk-summary-list__value").text() mustBe "31 December 2024"
+    }
+
+    "have correct dynamic warning text" when {
+      "a new date is entered" in {
+        val warningText = view().getElementsByClass("govuk-warning-text").first()
+        warningText
+          .getElementsByClass("govuk-warning-text__text")
+          .text() mustBe "Warning This change will create an accounting period of 1 year."
+      }
+
+      "a new date is entered resulting in predicted periods" in {
+        val accountingPeriod = AccountingPeriod(LocalDate.of(2023, 1, 1), LocalDate.of(2024, 3, 31))
+        val duration         = "1 year and 3 months"
+        val predictedPeriods = Seq(
+          (AccountingPeriod(LocalDate.of(2022, 9, 28), LocalDate.of(2022, 12, 31)), "3 months and 4 days"),
+          (AccountingPeriod(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 9, 27)), "5 months and 27 days")
+        )
+
+        val warningText = view(newPeriod = accountingPeriod, newDurationText = duration, predictedPeriods = predictedPeriods)
+          .getElementsByClass("govuk-warning-text")
+          .first()
+        warningText
+          .getElementsByClass("govuk-warning-text__text")
+          .text() mustBe "Warning This change will create an accounting period of 1 year and 3 months. " +
+          "This will create an accounting period of 3 months and 4 days from 28 September 2022 to 31 December 2022. " +
+          "This will create an accounting period of 5 months and 27 days from 1 April 2024 to 27 September 2024."
+      }
+
+      "a new date is entered and is the same as the accounting period date being changed" in {
+        val warningText = view(sameDatesEntered = true).getElementsByClass("govuk-warning-text").first()
+        warningText
+          .getElementsByClass("govuk-warning-text__text")
+          .text() mustBe "Warning The dates you entered are the same as the accounting period you requested to change. Your accounting period will remain as 1 year."
+      }
+    }
+
+    "have a button" in {
+      view().getElementsByClass("govuk-button").text mustBe "Confirm"
+    }
+
+    val viewScenarios: Seq[ViewScenario] =
+      Seq(
+        ViewScenario("view", view()),
+        ViewScenario("agentView", view(isAgent = true))
+      )
+
+    behaveLikeAccessiblePage(viewScenarios)
+  }
+}


### PR DESCRIPTION
On the Confirm Accounting period page in the Change Accounting period journey when the user enters the same start date and same end date for the accounting period they have chosen to change then we display a new warning message:
‘The dates you entered are the same as the accounting period you requested to change’ The existing ‘Your accounting period will remain as X year and X months or X days’ this calculation should be reused for this warning message and the only difference is the ‘remain’ wording.
Display the link: ’Cancel and return to homepage’ alongside the ‘Confirm button’
This warning should be able to appear on the Organisation version and Agent version of the page