### PR TITLE
PIL-3009: Corrected MonthFormatter to trim leading/trailing spaces that was causing an invalid validation error

### DIFF
--- a/app/forms/mappings/LocalDateFormatter.scala
+++ b/app/forms/mappings/LocalDateFormatter.scala
@@ -99,7 +99,7 @@ private[mappings] class LocalDateFormatter(
 
       val months      = Month.values.toList
       val updatedData = data.map {
-        case (key, value) if key.contains("month") => key -> value.replaceFirst("^0+(?!$)", "")
+        case (key, value) if key.contains("month") => key -> value.trim.replaceFirst("^0+(?!$)", "")
         case other                                 => other
       }
       baseFormatter

--- a/test/forms/NewAccountingPeriodFormProviderSpec.scala
+++ b/test/forms/NewAccountingPeriodFormProviderSpec.scala
@@ -35,6 +35,34 @@ class NewAccountingPeriodFormProviderSpec extends DateBehaviours {
   val formProvider = new NewAccountingPeriodFormProvider()
   val form: Form[AccountingPeriod] = formProvider(chosenAccountingPeriod)
 
+  "bind successfully when a valid date is provided" in {
+    val data = Map(
+      "startDate.day"   -> "1",
+      "startDate.month" -> "1",
+      "startDate.year"  -> "2024",
+      "endDate.day"     -> "31",
+      "endDate.month"   -> "12",
+      "endDate.year"    -> "2024"
+    )
+
+    form.bind(data).errors mustBe empty
+    form.bind(data).value.value mustBe AccountingPeriod(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31))
+  }
+
+  "bind successfully when leading/trailing spaces are present in a valid date" in {
+    val data = Map(
+      "startDate.day"   -> " 1 ",
+      "startDate.month" -> " 1 ",
+      "startDate.year"  -> " 2024 ",
+      "endDate.day"     -> " 31 ",
+      "endDate.month"   -> " 12 ",
+      "endDate.year"    -> " 2024 "
+    )
+
+    form.bind(data).errors mustBe empty
+    form.bind(data).value.value mustBe AccountingPeriod(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31))
+  }
+
   "throw a form error for a start date before 31/12/2023" in {
 
     val startDate = LocalDate.of(2023, 12, 30)


### PR DESCRIPTION
Issue: Date field validation doesn't allow spaces and displays misleading error #11200
WCAG violation: 3.3.3: Error Suggestion
Page: What is the group’s new accounting period?
URL: https://www.staging.tax.service.gov.uk/report-pillar2-top-up-taxes/manage-account/account-details/new-accounting-period
Journey/Step: J3 S3
Description: Date field validation doesn't allow spaces, and displays error message the start/end date must be a real date when the month field has spaces. Which is misleading as the date is real.
Resolve: Follow Date input – GOV.UK Design System and Recover from validation errors guidance.
accept user entry in different format, including spaces
Make sure errors follow the guidance in the Error message component and have specific error messages for specific error states.
Allow the user to add in spaces but strip these out before submission of the new dates