### PR TITLE
PIL-3093: Removed duplicated scope attribute from tables

### DIFF
--- a/app/controllers/TransactionHistoryController.scala
+++ b/app/controllers/TransactionHistoryController.scala
@@ -226,10 +226,10 @@ object TransactionHistoryController {
       rows = rows,
       head = Some(
         Seq(
-          HeadCell(Text(messages("transactionHistory.date")), attributes = Map("scope" -> "col")),
-          HeadCell(Text(messages("transactionHistory.description")), attributes = Map("scope" -> "col")),
-          HeadCell(Text(messages("transactionHistory.amountPaid")), classes = "govuk-table__header--numeric", attributes = Map("scope" -> "col")),
-          HeadCell(Text(messages("transactionHistory.amountRepaid")), classes = "govuk-table__header--numeric", attributes = Map("scope" -> "col"))
+          HeadCell(Text(messages("transactionHistory.date"))),
+          HeadCell(Text(messages("transactionHistory.description"))),
+          HeadCell(Text(messages("transactionHistory.amountPaid")), classes = "govuk-table__header--numeric"),
+          HeadCell(Text(messages("transactionHistory.amountRepaid")), classes = "govuk-table__header--numeric")
         )
       ),
       firstCellIsHeader = true,

--- a/app/views/helpers/SubmissionHistoryHelper.scala
+++ b/app/views/helpers/SubmissionHistoryHelper.scala
@@ -47,13 +47,11 @@ object SubmissionHistoryHelper {
         Seq(
           HeadCell(
             Text(messages("submissionHistory.typeOfReturn")),
-            classes = "govuk-table__header govuk-!-width-two-thirds",
-            attributes = Map("scope" -> "col")
+            classes = "govuk-table__header govuk-!-width-two-thirds"
           ),
           HeadCell(
             Text(messages("submissionHistory.submissionDate")),
-            classes = "govuk-table__header govuk-!-width-two-thirds",
-            attributes = Map("scope" -> "col")
+            classes = "govuk-table__header govuk-!-width-two-thirds"
           )
         )
       ),

--- a/app/views/outstandingpayments/_OutstandingPaymentsActivityTable.scala.html
+++ b/app/views/outstandingpayments/_OutstandingPaymentsActivityTable.scala.html
@@ -27,10 +27,10 @@
     @LabelledScrollWrapper(messages("payments.outstanding.table.caption"))(
         govukTable(Table(
             head = Some(Seq(
-                HeadCell(Text(messages("payments.outstanding.table.heading.description")), classes = "govuk-table__header govuk-!-width-one-third", attributes = Map("scope" -> "col")),
-                HeadCell(Text(messages("payments.outstanding.table.heading.chargeAmount")), format = Some("numeric"), classes = "govuk-table__header govuk-!-width-one-quarter", attributes = Map("scope" -> "col")),
-                HeadCell(Text(messages("payments.outstanding.table.heading.amountDue")), format = Some("numeric"), classes = "govuk-table__header govuk-!-width-one-quarter", attributes = Map("scope" -> "col")),
-                HeadCell(Text(messages("payments.outstanding.table.heading.dueDate")), classes = "govuk-table__header govuk-!-width-one-sixth", attributes = Map("scope" -> "col"))
+                HeadCell(Text(messages("payments.outstanding.table.heading.description")), classes = "govuk-table__header govuk-!-width-one-third"),
+                HeadCell(Text(messages("payments.outstanding.table.heading.chargeAmount")), format = Some("numeric"), classes = "govuk-table__header govuk-!-width-one-quarter"),
+                HeadCell(Text(messages("payments.outstanding.table.heading.amountDue")), format = Some("numeric"), classes = "govuk-table__header govuk-!-width-one-quarter"),
+                HeadCell(Text(messages("payments.outstanding.table.heading.dueDate")), classes = "govuk-table__header govuk-!-width-one-sixth")
             )),
             rows = penalties.map { row =>
                 Seq(
@@ -52,10 +52,10 @@
   @LabelledScrollWrapper(s"Accounting period: ${messages(summary.accountingPeriod.startDate.toDateFormat)} to ${summary.accountingPeriod.endDate.toDateFormat}")(
     govukTable(Table(
       head = Some(Seq(
-        HeadCell(messages("payments.outstanding.table.heading.description"), classes = "govuk-table__header govuk-!-width-one-third", attributes = Map("scope" -> "col")),
-        HeadCell(messages("payments.outstanding.table.heading.chargeAmount"), format = Some("numeric"), classes = "govuk-table__header govuk-!-width-one-quarter", attributes = Map("scope" -> "col")),
-        HeadCell(messages("payments.outstanding.table.heading.amountDue"), format = Some("numeric"), classes = "govuk-table__header govuk-!-width-one-quarter", attributes = Map("scope" -> "col")),
-        HeadCell(messages("payments.outstanding.table.heading.dueDate"), classes = "govuk-table__header govuk-!-width-one-sixth", attributes = Map("scope" -> "col")),
+        HeadCell(messages("payments.outstanding.table.heading.description"), classes = "govuk-table__header govuk-!-width-one-third"),
+        HeadCell(messages("payments.outstanding.table.heading.chargeAmount"), format = Some("numeric"), classes = "govuk-table__header govuk-!-width-one-quarter"),
+        HeadCell(messages("payments.outstanding.table.heading.amountDue"), format = Some("numeric"), classes = "govuk-table__header govuk-!-width-one-quarter"),
+        HeadCell(messages("payments.outstanding.table.heading.dueDate"), classes = "govuk-table__header govuk-!-width-one-sixth"),
       )),
       rows = summary.rows.map { row =>
         Seq(

--- a/app/views/outstandingpayments/_OutstandingPaymentsTable.scala.html
+++ b/app/views/outstandingpayments/_OutstandingPaymentsTable.scala.html
@@ -28,9 +28,9 @@
   @LabelledScrollWrapper(messages("payments.outstanding.accountingPeriod", summary.accountingPeriod.startDate.toDateFormat, summary.accountingPeriod.endDate.toDateFormat))(
     govukTable(Table(
       head = Some(Seq(
-        HeadCell(Text(messages("payments.outstanding.table.heading.description")), classes = "govuk-table__header govuk-!-width-one-half", attributes = Map("scope" -> "col")),
-        HeadCell(Text(messages("payments.outstanding.table.heading.amount")), format = Some("numeric"), classes = "govuk-table__header govuk-!-width-one-quarter", attributes = Map("scope" -> "col")),
-        HeadCell(Text(messages("payments.outstanding.table.heading.dueDate")), classes = "govuk-table__header govuk-!-width-one-quarter", attributes = Map("scope" -> "col"))
+        HeadCell(Text(messages("payments.outstanding.table.heading.description")), classes = "govuk-table__header govuk-!-width-one-half"),
+        HeadCell(Text(messages("payments.outstanding.table.heading.amount")), format = Some("numeric"), classes = "govuk-table__header govuk-!-width-one-quarter"),
+        HeadCell(Text(messages("payments.outstanding.table.heading.dueDate")), classes = "govuk-table__header govuk-!-width-one-quarter")
       )),
       rows = summary.rows.map { row =>
         Seq(

--- a/app/views/stoodoverCharges/StoodoverChargesView.scala.html
+++ b/app/views/stoodoverCharges/StoodoverChargesView.scala.html
@@ -78,8 +78,8 @@
                     govukTable(Table(
                         head = Some(
                             Seq(
-                                HeadCell(Text("Description"), classes = "govuk-table__header govuk-!-width-one-half", attributes = Map("scope" -> "col")),
-                                HeadCell(Text("Stoodover amount"), format = Some("numeric"), classes = "govuk-table__header govuk-table__header--numeric", attributes = Map("scope" -> "col")),
+                                HeadCell(Text("Description"), classes = "govuk-table__header govuk-!-width-one-half"),
+                                HeadCell(Text("Stoodover amount"), format = Some("numeric"), classes = "govuk-table__header govuk-table__header--numeric"),
                             )
                         ),
                         rows =  summary.rows.map { row =>


### PR DESCRIPTION
The scope="col" attribute has been duplicated in all the <th> elements (you can see this via the page source rather than inspecting dev tools). This is not valid HTML. Different user agents may implement different heuristics to recover from errors, resulting in inconsistent functionality or presentation of the content.

Remove the duplicate attribute. Check all tables for the same error.