### PR TITLE
PIL-3087: Removed focus styling from tables so that we don't fail the contrast testing

### DIFF
--- a/app/assets/stylesheets/table-scroll-styles.scss
+++ b/app/assets/stylesheets/table-scroll-styles.scss
@@ -4,13 +4,6 @@
     width: 100%;
 }
 
-.table-scroll-wrapper:focus,
-.table-scroll-wrapper:focus-visible {
-    outline: 3px solid #ffdd00;
-    outline-offset: 0;
-    padding: 5px;
-}
-
 .govuk-table thead th {
     position: sticky;
     top: 0;


### PR DESCRIPTION
Issue: Contrast is not sufficient for the table focus (AA)
WCAG violation: 1.4.11 Non-text Contrast
Page: Outstanding payments
URL: https://www.staging.tax.service.gov.uk/report-pillar2-top-up-taxes/payment/outstanding
Journey/Step: J1 S2, All pages with tables
Description: When the tables are navigated to using a keyboard (using the tab key), the yellow visible focus does not sufficiently provide contrast against the white background. Some users with visual impairments may not see this focus indicator.
Note, on the transaction history page (J1 S6, J2 S8), the table focus colour has not been set so is the default browser blue which does not fail contrast.
Also, the current implementation for providing padding makes the table content "jump" when it receives focus which can be distracting for some users.
Resolve: Remove these lines of code and check that the focus provides a single blue line.

.table-scroll-wrapper:focus,
.table-scroll-wrapper:focus-visible {
    outline: 3px solid #ffdd00;
    outline-offset: 0;
    padding: 5px;
}