### PR TITLE
PIL-3000: Moved 'Other ways to pay' section above payment button on OutstandingPaymentsView

### DIFF
--- a/app/views/outstandingpayments/OutstandingPaymentsView.scala.html
+++ b/app/views/outstandingpayments/OutstandingPaymentsView.scala.html
@@ -91,21 +91,17 @@
                     ))))
                 }
             }
-            @h2(messages("payments.outstanding.otherWaysToPay.heading"), size = "m")
+            @h2(messages("payments.outstanding.howToPay.heading"), size = "m")
+            @paragraphBody(messages("payments.outstanding.howToPay.p1"))
+            <p class="govuk-body">@messages("payments.outstanding.howToPay.p2") <strong>@plrReference</strong></p>
             @paragraphBody(
                 userTypeDependentText(
-                    messages("payments.outstanding.otherWaysToPay.p1", plrReference),
-                    messages("payments.outstanding.otherWaysToPay.agent.p1", plrReference)
-                )
-            )
-            @paragraphBody(
-                userTypeDependentText(
-                    messages("payments.outstanding.otherWaysToPay.p2"),
-                    messages("payments.outstanding.otherWaysToPay.agent.p2")
+                    messages("payments.outstanding.howToPay.p3"),
+                    messages("payments.outstanding.howToPay.agent.p3")
                 )
             )
             @paragraphMessageWithLink(
-                linkMessage = messages("payments.outstanding.otherWaysToPay.linkText"),
+                linkMessage = messages("payments.outstanding.howToPay.linkText"),
                 linkUrl = appConfig.howToPayPillar2TaxesUrl,
                 target = "_blank"
             )

--- a/app/views/outstandingpayments/OutstandingPaymentsView.scala.html
+++ b/app/views/outstandingpayments/OutstandingPaymentsView.scala.html
@@ -91,11 +91,6 @@
                     ))))
                 }
             }
-            @govukButton(
-                ButtonViewModel(
-                    messages("payments.outstanding.pay.buttonText")
-                ).asLink(controllers.payments.routes.MakeAPaymentDashboardController.onRedirect().url))
-
             @h2(messages("payments.outstanding.otherWaysToPay.heading"), size = "m")
             @paragraphBody(
                 userTypeDependentText(
@@ -114,6 +109,12 @@
                 linkUrl = appConfig.howToPayPillar2TaxesUrl,
                 target = "_blank"
             )
+
+            @govukButton(
+                ButtonViewModel(
+                    messages("payments.outstanding.pay.buttonText")
+                ).asLink(controllers.payments.routes.MakeAPaymentDashboardController.onRedirect().url))
+
             @if(useAccountActivity) {
                 @if(hasOverdueReturnPayment) {
                   @govukWarningText(WarningText(content = messages("payments.outstanding.accruedInterest.warningText", formatAmount(accruedInterest))))

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1864,12 +1864,12 @@ payments.outstanding.accruedInterest.description.p1 = Late payment interest incr
 payments.outstanding.accruedInterest.description.p2 = It is shown separately from the amount due as we do not charge the interest due until we receive the associated payment.
 
 payments.outstanding.pay.buttonText = Pay online
-payments.outstanding.otherWaysToPay.heading = Other ways to pay
-payments.outstanding.otherWaysToPay.p1 = Your Pillar 2 reference: {0}
-payments.outstanding.otherWaysToPay.agent.p1 = Pillar 2 reference: {0}
-payments.outstanding.otherWaysToPay.p2 = You’ll need to use this reference if you want to make a manual payment.
-payments.outstanding.otherWaysToPay.agent.p2 = You’ll need to use this reference if you want to make a manual payment for this group.
-payments.outstanding.otherWaysToPay.linkText = Find out more about ways to pay (opens in a new page)
+payments.outstanding.howToPay.heading = How to pay
+payments.outstanding.howToPay.p1 = You can pay online or make a manual payment.
+payments.outstanding.howToPay.p2 = Pillar 2 reference:
+payments.outstanding.howToPay.p3 = You’ll need to use this reference if you want to make a manual payment.
+payments.outstanding.howToPay.agent.p3 = You’ll need to use this reference if you want to make a manual payment for this group.
+payments.outstanding.howToPay.linkText = Find out more about ways to pay (opens in a new tab)
 
 payments.outstanding.details.heading = Details of outstanding payments
 payments.outstanding.details.p1 = We have separated any payments due by the associated accounting period where there is one.

--- a/test/views/outstandingpayments/OutstandingPaymentsViewSpec.scala
+++ b/test/views/outstandingpayments/OutstandingPaymentsViewSpec.scala
@@ -140,11 +140,11 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
           .text() must include("Late payment interest accrued: £")
         accountActivityOrganisationView
           .getElementsByClass("govuk-body")
-          .get(5)
+          .get(6)
           .text() mustBe "Late payment interest increases daily. The amount shows the interest accrued up until today."
         accountActivityOrganisationView
           .getElementsByClass("govuk-body")
-          .get(6)
+          .get(7)
           .text mustBe "It is shown separately from the amount due as we do not charge the interest due until we receive the associated payment."
       }
 
@@ -173,14 +173,16 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
       }
     }
 
-    "display other ways to pay section" in {
-      h2Elements.get(1).text() mustBe "Other ways to pay"
-      paragraphs.get(2).text() mustBe "Your Pillar 2 reference: XMPLR0012345678"
-      paragraphs.get(3).text() mustBe "You’ll need to use this reference if you want to make a manual payment."
+    "display how to pay section" in {
+      h2Elements.get(1).text() mustBe "How to pay"
+      paragraphs.get(2).text() mustBe "You can pay online or make a manual payment."
+      paragraphs.get(3).text() mustBe "Pillar 2 reference: XMPLR0012345678"
+      paragraphs.get(3).select("strong").text() mustBe "XMPLR0012345678"
+      paragraphs.get(4).text() mustBe "You’ll need to use this reference if you want to make a manual payment."
 
       val howToPayLink = links.get(2)
 
-      howToPayLink.text() mustBe "Find out more about ways to pay (opens in a new page)"
+      howToPayLink.text() mustBe "Find out more about ways to pay (opens in a new tab)"
       howToPayLink.attr("href") mustBe "https://www.gov.uk/guidance/pay-pillar-2-top-up-taxes-domestic-top-up-tax-and-multinational-top-up-tax"
       howToPayLink.attr("target") mustBe "_blank"
     }
@@ -201,8 +203,8 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
         "account activity toggle is true, include stoodover charge content" in {
           val paragraphs = accountActivityOrganisationView.getElementsByClass("govuk-body")
 
-          paragraphs.get(7).text() mustBe "We have separated any payments due by the associated accounting period where there is one."
-          paragraphs.get(8).text() mustBe "An appealed charge is still part of the amount due until it is partly or completely stoodover."
+          paragraphs.get(8).text() mustBe "We have separated any payments due by the associated accounting period where there is one."
+          paragraphs.get(9).text() mustBe "An appealed charge is still part of the amount due until it is partly or completely stoodover."
 
           accountActivityOrganisationView.getElementsByClass("govuk-link")
 
@@ -230,7 +232,7 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
         }
 
         "account activity toggle is false, show correct content" in {
-          paragraphs.get(5).text() mustBe "We have separated any payments due by the associated accounting period where there is one."
+          paragraphs.get(6).text() mustBe "We have separated any payments due by the associated accounting period where there is one."
 
           val table = organisationView.getElementsByClass("govuk-table").first()
 
@@ -263,7 +265,7 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
             .toString()
         )
 
-        noPaymentsView.getElementsByClass("govuk-body").get(6).text() mustBe "No payments due."
+        noPaymentsView.getElementsByClass("govuk-body").get(7).text() mustBe "No payments due."
         noPaymentsView.getElementsByClass("govuk-table").size() mustBe 0
       }
     }
@@ -293,7 +295,7 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
         accountActivityOrganisationView.getElementsByTag("h2").get(3).text() mustBe "Stoodover charges"
         accountActivityOrganisationView
           .getElementsByClass("govuk-body")
-          .get(10)
+          .get(11)
           .text() mustBe "Details of appealed charges and other standover payments."
 
         val viewTransactionHistoryLink = accountActivityOrganisationView.getElementsByClass("govuk-link").get(3)
@@ -311,7 +313,7 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
 
     "display transaction history section" in {
       h2Elements.get(3).text() mustBe "Transaction history"
-      paragraphs.get(6).text() mustBe "Find details on payments and refunds. It may take up to 5 working days for transactions to appear."
+      paragraphs.get(7).text() mustBe "Find details on payments and refunds. It may take up to 5 working days for transactions to appear."
 
       val viewTransactionHistoryLink = links.get(3)
 
@@ -321,7 +323,7 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
 
     "display penalties and charges section" in {
       h2Elements.get(4).text() mustBe "Penalties and interest charges"
-      paragraphs.get(9).text() mustBe "Find out how HMRC may charge your group penalties and interest."
+      paragraphs.get(10).text() mustBe "Find out how HMRC may charge your group penalties and interest."
 
       val penaltiesLink: Element = links.get(4)
 
@@ -370,10 +372,12 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
 
         agentViewParagraphs.get(1).text() mustBe "Any payments made before today have reduced the amount due and are not " +
           "included in this total. The group must still pay the amount due."
-        agentViewParagraphs.get(2).text() mustBe "Pillar 2 reference: XMPLR0012345678"
-        agentViewParagraphs.get(3).text() mustBe "You’ll need to use this reference if you want to make a manual " +
+        agentViewParagraphs.get(2).text() mustBe "You can pay online or make a manual payment."
+        agentViewParagraphs.get(3).text() mustBe "Pillar 2 reference: XMPLR0012345678"
+        agentViewParagraphs.get(3).select("strong").text() mustBe "XMPLR0012345678"
+        agentViewParagraphs.get(4).text() mustBe "You’ll need to use this reference if you want to make a manual " +
           "payment for this group."
-        agentViewParagraphs.get(9).text() mustBe "Find out how HMRC may charge the group penalties and interest."
+        agentViewParagraphs.get(10).text() mustBe "Find out how HMRC may charge the group penalties and interest."
       }
 
       "display interest warning text section" should {

--- a/test/views/outstandingpayments/OutstandingPaymentsViewSpec.scala
+++ b/test/views/outstandingpayments/OutstandingPaymentsViewSpec.scala
@@ -173,13 +173,6 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
       }
     }
 
-    "display payment button with correct link" in {
-      val button = organisationView.getElementsByClass("govuk-button").first()
-
-      button.text() mustBe "Pay online"
-      button.attr("href") mustBe controllers.payments.routes.MakeAPaymentDashboardController.onRedirect().url
-    }
-
     "display other ways to pay section" in {
       h2Elements.get(1).text() mustBe "Other ways to pay"
       paragraphs.get(2).text() mustBe "Your Pillar 2 reference: XMPLR0012345678"
@@ -190,6 +183,13 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
       howToPayLink.text() mustBe "Find out more about ways to pay (opens in a new page)"
       howToPayLink.attr("href") mustBe "https://www.gov.uk/guidance/pay-pillar-2-top-up-taxes-domestic-top-up-tax-and-multinational-top-up-tax"
       howToPayLink.attr("target") mustBe "_blank"
+    }
+
+    "display payment button with correct link" in {
+      val button = organisationView.getElementsByClass("govuk-button").first()
+
+      button.text() mustBe "Pay online"
+      button.attr("href") mustBe controllers.payments.routes.MakeAPaymentDashboardController.onRedirect().url
     }
 
     "display a payment section that contains" should {


### PR DESCRIPTION
Details of payments and other payment methods are after the ‘Pay now’ button.This information could be useful for users to make a decision on payment and should be visible before they make a decision. Also screenreader and screen mganification users may miss this information as they navigate down the page. See attachment.
Resolution: Content Design have reviewed the issue and have moved the content before the 'pay now' button. This ticket is to change this for all versions of the Outstanding payment page that display the 'Pay Now' button:
The following moves above the 'Pay Now' button for the Group and Agent versions
Other ways to pay
Your Pillar 2 reference: WSQBA0123456789
You’ll need to use this reference if you want to make a manual payment.
Find out more about ways to pay (opens in new tab)