### PR TITLE
PIL-3013: Removed transactions H2 and added it to table as a caption param

### DIFF
--- a/app/controllers/TransactionHistoryController.scala
+++ b/app/controllers/TransactionHistoryController.scala
@@ -232,7 +232,9 @@ object TransactionHistoryController {
           HeadCell(Text(messages("transactionHistory.amountRepaid")), classes = "govuk-table__header--numeric", attributes = Map("scope" -> "col"))
         )
       ),
-      firstCellIsHeader = true
+      firstCellIsHeader = true,
+      caption = Some(messages("transactionHistory.transactions")),
+      captionClasses = "govuk-table__caption--m"
     )
 
   private def createTableRows(history: Transaction, useNewApi: Boolean)(using messages: Messages): Seq[TableRow] = {

--- a/app/views/paymenthistory/TransactionHistoryView.scala.html
+++ b/app/views/paymenthistory/TransactionHistoryView.scala.html
@@ -79,8 +79,6 @@
       ))
   ))
 
-  @h2(messages("transactionHistory.transactions"), size = "m")
-
   @ScrollWrapper {
     @govukTable(transactionHistoryTable)
   }

--- a/test/views/paymenthistory/TransactionHistoryViewSpec.scala
+++ b/test/views/paymenthistory/TransactionHistoryViewSpec.scala
@@ -19,7 +19,7 @@ package views.paymenthistory
 import base.ViewSpecBase
 import controllers.routes
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
+import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
 import uk.gov.hmrc.govukfrontend.views.Aliases.*
 import uk.gov.hmrc.govukfrontend.views.viewmodels.table.Table
@@ -44,7 +44,9 @@ class TransactionHistoryViewSpec extends ViewSpecBase {
         HeadCell(Text("You paid HMRC")),
         HeadCell(Text("HMRC paid you"))
       )
-    )
+    ),
+    caption = Some("Transactions"),
+    captionClasses = "govuk-table__caption--m"
   )
 
   lazy val pagination: Some[Pagination] = Some(
@@ -165,13 +167,12 @@ class TransactionHistoryViewSpec extends ViewSpecBase {
       )
     }
 
-    "display transactions heading" in {
-      groupView.getElementsByClass("govuk-heading-m").get(1).text() mustBe "Transactions"
-    }
-
     "have a table" in {
       val tableElements: Elements = groupView.select("table.govuk-table")
       tableElements.size() mustBe 1
+
+      val caption: Element = tableElements.first().getElementsByClass("govuk-table__caption--m").first()
+      caption.text() mustBe "Transactions"
 
       val tableHead: Elements = tableElements.first().getElementsByClass("govuk-table__head")
       val tableHeadColumns = tableHead.first().getElementsByClass("govuk-table__header")
@@ -224,7 +225,7 @@ class TransactionHistoryViewSpec extends ViewSpecBase {
 
     "have an 'Outstanding payments' heading" in {
       val h2Elements: Elements = groupView.getElementsByTag("h2")
-      h2Elements.get(2).text() mustBe "Outstanding payments"
+      h2Elements.get(1).text() mustBe "Outstanding payments"
     }
 
     "show the correct transaction history description" in {


### PR DESCRIPTION
Requirements Summary	Issue description: Table caption missing (P1) from Transaction history
Problem: ‘Transactions’ copy is marked up as h2, instead of table caption.
The table <caption> element describes a table in the same way you would use a heading, helping users find, navigate and understand tables. Whilst other semantic information, i.e. the heading preceding it is sufficient for in-page context it would be preferable to have the table appropriately captioned (avoid repeating page heading) so it is correctly announced if a screen reader user moves to it directly.
Resolution: Follow the table captions guidance:https://design-system.service.gov.uk/components/table/#table-captions Auditor Note, the <caption> to the table could also be govuk-visually-hidden using the captionClasses, but visible caption used on other pages do display it for consistency. 