### PR TITLE
PIL-3027: Corrected link text on outstanding payments page

### DIFF
--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1909,7 +1909,7 @@ payments.outstanding.penaltiesAndCharges.p1 = Find out how HMRC may charge your 
 payments.outstanding.activity.penaltiesAndCharges.p1 = Find out when HMRC may charge your group penalties and interest.
 payments.outstanding.penaltiesAndCharges.agent.p1 = Find out how HMRC may charge the group penalties and interest.
 payments.outstanding.activity.penaltiesAndCharges.agent.p1 = Find out when HMRC may charge the group penalties and interest.
-payments.outstanding.penaltiesAndCharges.linkText = Pillar 2 Top-up Taxes penalties information (opens in a new page)
+payments.outstanding.penaltiesAndCharges.linkText = Pillar 2 Top-up Taxes penalties information (opens in a new tab)
 
 payments.noOutstanding.title = Outstanding payments
 payments.noOutstanding.heading = Outstanding payments

--- a/test/views/outstandingpayments/OutstandingPaymentsViewSpec.scala
+++ b/test/views/outstandingpayments/OutstandingPaymentsViewSpec.scala
@@ -327,7 +327,7 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
 
       val penaltiesLink: Element = links.get(4)
 
-      penaltiesLink.text() mustBe "Pillar 2 Top-up Taxes penalties information (opens in a new page)"
+      penaltiesLink.text() mustBe "Pillar 2 Top-up Taxes penalties information (opens in a new tab)"
       penaltiesLink.attr("href") mustBe appConfig.penaltiesInformationUrl
       penaltiesLink.attr("target") mustBe "_blank"
     }


### PR DESCRIPTION
Issue description: 'opens in new page' copy (P2)
Page: Outstanding payments
URL: https://www.staging.tax.service.gov.uk/report-pillar2-top-up-taxes/payment/outstanding
Journey/Step: J2 S4
Description: The link text for 'Find out more about ways to pay' ends with 'opens in new page', rather than 'opens in new tab'.
Resolution: Follow the design system link opens in the new tab style guide.