### PR TITLE
NOJIRA - Use v2 read subscription when amendMultipleAccountingPeriods is enabled

### DIFF
--- a/app/connectors/SubscriptionConnector.scala
+++ b/app/connectors/SubscriptionConnector.scala
@@ -97,8 +97,8 @@ class SubscriptionConnector @Inject() (val config: FrontendAppConfig, val http: 
       }
   }
 
-  /** Read Subscription V2: returns multiple accounting periods with canAmend flags. */
-  def readSubscriptionV2(
+  /** Read and cache Subscription V2: returns multiple accounting periods with canAmend flags, caches the result. */
+  def readAndCacheSubscriptionV2(
     userId:       String,
     plrReference: String
   )(using hc: HeaderCarrier, ec: ExecutionContext): Future[SubscriptionDataV2] = {
@@ -113,6 +113,27 @@ class SubscriptionConnector @Inject() (val config: FrontendAppConfig, val http: 
           Future.failed(UnprocessableEntityError)
         case notFoundResponse if notFoundResponse.status == NOT_FOUND =>
           Future.failed(NoResultFound)
+        case e =>
+          logger.warn(s"Connection issue when calling read subscription v2 with status: ${e.status}")
+          if RetryableGatewayError.retryableStatuses(e.status) then Future.failed(RetryableGatewayError)
+          else Future.failed(InternalIssueError)
+      }
+  }
+
+  /** Read Subscription V2 (no cache). Uses the v2 endpoint that returns multiple accounting periods. */
+  def readSubscriptionV2(
+    plrReference: String
+  )(using hc: HeaderCarrier, ec: ExecutionContext): Future[Option[SubscriptionDataV2]] = {
+    val subscriptionUrl = s"${config.pillar2BaseUrl}/report-pillar2-top-up-taxes/subscription/v2/read-subscription/$plrReference"
+    http
+      .get(url"$subscriptionUrl")
+      .execute[HttpResponse]
+      .flatMap {
+        case response if response.status == OK =>
+          Future.successful(Some(Json.parse(response.body).as[SubscriptionSuccessV2].success))
+        case response if response.status == UNPROCESSABLE_ENTITY =>
+          Future.failed(UnprocessableEntityError)
+        case notFoundResponse if notFoundResponse.status == NOT_FOUND => Future.successful(None)
         case e =>
           logger.warn(s"Connection issue when calling read subscription v2 with status: ${e.status}")
           if RetryableGatewayError.retryableStatuses(e.status) then Future.failed(RetryableGatewayError)

--- a/app/connectors/SubscriptionConnector.scala
+++ b/app/connectors/SubscriptionConnector.scala
@@ -134,7 +134,7 @@ class SubscriptionConnector @Inject() (val config: FrontendAppConfig, val http: 
         case response if response.status == UNPROCESSABLE_ENTITY =>
           Future.failed(UnprocessableEntityError)
         case notFoundResponse if notFoundResponse.status == NOT_FOUND => Future.successful(None)
-        case e =>
+        case e                                                        =>
           logger.warn(s"Connection issue when calling read subscription v2 with status: ${e.status}")
           if RetryableGatewayError.retryableStatuses(e.status) then Future.failed(RetryableGatewayError)
           else Future.failed(InternalIssueError)

--- a/app/models/subscription/SubscriptionDataV2.scala
+++ b/app/models/subscription/SubscriptionDataV2.scala
@@ -27,7 +27,19 @@ final case class SubscriptionDataV2(
   filingMemberDetails:      Option[FilingMemberDetails],
   accountingPeriod:         Seq[AccountingPeriodV2] = Seq.empty,
   accountStatus:            Option[AccountStatus]
-)
+) {
+
+  def toSubscriptionData: SubscriptionData = SubscriptionData(
+    formBundleNumber = formBundleNumber,
+    upeDetails = upeDetails,
+    upeCorrespAddressDetails = upeCorrespAddressDetails,
+    primaryContactDetails = primaryContactDetails,
+    secondaryContactDetails = secondaryContactDetails,
+    filingMemberDetails = filingMemberDetails,
+    accountingPeriod = accountingPeriod.head.toAccountingPeriod,
+    accountStatus = accountStatus
+  )
+}
 
 object SubscriptionDataV2 {
   given format: OFormat[SubscriptionDataV2] = Json.format[SubscriptionDataV2]

--- a/app/services/SubscriptionService.scala
+++ b/app/services/SubscriptionService.scala
@@ -41,7 +41,8 @@ class SubscriptionService @Inject() (
   subscriptionConnector:        SubscriptionConnector,
   userAnswersConnectors:        UserAnswersConnectors,
   enrolmentConnector:           TaxEnrolmentConnector,
-  enrolmentStoreProxyConnector: EnrolmentStoreProxyConnector
+  enrolmentStoreProxyConnector: EnrolmentStoreProxyConnector,
+  appConfig:                    config.FrontendAppConfig
 )(using ec: ExecutionContext)
     extends Logging {
 
@@ -68,10 +69,13 @@ class SubscriptionService @Inject() (
     }
 
   def maybeReadSubscription(plrReference: String)(using hc: HeaderCarrier): Future[Option[SubscriptionData]] =
-    subscriptionConnector.readSubscription(plrReference)
+    if appConfig.amendMultipleAccountingPeriods then
+      subscriptionConnector.readSubscriptionV2(plrReference).map(_.map(_.toSubscriptionData))
+    else
+      subscriptionConnector.readSubscription(plrReference)
 
   def readSubscription(plrReference: String)(using hc: HeaderCarrier): Future[SubscriptionData] =
-    subscriptionConnector.readSubscription(plrReference).flatMap {
+    maybeReadSubscription(plrReference).flatMap {
       case Some(subData) => Future.successful(subData)
       case None          => Future.failed(NoResultFound)
     }
@@ -96,7 +100,7 @@ class SubscriptionService @Inject() (
   )(using hc: HeaderCarrier): Future[SubscriptionLocalData] =
     for {
       existingOpt <- subscriptionConnector.getSubscriptionCache(userId)
-      v2          <- subscriptionConnector.readSubscriptionV2(userId, plrReference)
+      v2          <- subscriptionConnector.readAndCacheSubscriptionV2(userId, plrReference)
       fresh  = subscriptionDataV2ToLocalData(plrReference, v2)
       merged = existingOpt match {
                  case Some(existing) =>

--- a/app/services/SubscriptionService.scala
+++ b/app/services/SubscriptionService.scala
@@ -69,10 +69,8 @@ class SubscriptionService @Inject() (
     }
 
   def maybeReadSubscription(plrReference: String)(using hc: HeaderCarrier): Future[Option[SubscriptionData]] =
-    if appConfig.amendMultipleAccountingPeriods then
-      subscriptionConnector.readSubscriptionV2(plrReference).map(_.map(_.toSubscriptionData))
-    else
-      subscriptionConnector.readSubscription(plrReference)
+    if appConfig.amendMultipleAccountingPeriods then subscriptionConnector.readSubscriptionV2(plrReference).map(_.map(_.toSubscriptionData))
+    else subscriptionConnector.readSubscription(plrReference)
 
   def readSubscription(plrReference: String)(using hc: HeaderCarrier): Future[SubscriptionData] =
     maybeReadSubscription(plrReference).flatMap {

--- a/test/connectors/SubscriptionConnectorSpec.scala
+++ b/test/connectors/SubscriptionConnectorSpec.scala
@@ -178,11 +178,11 @@ class SubscriptionConnectorSpec extends SpecBase with WireMockServerHandler {
       }
     }
 
-    "readSubscriptionV2" should {
+    "readAndCacheSubscriptionV2" should {
 
       "return SubscriptionDataV2 when backend returns 200 OK" in {
         stubGet(s"$readSubscriptionV2Path/$id/$plrReference", OK, v2SuccessJson)
-        val result = connector.readSubscriptionV2(id, plrReference).futureValue
+        val result = connector.readAndCacheSubscriptionV2(id, plrReference).futureValue
         result.formBundleNumber mustBe "119000004323"
         result.accountingPeriod must have size 1
         result.accountingPeriod.head.canAmendStartDate mustBe true
@@ -190,27 +190,59 @@ class SubscriptionConnectorSpec extends SpecBase with WireMockServerHandler {
 
       "fail with NoResultFound when backend returns 404" in {
         stubGet(s"$readSubscriptionV2Path/$id/$plrReference", NOT_FOUND, unsuccessfulNotFoundJson)
-        connector.readSubscriptionV2(id, plrReference).failed.futureValue mustBe models.NoResultFound
+        connector.readAndCacheSubscriptionV2(id, plrReference).failed.futureValue mustBe models.NoResultFound
       }
 
       "fail with UnprocessableEntityError when backend returns 422" in {
         stubGet(s"$readSubscriptionV2Path/$id/$plrReference", UNPROCESSABLE_ENTITY, unsuccessfulResponseJson)
-        connector.readSubscriptionV2(id, plrReference).failed.futureValue mustBe UnprocessableEntityError
+        connector.readAndCacheSubscriptionV2(id, plrReference).failed.futureValue mustBe UnprocessableEntityError
       }
 
       "fail with RetryableGatewayError when backend returns 500" in {
         stubGet(s"$readSubscriptionV2Path/$id/$plrReference", INTERNAL_SERVER_ERROR, "")
-        connector.readSubscriptionV2(id, plrReference).failed.futureValue mustBe RetryableGatewayError
+        connector.readAndCacheSubscriptionV2(id, plrReference).failed.futureValue mustBe RetryableGatewayError
       }
 
       "fail with RetryableGatewayError when backend returns 502" in {
         stubGet(s"$readSubscriptionV2Path/$id/$plrReference", BAD_GATEWAY, "")
-        connector.readSubscriptionV2(id, plrReference).failed.futureValue mustBe RetryableGatewayError
+        connector.readAndCacheSubscriptionV2(id, plrReference).failed.futureValue mustBe RetryableGatewayError
       }
 
       "fail with InternalIssueError when backend returns 503" in {
         stubGet(s"$readSubscriptionV2Path/$id/$plrReference", SERVICE_UNAVAILABLE, "")
-        connector.readSubscriptionV2(id, plrReference).failed.futureValue mustBe InternalIssueError
+        connector.readAndCacheSubscriptionV2(id, plrReference).failed.futureValue mustBe InternalIssueError
+      }
+    }
+
+    "readSubscriptionV2 (read-only)" should {
+
+      "return Some(SubscriptionDataV2) when backend returns 200 OK" in {
+        stubGet(s"$readSubscriptionV2Path/$plrReference", OK, v2SuccessWrappedJson)
+        val result = connector.readSubscriptionV2(plrReference).futureValue
+        result mustBe defined
+        result.get.formBundleNumber mustBe "119000004323"
+        result.get.accountingPeriod must have size 1
+        result.get.accountingPeriod.head.canAmendStartDate mustBe true
+      }
+
+      "return None when backend returns 404" in {
+        stubGet(s"$readSubscriptionV2Path/$plrReference", NOT_FOUND, unsuccessfulNotFoundJson)
+        connector.readSubscriptionV2(plrReference).futureValue mustBe None
+      }
+
+      "fail with UnprocessableEntityError when backend returns 422" in {
+        stubGet(s"$readSubscriptionV2Path/$plrReference", UNPROCESSABLE_ENTITY, unsuccessfulResponseJson)
+        connector.readSubscriptionV2(plrReference).failed.futureValue mustBe UnprocessableEntityError
+      }
+
+      "fail with RetryableGatewayError when backend returns 500" in {
+        stubGet(s"$readSubscriptionV2Path/$plrReference", INTERNAL_SERVER_ERROR, "")
+        connector.readSubscriptionV2(plrReference).failed.futureValue mustBe RetryableGatewayError
+      }
+
+      "fail with InternalIssueError when backend returns 503" in {
+        stubGet(s"$readSubscriptionV2Path/$plrReference", SERVICE_UNAVAILABLE, "")
+        connector.readSubscriptionV2(plrReference).failed.futureValue mustBe InternalIssueError
       }
     }
 
@@ -305,6 +337,9 @@ object SubscriptionConnectorSpec {
       |  "accountStatus": { "inactive": false }
       |}
       |""".stripMargin
+
+  val v2SuccessWrappedJson: String =
+    s"""{ "success": $v2SuccessJson }"""
 
   private val businessSubscriptionSuccessJson: String =
     """

--- a/test/models/subscription/SubscriptionDataV2Spec.scala
+++ b/test/models/subscription/SubscriptionDataV2Spec.scala
@@ -97,5 +97,26 @@ class SubscriptionDataV2Spec extends SpecBase {
       val result  = wrapped.as[SubscriptionSuccessV2]
       result.success.formBundleNumber mustBe "119000004323"
     }
+
+    "toSubscriptionData converts V2 to V1 using the head accounting period" in {
+      val v2 = v2Json.as[SubscriptionDataV2]
+      val v1 = v2.toSubscriptionData
+
+      v1.formBundleNumber mustBe v2.formBundleNumber
+      v1.upeDetails mustBe v2.upeDetails
+      v1.upeCorrespAddressDetails mustBe v2.upeCorrespAddressDetails
+      v1.primaryContactDetails mustBe v2.primaryContactDetails
+      v1.secondaryContactDetails mustBe v2.secondaryContactDetails
+      v1.filingMemberDetails mustBe v2.filingMemberDetails
+      v1.accountStatus mustBe v2.accountStatus
+      v1.accountingPeriod.startDate mustBe LocalDate.of(2024, 1, 6)
+      v1.accountingPeriod.endDate mustBe LocalDate.of(2025, 4, 6)
+      v1.accountingPeriod.dueDate mustBe Some(LocalDate.of(2024, 4, 6))
+    }
+
+    "toSubscriptionData throws when accountingPeriod is empty" in {
+      val v2 = v2Json.as[SubscriptionDataV2].copy(accountingPeriod = Seq.empty)
+      a[NoSuchElementException] must be thrownBy v2.toSubscriptionData
+    }
   }
 }

--- a/test/services/SubscriptionServiceSpec.scala
+++ b/test/services/SubscriptionServiceSpec.scala
@@ -451,6 +451,59 @@ class SubscriptionServiceSpec extends SpecBase {
           resultFuture.failed.futureValue shouldBe a[RuntimeException]
         }
       }
+
+      "use v2 read-only endpoint when amendMultipleAccountingPeriods is enabled" in {
+        val v2Period = AccountingPeriodV2(
+          startDate = LocalDate.of(2024, 1, 6),
+          endDate = LocalDate.of(2025, 4, 6),
+          dueDate = LocalDate.of(2024, 4, 6),
+          canAmendStartDate = true,
+          canAmendEndDate = true
+        )
+        val v2Data = SubscriptionDataV2(
+          formBundleNumber = "form bundle",
+          upeDetails = subscriptionData.upeDetails,
+          upeCorrespAddressDetails = subscriptionData.upeCorrespAddressDetails,
+          primaryContactDetails = subscriptionData.primaryContactDetails,
+          secondaryContactDetails = subscriptionData.secondaryContactDetails,
+          filingMemberDetails = subscriptionData.filingMemberDetails,
+          accountingPeriod = Seq(v2Period),
+          accountStatus = subscriptionData.accountStatus
+        )
+
+        val application = applicationBuilder(additionalData = Map("features.amendMultipleAccountingPeriods" -> true))
+          .overrides(
+            bind[SubscriptionConnector].toInstance(mockSubscriptionConnector)
+          )
+          .build()
+        running(application) {
+          when(mockSubscriptionConnector.readSubscriptionV2(any())(using any(), any()))
+            .thenReturn(Future.successful(Some(v2Data)))
+          val service: SubscriptionService = application.injector.instanceOf[SubscriptionService]
+          val result = service.maybeReadSubscription(plrReference).futureValue
+
+          result mustBe defined
+          result.get.formBundleNumber mustBe "form bundle"
+          result.get.accountingPeriod.startDate mustBe LocalDate.of(2024, 1, 6)
+          result.get.accountingPeriod.endDate mustBe LocalDate.of(2025, 4, 6)
+        }
+      }
+
+      "return None via v2 when amendMultipleAccountingPeriods is enabled and connector returns None" in {
+        val application = applicationBuilder(additionalData = Map("features.amendMultipleAccountingPeriods" -> true))
+          .overrides(
+            bind[SubscriptionConnector].toInstance(mockSubscriptionConnector)
+          )
+          .build()
+        running(application) {
+          when(mockSubscriptionConnector.readSubscriptionV2(any())(using any(), any()))
+            .thenReturn(Future.successful(None))
+          val service: SubscriptionService = application.injector.instanceOf[SubscriptionService]
+          val result = service.maybeReadSubscription(plrReference).futureValue
+
+          result mustBe None
+        }
+      }
     }
 
     "amendSubscription" when {
@@ -949,7 +1002,7 @@ class SubscriptionServiceSpec extends SpecBase {
 
       "fetch V2 data from connector, convert to SubscriptionLocalData, save and return it" in
         running(application) {
-          when(mockSubscriptionConnector.readSubscriptionV2(eqTo("id"), eqTo(plrRef))(using any(), any()))
+          when(mockSubscriptionConnector.readAndCacheSubscriptionV2(eqTo("id"), eqTo(plrRef))(using any(), any()))
             .thenReturn(Future.successful(v2Data))
           when(mockSubscriptionConnector.save(eqTo("id"), any())(using any()))
             .thenReturn(Future.successful(play.api.libs.json.Json.obj()))
@@ -980,7 +1033,7 @@ class SubscriptionServiceSpec extends SpecBase {
           )
         )
         running(application) {
-          when(mockSubscriptionConnector.readSubscriptionV2(eqTo("id"), eqTo(plrRef))(using any(), any()))
+          when(mockSubscriptionConnector.readAndCacheSubscriptionV2(eqTo("id"), eqTo(plrRef))(using any(), any()))
             .thenReturn(Future.successful(v2DataWithDetails))
           when(mockSubscriptionConnector.save(eqTo("id"), any())(using any()))
             .thenReturn(Future.successful(play.api.libs.json.Json.obj()))
@@ -999,7 +1052,7 @@ class SubscriptionServiceSpec extends SpecBase {
 
       "propagate failure when save fails" in
         running(application) {
-          when(mockSubscriptionConnector.readSubscriptionV2(eqTo("id"), eqTo(plrRef))(using any(), any()))
+          when(mockSubscriptionConnector.readAndCacheSubscriptionV2(eqTo("id"), eqTo(plrRef))(using any(), any()))
             .thenReturn(Future.successful(v2Data))
           when(mockSubscriptionConnector.save(eqTo("id"), any())(using any()))
             .thenReturn(Future.failed(InternalIssueError))
@@ -1009,9 +1062,9 @@ class SubscriptionServiceSpec extends SpecBase {
           service.readSubscriptionV2AndSave("id", plrRef).failed.futureValue mustBe InternalIssueError
         }
 
-      "propagate failure when readSubscriptionV2 fails" in
+      "propagate failure when readAndCacheSubscriptionV2 fails" in
         running(application) {
-          when(mockSubscriptionConnector.readSubscriptionV2(any(), any())(using any(), any()))
+          when(mockSubscriptionConnector.readAndCacheSubscriptionV2(any(), any())(using any(), any()))
             .thenReturn(Future.failed(InternalIssueError))
           when(mockSubscriptionConnector.getSubscriptionCache(eqTo("id"))(using any(), any()))
             .thenReturn(Future.successful(None))


### PR DESCRIPTION
## Summary

- When `amendMultipleAccountingPeriods = true`, the downstream ETMP returns `accountingPeriod` as a JSON array. The v1 read subscription endpoint expects a single JSON object, causing a `JsResultException` (`error.expected.jsobject`) on any page that reads subscription data.
- This change makes `SubscriptionService.readSubscription` and `maybeReadSubscription` automatically route through the v2 read endpoint when the flag is enabled, so all callers (payments, transaction history, amend flows, etc.) are fixed without individual controller changes.
- Renames `readSubscriptionV2` → `readAndCacheSubscriptionV2` and introduces a new read-only `readSubscriptionV2` on the connector for consistency with the v1 naming pattern (`readSubscription` vs `cacheSubscription`).

### Companion backend PR

The backend `sendAmendedDataV2` also calls `storeSubscriptionResponse` (v1) to refresh its cache after a successful v2 amend, which fails for the same reason. [A companion PR](https://github.com/hmrc/pillar2/pull/146) in `pillar2` switches it to `storeSubscriptionResponseV2`.