### PR TITLE
PIL-2971: Implemented use of paragraph statements as opposed to H2's for totals across stoodover charges, outstanding payments and transaction history pages

### DIFF
--- a/app/views/outstandingpayments/OutstandingPaymentsView.scala.html
+++ b/app/views/outstandingpayments/OutstandingPaymentsView.scala.html
@@ -69,7 +69,9 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             @h1(messages("payments.outstanding.title"))
-            @h2(messages("payments.outstanding.amountDue", formatAmount(amountDue)), size = "m")
+            <p class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-24">
+              @messages("payments.outstanding.amountDue", formatAmount(amountDue))
+            </p>
             @if(useAccountActivity) {
               @paragraphBody(messages("payments.outstanding.activity.p1"))
                 @paragraphBody(userTypeDependentText(

--- a/app/views/paymenthistory/TransactionHistoryView.scala.html
+++ b/app/views/paymenthistory/TransactionHistoryView.scala.html
@@ -58,7 +58,9 @@
   @p(messages("transactionHistory.p2"), classes = "govuk-body govuk-!-width-two-thirds")
 
   @if(showUnallocatedPaymentAmount) {
-    @h2(messages("transactionHistory.unallocatedPaymentAmount", formatAmount(unallocatedPaymentAmount)), size = "m")
+    <p class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-24">
+      @messages("transactionHistory.unallocatedPaymentAmount", formatAmount(unallocatedPaymentAmount))
+    </p>
     @p(messages("transactionHistory.unallocatedPaymentAmount.description"))
   }
 

--- a/app/views/stoodoverCharges/StoodoverChargesView.scala.html
+++ b/app/views/stoodoverCharges/StoodoverChargesView.scala.html
@@ -45,7 +45,9 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             @h1(messages("payments.stoodoverCharges.title"), classes = "govuk-heading-l")
-            @h2(messages("payments.stoodoverCharges.stoodoverTotal", formatAmount(stoodoverTotal)), size = "m")
+            <p class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-24">
+              @messages("payments.stoodoverCharges.stoodoverTotal", formatAmount(stoodoverTotal))
+            </p>
             @h2(messages("payments.stoodoverCharges.details.heading"), size = "m")
             @paragraphBody(messages("payments.stoodoverCharges.p1"))
         </div>

--- a/test/views/outstandingpayments/OutstandingPaymentsViewSpec.scala
+++ b/test/views/outstandingpayments/OutstandingPaymentsViewSpec.scala
@@ -112,13 +112,13 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
     }
 
     "display total amount due correctly" in {
-      organisationView.getElementsByClass("govuk-heading-m").first().text() mustBe "Amount due: £1,000.00"
+      paragraphs.get(0).text() mustBe "Amount due: £1,000.00"
     }
 
-    "display the leading paragraphs correctly" in {
-      paragraphs.get(0).text() mustBe "The amount includes all tax liabilities and penalty charges currently due. " +
+    "display outstanding payment breakdown paragraphs" in {
+      paragraphs.get(1).text() mustBe "The amount includes all tax liabilities and penalty charges currently due. " +
         "This may include more than one accounting period."
-      paragraphs.get(1).text() mustBe "Any payments made before today have reduced the amount due and are not " +
+      paragraphs.get(2).text() mustBe "Any payments made before today have reduced the amount due and are not " +
         "included in this total. You must still pay the amount due."
     }
 
@@ -140,11 +140,11 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
           .text() must include("Late payment interest accrued: £")
         accountActivityOrganisationView
           .getElementsByClass("govuk-body")
-          .get(6)
+          .get(7)
           .text() mustBe "Late payment interest increases daily. The amount shows the interest accrued up until today."
         accountActivityOrganisationView
           .getElementsByClass("govuk-body")
-          .get(7)
+          .get(8)
           .text mustBe "It is shown separately from the amount due as we do not charge the interest due until we receive the associated payment."
       }
 
@@ -174,11 +174,11 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
     }
 
     "display how to pay section" in {
-      h2Elements.get(1).text() mustBe "How to pay"
-      paragraphs.get(2).text() mustBe "You can pay online or make a manual payment."
-      paragraphs.get(3).text() mustBe "Pillar 2 reference: XMPLR0012345678"
-      paragraphs.get(3).select("strong").text() mustBe "XMPLR0012345678"
-      paragraphs.get(4).text() mustBe "You’ll need to use this reference if you want to make a manual payment."
+      h2Elements.get(0).text() mustBe "How to pay"
+      paragraphs.get(3).text() mustBe "You can pay online or make a manual payment."
+      paragraphs.get(4).text() mustBe "Pillar 2 reference: XMPLR0012345678"
+      paragraphs.get(4).select("strong").text() mustBe "XMPLR0012345678"
+      paragraphs.get(5).text() mustBe "You’ll need to use this reference if you want to make a manual payment."
 
       val howToPayLink = links.get(2)
 
@@ -196,15 +196,15 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
 
     "display a payment section that contains" should {
       "a heading" in {
-        h2Elements.get(2).text() mustBe "Details of outstanding payments"
+        h2Elements.get(1).text() mustBe "Details of outstanding payments"
       }
 
       "table if there are outstanding payments" when {
         "account activity toggle is true, include stoodover charge content" in {
           val paragraphs = accountActivityOrganisationView.getElementsByClass("govuk-body")
 
-          paragraphs.get(8).text() mustBe "We have separated any payments due by the associated accounting period where there is one."
-          paragraphs.get(9).text() mustBe "An appealed charge is still part of the amount due until it is partly or completely stoodover."
+          paragraphs.get(9).text() mustBe "We have separated any payments due by the associated accounting period where there is one."
+          paragraphs.get(10).text() mustBe "An appealed charge is still part of the amount due until it is partly or completely stoodover."
 
           accountActivityOrganisationView.getElementsByClass("govuk-link")
 
@@ -232,7 +232,7 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
         }
 
         "account activity toggle is false, show correct content" in {
-          paragraphs.get(6).text() mustBe "We have separated any payments due by the associated accounting period where there is one."
+          paragraphs.get(7).text() mustBe "We have separated any payments due by the associated accounting period where there is one."
 
           val table = organisationView.getElementsByClass("govuk-table").first()
 
@@ -265,7 +265,7 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
             .toString()
         )
 
-        noPaymentsView.getElementsByClass("govuk-body").get(7).text() mustBe "No payments due."
+        noPaymentsView.getElementsByClass("govuk-body").get(8).text() mustBe "No payments due."
         noPaymentsView.getElementsByClass("govuk-table").size() mustBe 0
       }
     }
@@ -292,10 +292,10 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
 
     "The stoodover charges section" must {
       "be displayed when account activity toggle is true" in {
-        accountActivityOrganisationView.getElementsByTag("h2").get(3).text() mustBe "Stoodover charges"
+        accountActivityOrganisationView.getElementsByTag("h2").get(2).text() mustBe "Stoodover charges"
         accountActivityOrganisationView
           .getElementsByClass("govuk-body")
-          .get(11)
+          .get(12)
           .text() mustBe "Details of appealed charges and other standover payments."
 
         val viewTransactionHistoryLink = accountActivityOrganisationView.getElementsByClass("govuk-link").get(3)
@@ -312,8 +312,8 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
     }
 
     "display transaction history section" in {
-      h2Elements.get(3).text() mustBe "Transaction history"
-      paragraphs.get(7).text() mustBe "Find details on payments and refunds. It may take up to 5 working days for transactions to appear."
+      h2Elements.get(2).text() mustBe "Transaction history"
+      paragraphs.get(8).text() mustBe "Find details on payments and refunds. It may take up to 5 working days for transactions to appear."
 
       val viewTransactionHistoryLink = links.get(3)
 
@@ -322,8 +322,8 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
     }
 
     "display penalties and charges section" in {
-      h2Elements.get(4).text() mustBe "Penalties and interest charges"
-      paragraphs.get(10).text() mustBe "Find out how HMRC may charge your group penalties and interest."
+      h2Elements.get(3).text() mustBe "Penalties and interest charges"
+      paragraphs.get(11).text() mustBe "Find out how HMRC may charge your group penalties and interest."
 
       val penaltiesLink: Element = links.get(4)
 
@@ -370,14 +370,14 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
       "should display agent-specific paragraphs" in {
         val agentViewParagraphs: Elements = agentView.getElementsByClass("govuk-body")
 
-        agentViewParagraphs.get(1).text() mustBe "Any payments made before today have reduced the amount due and are not " +
+        agentViewParagraphs.get(2).text() mustBe "Any payments made before today have reduced the amount due and are not " +
           "included in this total. The group must still pay the amount due."
-        agentViewParagraphs.get(2).text() mustBe "You can pay online or make a manual payment."
-        agentViewParagraphs.get(3).text() mustBe "Pillar 2 reference: XMPLR0012345678"
-        agentViewParagraphs.get(3).select("strong").text() mustBe "XMPLR0012345678"
-        agentViewParagraphs.get(4).text() mustBe "You’ll need to use this reference if you want to make a manual " +
+        agentViewParagraphs.get(3).text() mustBe "You can pay online or make a manual payment."
+        agentViewParagraphs.get(4).text() mustBe "Pillar 2 reference: XMPLR0012345678"
+        agentViewParagraphs.get(4).select("strong").text() mustBe "XMPLR0012345678"
+        agentViewParagraphs.get(5).text() mustBe "You’ll need to use this reference if you want to make a manual " +
           "payment for this group."
-        agentViewParagraphs.get(10).text() mustBe "Find out how HMRC may charge the group penalties and interest."
+        agentViewParagraphs.get(11).text() mustBe "Find out how HMRC may charge the group penalties and interest."
       }
 
       "display interest warning text section" should {

--- a/test/views/paymenthistory/TransactionHistoryViewSpec.scala
+++ b/test/views/paymenthistory/TransactionHistoryViewSpec.scala
@@ -128,10 +128,9 @@ class TransactionHistoryViewSpec extends ViewSpecBase {
     }
 
     "have the correct unallocated payment amount shown" in {
-      groupView.getElementsByClass("govuk-heading-m").get(0).text() mustBe "Unallocated amount: £500"
-      groupView
-        .getElementsByClass("govuk-body")
-        .get(2)
+      groupViewParagraphs.get(2).text() mustBe "Unallocated amount: £500"
+      groupViewParagraphs
+        .get(3)
         .text() mustBe "Unallocated amounts are payments received that have not been allocated to a charge yet." +
         " If you have made a payment for an existing charge this will usually update over night and you will see it appear in the transaction details."
     }
@@ -166,7 +165,7 @@ class TransactionHistoryViewSpec extends ViewSpecBase {
     }
 
     "display transactions heading" in {
-      groupView.getElementsByClass("govuk-heading-m").get(1).text() mustBe "Transactions"
+      groupView.getElementsByClass("govuk-heading-m").get(0).text() mustBe "Transactions"
     }
 
     "have a table" in {
@@ -224,11 +223,11 @@ class TransactionHistoryViewSpec extends ViewSpecBase {
 
     "have an 'Outstanding payments' heading" in {
       val h2Elements: Elements = groupView.getElementsByTag("h2")
-      h2Elements.get(2).text() mustBe "Outstanding payments"
+      h2Elements.get(1).text() mustBe "Outstanding payments"
     }
 
     "show the correct transaction history description" in {
-      groupViewParagraphs.get(3).text mustBe "Find full details of any payments due, including penalties and interest."
+      groupViewParagraphs.get(4).text mustBe "Find full details of any payments due, including penalties and interest."
     }
 
     "show the correct outstanding payments link" in {

--- a/test/views/stoodovercharges/StoodoverChargesViewSpec.scala
+++ b/test/views/stoodovercharges/StoodoverChargesViewSpec.scala
@@ -86,16 +86,16 @@ class StoodoverChargesViewSpec extends ViewSpecBase {
       agentView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
-    "display stoodover total subheading" in {
-      h2Elements.first().text() mustBe "Stoodover total: £1,000"
+    "display stoodover total content" in {
+      paragraphs.get(0).text() mustBe "Stoodover total: £1,000"
     }
 
     "display details of stoodover charges subheading" in {
-      h2Elements.get(1).text() mustBe "Details of stoodover charges"
+      h2Elements.get(0).text() mustBe "Details of stoodover charges"
     }
 
-    "display the leading paragraph" in {
-      paragraphs.get(0).text() mustBe "We have separated the charges by accounting period."
+    "display separated charges by accounting period paragraph" in {
+      paragraphs.get(1).text() mustBe "We have separated the charges by accounting period."
     }
 
     "display a correct html details section" in {
@@ -143,14 +143,14 @@ class StoodoverChargesViewSpec extends ViewSpecBase {
     }
 
     "display 'No stoodover charges' message if no stood overcharges are present" in {
-      noStoodoverChargesView.getElementsByClass("govuk-body").get(1).text() mustBe "No stoodover charges."
+      noStoodoverChargesView.getElementsByClass("govuk-body").get(2).text() mustBe "No stoodover charges."
       noStoodoverChargesView.getElementsByClass("govuk-table").size() mustBe 0
     }
   }
 
   "display outstanding payments section" in {
-    h2Elements.get(2).text() mustBe "Outstanding payments"
-    paragraphs.get(1).text() mustBe "Find full details of any payments due, including penalties and interest."
+    h2Elements.get(1).text() mustBe "Outstanding payments"
+    paragraphs.get(2).text() mustBe "Find full details of any payments due, including penalties and interest."
 
     val viewOutstandingPaymentsLink = links.get(2)
 
@@ -159,8 +159,8 @@ class StoodoverChargesViewSpec extends ViewSpecBase {
   }
 
   "display transaction history section" in {
-    h2Elements.get(3).text() mustBe "Transaction history"
-    paragraphs.get(3).text() mustBe "Find details on payments and refunds. It may take up to 5 working days for transactions to appear."
+    h2Elements.get(2).text() mustBe "Transaction history"
+    paragraphs.get(4).text() mustBe "Find details on payments and refunds. It may take up to 5 working days for transactions to appear."
 
     val viewTransactionHistoryLink = links.get(3)
 


### PR DESCRIPTION
Solution
For example, in the stoodover page:change from H2 to paragraph text.
Existing view
`<h2 class="govuk-heading-m">Stoodover total: 1000</h2>`
Solution view
`<p class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-24">Stoodover total 1000</p>`
The solution needs to apply to stoodover pages, transaction history and outstanding payments.