### PR TITLE
NOJIRA Added validation and tests for AccountingPeriodAmendV2

### DIFF
--- a/app/models/subscription/AccountingPeriodAmendV2.scala
+++ b/app/models/subscription/AccountingPeriodAmendV2.scala
@@ -16,7 +16,7 @@
 
 package models.subscription
 
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json.*
 
 final case class AccountingPeriodAmendV2(
   amendAccountingPeriod:     Boolean,
@@ -25,5 +25,25 @@ final case class AccountingPeriodAmendV2(
 )
 
 object AccountingPeriodAmendV2 {
-  given format: OFormat[AccountingPeriodAmendV2] = Json.format[AccountingPeriodAmendV2]
+
+  private val macroFormat: OFormat[AccountingPeriodAmendV2] = Json.format[AccountingPeriodAmendV2]
+
+  given format: OFormat[AccountingPeriodAmendV2] = OFormat(
+    Reads { json =>
+      json.validate[AccountingPeriodAmendV2](macroFormat).flatMap { accountingPeriodAmendV2 =>
+        (
+          accountingPeriodAmendV2.amendAccountingPeriod,
+          accountingPeriodAmendV2.originalAccountingPeriods,
+          accountingPeriodAmendV2.newAccountingPeriod
+        ) match {
+          case (true, Some(originalAccPeriods), Some(_)) if originalAccPeriods.nonEmpty => JsSuccess(accountingPeriodAmendV2)
+          case (false, None, None)                                                      => JsSuccess(accountingPeriodAmendV2)
+          case (true, _, _) => JsError("When amendAccountingPeriod is true, both originalAccountingPeriods and newAccountingPeriod must be set")
+          case _            => JsError("When amendAccountingPeriod is false, originalAccountingPeriods and newAccountingPeriod must be None")
+        }
+      }
+    },
+    macroFormat
+  )
+
 }

--- a/app/services/SubscriptionService.scala
+++ b/app/services/SubscriptionService.scala
@@ -334,15 +334,11 @@ class SubscriptionService @Inject() (
         domesticOnly = userData.subMneOrDomestic == MneOrDomestic.Uk,
         filingMember = currentData.upeDetails.filingMember
       ),
-      // contact/group amend only so not touching the accounting period
-      accountingPeriod = {
-        val accountingPeriod: AccountingPeriod = userData.subAccountingPeriod.getOrElse(currentData.accountingPeriod)
-        AccountingPeriodAmendV2(
-          amendAccountingPeriod = false,
-          originalAccountingPeriods = Some(Seq(OriginalAccountingPeriod(accountingPeriod.startDate, accountingPeriod.endDate))),
-          newAccountingPeriod = None
-        )
-      },
+      accountingPeriod = AccountingPeriodAmendV2(
+        amendAccountingPeriod = false,
+        originalAccountingPeriods = None,
+        newAccountingPeriod = None
+      ),
       upeCorrespAddressDetails = UpeCorrespAddressDetails(
         addressLine1 = userData.subRegisteredAddress.addressLine1,
         addressLine2 = userData.subRegisteredAddress.addressLine2,

--- a/test/models/grs/AccountingPeriodAmendV2Spec.scala
+++ b/test/models/grs/AccountingPeriodAmendV2Spec.scala
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.grs
+
+import base.SpecBase
+import models.subscription.{AccountingPeriodAmendV2, NewAccountingPeriod, OriginalAccountingPeriod}
+import play.api.libs.json.*
+
+import java.time.LocalDate
+
+class AccountingPeriodAmendV2Spec extends SpecBase {
+
+  private val originalPeriod = OriginalAccountingPeriod(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31))
+  private val newPeriod      = NewAccountingPeriod(LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31))
+
+  "AccountingPeriodAmendV2" when {
+
+    "amendAccountingPeriod is set to true" must {
+
+      "parse when both periods are set" in {
+        val testAccountingPeriodAmendV2Json = Json.parse("""
+            |{
+            |  "amendAccountingPeriod": true,
+            |  "originalAccountingPeriods": [
+            |    {
+            |      "taxObligationStartDate": "2024-01-01",
+            |      "taxObligationEndDate":"2024-12-31"
+            |    }
+            |  ],
+            |  "newAccountingPeriod": {
+            |    "updateObligationStartDate": "2025-01-01",
+            |    "updateObligationEndDate": "2025-12-31"
+            |  }
+            |}
+            |""".stripMargin)
+
+        val expectedAccountingPeriodAmendV2: AccountingPeriodAmendV2 =
+          AccountingPeriodAmendV2(
+            amendAccountingPeriod = true,
+            originalAccountingPeriods = Some(Seq(originalPeriod)),
+            newAccountingPeriod = Some(newPeriod)
+          )
+
+        val result = testAccountingPeriodAmendV2Json.validate[AccountingPeriodAmendV2]
+
+        result mustBe JsSuccess(expectedAccountingPeriodAmendV2)
+      }
+
+      "fail to parse when only originalAccountingPeriods is set" in {
+        val testAccountingPeriodAmendV2Json = Json.parse("""
+            |{
+            |  "amendAccountingPeriod": true,
+            |  "originalAccountingPeriods": [
+            |    {
+            |      "taxObligationStartDate": "2024-01-01",
+            |      "taxObligationEndDate":"2024-12-31"
+            |    }
+            |  ]
+            |}
+            |""".stripMargin)
+
+        val result = testAccountingPeriodAmendV2Json.validate[AccountingPeriodAmendV2]
+
+        result mustBe a[JsError]
+      }
+
+      "fail to parse when only newAccountingPeriod is set" in {
+        val testAccountingPeriodAmendV2Json = Json.parse("""
+            |{
+            |  "amendAccountingPeriod": true,
+            |  "newAccountingPeriod": {
+            |    "updateObligationStartDate": "2025-01-01",
+            |    "updateObligationEndDate": "2025-12-31"
+            |  }
+            |}
+            |""".stripMargin)
+
+        val result = testAccountingPeriodAmendV2Json.validate[AccountingPeriodAmendV2]
+
+        result mustBe a[JsError]
+      }
+
+      "fail to parse when originalAccountingPeriods is an empty array" in {
+        val testAccountingPeriodAmendV2Json = Json.parse("""
+            |{
+            |  "amendAccountingPeriod": true,
+            |  "originalAccountingPeriods": [],
+            |  "newAccountingPeriod": {
+            |    "updateObligationStartDate": "2025-01-01",
+            |    "updateObligationEndDate": "2025-12-31"
+            |  }
+            |}
+            |""".stripMargin)
+
+        val result = testAccountingPeriodAmendV2Json.validate[AccountingPeriodAmendV2]
+
+        result mustBe a[JsError]
+      }
+
+      "fail to parse when both periods are absent" in {
+        val testAccountingPeriodAmendV2Json = Json.parse("""
+            |{
+            |  "amendAccountingPeriod": true
+            |}
+            |""".stripMargin)
+
+        val result = testAccountingPeriodAmendV2Json.validate[AccountingPeriodAmendV2]
+
+        result mustBe a[JsError]
+      }
+
+      "successfully deserialise with both periods" in {
+        val testAccountingPeriodAmendV2: AccountingPeriodAmendV2 = AccountingPeriodAmendV2(
+          amendAccountingPeriod = true,
+          originalAccountingPeriods = Some(Seq(originalPeriod)),
+          newAccountingPeriod = Some(newPeriod)
+        )
+
+        val expectedAccountingPeriodAmendV2Json: JsValue = Json.parse("""
+            |{
+            |  "amendAccountingPeriod": true,
+            |  "originalAccountingPeriods": [
+            |    {
+            |      "taxObligationStartDate": "2024-01-01",
+            |      "taxObligationEndDate":"2024-12-31"
+            |    }
+            |  ],
+            |  "newAccountingPeriod": {
+            |    "updateObligationStartDate": "2025-01-01",
+            |    "updateObligationEndDate": "2025-12-31"
+            |  }
+            |}
+            |""".stripMargin)
+
+        val result: JsValue = Json.toJson(testAccountingPeriodAmendV2)
+
+        result mustBe expectedAccountingPeriodAmendV2Json
+      }
+
+    }
+
+    "amendAccountingPeriod is set to false" must {
+
+      "parse when both periods are absent" in {
+        val testAccountingPeriodAmendV2Json = Json.parse("""
+            |{
+            |  "amendAccountingPeriod": false
+            |}
+            |""".stripMargin)
+
+        val expectedAccountingPeriodAmendV2: AccountingPeriodAmendV2 =
+          AccountingPeriodAmendV2(
+            amendAccountingPeriod = false,
+            originalAccountingPeriods = None,
+            newAccountingPeriod = None
+          )
+
+        val result = testAccountingPeriodAmendV2Json.validate[AccountingPeriodAmendV2]
+
+        result mustBe JsSuccess(expectedAccountingPeriodAmendV2)
+      }
+
+      "fail to parse when both periods are set" in {
+        val testAccountingPeriodAmendV2Json = Json.parse("""
+            |{
+            |  "amendAccountingPeriod": false,
+            |  "originalAccountingPeriods": [
+            |    {
+            |      "taxObligationStartDate": "2024-01-01",
+            |      "taxObligationEndDate":"2024-12-31"
+            |    }
+            |  ],
+            |  "newAccountingPeriod": {
+            |    "updateObligationStartDate": "2025-01-01",
+            |    "updateObligationEndDate": "2025-12-31"
+            |  }
+            |}
+            |""".stripMargin)
+
+        val result = testAccountingPeriodAmendV2Json.validate[AccountingPeriodAmendV2]
+
+        result mustBe a[JsError]
+      }
+
+      "fail to parse when originalAccountingPeriods is set" in {
+        val testAccountingPeriodAmendV2Json = Json.parse("""
+            |{
+            |  "amendAccountingPeriod": false,
+            |  "originalAccountingPeriods": [
+            |    {
+            |      "taxObligationStartDate": "2024-01-01",
+            |      "taxObligationEndDate":"2024-12-31"
+            |    }
+            |  ]
+            |}
+            |""".stripMargin)
+
+        val result = testAccountingPeriodAmendV2Json.validate[AccountingPeriodAmendV2]
+
+        result mustBe a[JsError]
+      }
+
+      "fail to parse when newAccountingPeriod is set" in {
+        val testAccountingPeriodAmendV2Json = Json.parse("""
+            |{
+            |  "amendAccountingPeriod": false,
+            |  "newAccountingPeriod": {
+            |    "updateObligationStartDate": "2025-01-01",
+            |    "updateObligationEndDate": "2025-12-31"
+            |  }
+            |}
+            |""".stripMargin)
+
+        val result = testAccountingPeriodAmendV2Json.validate[AccountingPeriodAmendV2]
+
+        result mustBe a[JsError]
+      }
+
+      "successfully deserialise with no periods" in {
+        val testAccountingPeriodAmendV2: AccountingPeriodAmendV2 = AccountingPeriodAmendV2(
+          amendAccountingPeriod = false,
+          originalAccountingPeriods = None,
+          newAccountingPeriod = None
+        )
+
+        val expectedAccountingPeriodAmendV2Json: JsValue = Json.parse("""
+            |{
+            |  "amendAccountingPeriod": false
+            |}
+            |""".stripMargin)
+
+        val result: JsValue = Json.toJson(testAccountingPeriodAmendV2)
+
+        result mustBe expectedAccountingPeriodAmendV2Json
+      }
+    }
+
+  }
+}

--- a/test/services/SubscriptionServiceSpec.scala
+++ b/test/services/SubscriptionServiceSpec.scala
@@ -566,34 +566,36 @@ class SubscriptionServiceSpec extends SpecBase {
       }
     }
 
-    ".amendGroupOrContactDetailsV2" must {
+    "amendGroupOrContactDetailsV2" must {
       "build a v2 payload with amendAccountingPeriod = false for contact-only amend" in {
         val service = app.injector.instanceOf[SubscriptionService]
         val result  = service.amendGroupOrContactDetailsV2("plr", subscriptionData, emptySubscriptionLocalData)
 
         result.accountingPeriod.amendAccountingPeriod mustBe false
-        result.replaceFilingMember mustBe false
+        result.accountingPeriod.originalAccountingPeriods mustBe None
+        result.accountingPeriod.newAccountingPeriod mustBe None
       }
     }
 
-    ".amendContactOrGroupDetails" must {
+    "amendContactOrGroupDetails" must {
       "amendMultipleAccountingPeriods is enabled" should {
         "call amendSubscriptionV2 with amendAccountingPeriod = false" in {
-          val v2Period = AccountingPeriodV2(
+          val accountingPeriodV2 = AccountingPeriodV2(
             startDate = LocalDate.of(2024, 1, 6),
             endDate = LocalDate.of(2025, 4, 6),
             dueDate = LocalDate.of(2024, 4, 6),
             canAmendStartDate = true,
             canAmendEndDate = true
           )
-          val v2Data = SubscriptionDataV2(
+
+          val subscriptionDataV2 = SubscriptionDataV2(
             formBundleNumber = "form bundle",
             upeDetails = subscriptionData.upeDetails,
             upeCorrespAddressDetails = subscriptionData.upeCorrespAddressDetails,
             primaryContactDetails = subscriptionData.primaryContactDetails,
             secondaryContactDetails = subscriptionData.secondaryContactDetails,
             filingMemberDetails = subscriptionData.filingMemberDetails,
-            accountingPeriod = Seq(v2Period),
+            accountingPeriod = Seq(accountingPeriodV2),
             accountStatus = subscriptionData.accountStatus
           )
 
@@ -603,7 +605,7 @@ class SubscriptionServiceSpec extends SpecBase {
 
           running(application) {
             when(mockSubscriptionConnector.readSubscriptionV2(any())(using any(), any()))
-              .thenReturn(Future.successful(Some(v2Data)))
+              .thenReturn(Future.successful(Some(subscriptionDataV2)))
             when(mockSubscriptionConnector.amendSubscriptionV2(any(), any[AmendSubscriptionV2])(using any[HeaderCarrier]))
               .thenReturn(Future.successful(Done))
 
@@ -613,7 +615,11 @@ class SubscriptionServiceSpec extends SpecBase {
 
             verify(mockSubscriptionConnector).amendSubscriptionV2(
               eqTo("id"),
-              argThat[AmendSubscriptionV2](_.accountingPeriod.amendAccountingPeriod == false)
+              argThat[AmendSubscriptionV2] { amendSubscriptionV2 =>
+                amendSubscriptionV2.accountingPeriod.amendAccountingPeriod == false &&
+                amendSubscriptionV2.accountingPeriod.originalAccountingPeriods.isEmpty &&
+                amendSubscriptionV2.accountingPeriod.newAccountingPeriod.isEmpty
+              }
             )(using any[HeaderCarrier])
             verify(mockSubscriptionConnector, never).amendSubscription(any(), any())(using any[HeaderCarrier])
           }
@@ -1173,6 +1179,25 @@ class SubscriptionServiceSpec extends SpecBase {
             .thenReturn(Future.successful(Done))
 
           service.amendAccountingPeriods("id", plrRef, emptySubscriptionLocalData, Seq(affectedPeriod), newPeriod).futureValue mustBe Done
+        }
+
+      "call amendSubscriptionV2 with a valid amend shape and return Done" in
+        running(application) {
+          when(mockSubscriptionConnector.amendSubscriptionV2(any(), any[AmendSubscriptionV2])(using any[HeaderCarrier]))
+            .thenReturn(Future.successful(Done))
+
+          service
+            .amendAccountingPeriods("id", plrRef, emptySubscriptionLocalData, Seq(affectedPeriod), newPeriod)
+            .futureValue mustBe Done
+
+          verify(mockSubscriptionConnector).amendSubscriptionV2(
+            eqTo("id"),
+            argThat[AmendSubscriptionV2] { amendSubscriptionV2 =>
+              amendSubscriptionV2.accountingPeriod.amendAccountingPeriod &&
+              amendSubscriptionV2.accountingPeriod.originalAccountingPeriods.exists(_.nonEmpty) &&
+              amendSubscriptionV2.accountingPeriod.newAccountingPeriod.isDefined
+            }
+          )(using any[HeaderCarrier])
         }
 
       "propagate failure when amendSubscriptionV2 fails" in


### PR DESCRIPTION
- Added validation to AccountingPeriodAmendV2 so that when `amendAccountingPeriod` is false then `originalAccountingPeriods` and `newAccountingPeriod` must be set to `None`.
- Added tests
- Fixed SubscriptionService.amendGroupOrContactDetailsV2 that was sending `originalAccountingPeriods` when amend was set to false.