### PR TITLE
PIL-3017: Implemented preferred caption approach of using an h2 for accessibility

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,10 +28,6 @@ legend {
   border-bottom:none;
 }
 
-.no-margin-bottom {
-  margin-bottom: 0;
-}
-
 label[for="confirmation_0"] {
     padding-top: 0;
     font-weight: 600;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,6 +28,10 @@ legend {
   border-bottom:none;
 }
 
+.no-margin-bottom {
+  margin-bottom: 0;
+}
+
 label[for="confirmation_0"] {
     padding-top: 0;
     font-weight: 600;

--- a/app/views/btn/BTNAccountingPeriodView.scala.html
+++ b/app/views/btn/BTNAccountingPeriodView.scala.html
@@ -37,9 +37,9 @@
     @formHelper(action = controllers.btn.routes.BTNAccountingPeriodController.onSubmit(mode), Symbol("autoComplete") -> "off") {
 
         @if(isAgent && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName <strong>@{messages("homepage.id")}: </strong>@plrReference</span>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         } else if(isAgent) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @heading(messages("btn.accountingPeriod.header"), classes = "govuk-heading-l")

--- a/app/views/btn/BTNAccountingPeriodView.scala.html
+++ b/app/views/btn/BTNAccountingPeriodView.scala.html
@@ -37,9 +37,9 @@
     @formHelper(action = controllers.btn.routes.BTNAccountingPeriodController.onSubmit(mode), Symbol("autoComplete") -> "off") {
 
         @if(isAgent && organisationName.isDefined) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         } else if(isAgent) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @heading(messages("btn.accountingPeriod.header"), classes = "govuk-heading-l")

--- a/app/views/btn/BTNAlreadyInPlaceView.scala.html
+++ b/app/views/btn/BTNAlreadyInPlaceView.scala.html
@@ -29,9 +29,9 @@
     @layout(pageTitle = titleNoForm(messages("btn.alreadyInPlace.title")), bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
         @formHelper(action = controllers.btn.routes.BTNAccountingPeriodController.onSubmit(NormalMode), Symbol("autoComplete") -> "off") {
         @if(isAgent && organisationName.isDefined) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         } else if(isAgent) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
             @heading(messages("btn.alreadyInPlace.heading"), classes = "govuk-heading-l")

--- a/app/views/btn/BTNAlreadyInPlaceView.scala.html
+++ b/app/views/btn/BTNAlreadyInPlaceView.scala.html
@@ -28,11 +28,11 @@
 @(plrReference: String, isAgent: Boolean, organisationName: Option[String])(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
     @layout(pageTitle = titleNoForm(messages("btn.alreadyInPlace.title")), bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
         @formHelper(action = controllers.btn.routes.BTNAccountingPeriodController.onSubmit(NormalMode), Symbol("autoComplete") -> "off") {
-            @if(isAgent && organisationName.isDefined) {
-                <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName <strong>@{messages("homepage.id")}: </strong>@plrReference</span>
-            } else if(isAgent) {
-                <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
-            }
+        @if(isAgent && organisationName.isDefined) {
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+        } else if(isAgent) {
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+        }
 
             @heading(messages("btn.alreadyInPlace.heading"), classes = "govuk-heading-l")
 

--- a/app/views/btn/BTNAmendDetailsView.scala.html
+++ b/app/views/btn/BTNAmendDetailsView.scala.html
@@ -38,9 +38,9 @@
 ) {
 
     @if(isAgent && organisationName.isDefined) {
-        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+        <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
     } else if(isAgent) {
-        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+        <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
     }
 
     @if(isAgent) {

--- a/app/views/btn/BTNAmendDetailsView.scala.html
+++ b/app/views/btn/BTNAmendDetailsView.scala.html
@@ -38,9 +38,9 @@
 ) {
 
     @if(isAgent && organisationName.isDefined) {
-        <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}: </strong>@plrReference</span>
+        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
     } else if(isAgent) {
-        <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
+        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
     }
 
     @if(isAgent) {

--- a/app/views/btn/BTNBeforeStartView.scala.html
+++ b/app/views/btn/BTNBeforeStartView.scala.html
@@ -33,9 +33,9 @@
 @layout(pageTitle = titleNoForm(messages("btn.beforeStart.title")), bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
     @if(isAgent && organisationName.isDefined) {
-        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+        <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
     } else if(isAgent) {
-        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+        <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
     }
 
     @heading(messages("btn.beforeStart.header"), classes = "govuk-heading-l")

--- a/app/views/btn/BTNBeforeStartView.scala.html
+++ b/app/views/btn/BTNBeforeStartView.scala.html
@@ -33,9 +33,9 @@
 @layout(pageTitle = titleNoForm(messages("btn.beforeStart.title")), bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
     @if(isAgent && organisationName.isDefined) {
-        <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}: </strong>@plrReference</span>
+        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
     } else if(isAgent) {
-        <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
+        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
     }
 
     @heading(messages("btn.beforeStart.header"), classes = "govuk-heading-l")

--- a/app/views/btn/BTNChooseAccountingPeriodView.scala.html
+++ b/app/views/btn/BTNChooseAccountingPeriodView.scala.html
@@ -41,9 +41,9 @@
         }
 
         @if(isAgent && organisationName.isDefined) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         } else if(isAgent) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @heading(messages("btn.chooseAccountingPeriod.heading"), classes = "govuk-heading-l")

--- a/app/views/btn/BTNChooseAccountingPeriodView.scala.html
+++ b/app/views/btn/BTNChooseAccountingPeriodView.scala.html
@@ -41,9 +41,9 @@
         }
 
         @if(isAgent && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}: </strong>@plrReference</span>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         } else if(isAgent) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @heading(messages("btn.chooseAccountingPeriod.heading"), classes = "govuk-heading-l")

--- a/app/views/btn/BTNConfirmationView.scala.html
+++ b/app/views/btn/BTNConfirmationView.scala.html
@@ -38,9 +38,9 @@
 @layout(pageTitle = titleNoForm(messages("btn.confirmation.title")), showBackLink = false, bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
     @if(isAgent && companyName.isDefined) {
-        <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@companyName<strong> @{messages("homepage.id")}:</strong> @plrRef</span>
+        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @companyName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
     } else if(isAgent) {
-        <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrRef</span>
+        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
     }
 
     @govukPanel(Panel(

--- a/app/views/btn/BTNConfirmationView.scala.html
+++ b/app/views/btn/BTNConfirmationView.scala.html
@@ -38,9 +38,9 @@
 @layout(pageTitle = titleNoForm(messages("btn.confirmation.title")), showBackLink = false, bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
     @if(isAgent && companyName.isDefined) {
-        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @companyName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
+        <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @companyName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
     } else if(isAgent) {
-        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
+        <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
     }
 
     @govukPanel(Panel(

--- a/app/views/btn/BTNEntitiesInUKOnlyView.scala.html
+++ b/app/views/btn/BTNEntitiesInUKOnlyView.scala.html
@@ -35,9 +35,9 @@
         }
 
         @if(isAgent && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         } else if(isAgent) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @govukRadios(

--- a/app/views/btn/BTNEntitiesInUKOnlyView.scala.html
+++ b/app/views/btn/BTNEntitiesInUKOnlyView.scala.html
@@ -35,9 +35,9 @@
         }
 
         @if(isAgent && organisationName.isDefined) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         } else if(isAgent) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @govukRadios(

--- a/app/views/btn/BTNEntitiesInsideOutsideUKView.scala.html
+++ b/app/views/btn/BTNEntitiesInsideOutsideUKView.scala.html
@@ -35,9 +35,9 @@
         }
 
         @if(isAgent && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         } else if(isAgent) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @govukRadios(

--- a/app/views/btn/BTNEntitiesInsideOutsideUKView.scala.html
+++ b/app/views/btn/BTNEntitiesInsideOutsideUKView.scala.html
@@ -35,9 +35,9 @@
         }
 
         @if(isAgent && organisationName.isDefined) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         } else if(isAgent) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @govukRadios(

--- a/app/views/btn/BTNReturnSubmittedView.scala.html
+++ b/app/views/btn/BTNReturnSubmittedView.scala.html
@@ -44,9 +44,9 @@
 ) {
     @formHelper(action = controllers.btn.routes.BTNAccountingPeriodController.onSubmit(NormalMode), Symbol("autoComplete") -> "off") {
         @if(isAgent && organisationName.isDefined) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         } else if(isAgent) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @if(isAgent) {

--- a/app/views/btn/BTNReturnSubmittedView.scala.html
+++ b/app/views/btn/BTNReturnSubmittedView.scala.html
@@ -44,9 +44,9 @@
 ) {
     @formHelper(action = controllers.btn.routes.BTNAccountingPeriodController.onSubmit(NormalMode), Symbol("autoComplete") -> "off") {
         @if(isAgent && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         } else if(isAgent) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @if(isAgent) {

--- a/app/views/btn/BTNUnderEnquiryWarningView.scala.html
+++ b/app/views/btn/BTNUnderEnquiryWarningView.scala.html
@@ -33,9 +33,9 @@
 @layout(pageTitle = titleNoForm(messages("btn.underEnquiryWarning.title")), showBackLink = true) {
 
   @if(isAgent && organisationName.isDefined) {
-    <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+    <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
   } else if(isAgent) {
-    <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+    <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
   }
 
   @heading(messages("btn.underEnquiryWarning.heading"), classes = "govuk-heading-l")

--- a/app/views/btn/BTNUnderEnquiryWarningView.scala.html
+++ b/app/views/btn/BTNUnderEnquiryWarningView.scala.html
@@ -33,9 +33,9 @@
 @layout(pageTitle = titleNoForm(messages("btn.underEnquiryWarning.title")), showBackLink = true) {
 
   @if(isAgent && organisationName.isDefined) {
-    <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
+    <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
   } else if(isAgent) {
-    <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
+    <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
   }
 
   @heading(messages("btn.underEnquiryWarning.heading"), classes = "govuk-heading-l")

--- a/app/views/btn/CheckYourAnswersView.scala.html
+++ b/app/views/btn/CheckYourAnswersView.scala.html
@@ -36,9 +36,9 @@
   @formHelper(action = controllers.btn.routes.CheckYourAnswersController.onSubmit) {
 
     @if(isAgent && organisationName.isDefined) {
-        <span class="govuk-caption-m"><strong>@{messages("homepage.group")}: </strong>@organisationName<strong> @{messages("homepage.id")}: </strong>@plrReference</span>
+        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
     } else if(isAgent) {
-        <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
+        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
     }
 
     @heading(messages("btn.cya.heading"), classes = "govuk-heading-l")

--- a/app/views/btn/CheckYourAnswersView.scala.html
+++ b/app/views/btn/CheckYourAnswersView.scala.html
@@ -36,9 +36,9 @@
   @formHelper(action = controllers.btn.routes.CheckYourAnswersController.onSubmit) {
 
     @if(isAgent && organisationName.isDefined) {
-        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+        <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
     } else if(isAgent) {
-        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+        <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
     }
 
     @heading(messages("btn.cya.heading"), classes = "govuk-heading-l")

--- a/app/views/dueandoverduereturns/DueAndOverdueReturnsView.scala.html
+++ b/app/views/dueandoverduereturns/DueAndOverdueReturnsView.scala.html
@@ -46,7 +46,9 @@
 @layout(pageTitle = titleNoForm(messages("dueAndOverdueReturns.title")), bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
         @if(agentView && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName <strong>@{messages("homepage.id")}:</strong> @plrReference</span>
+          <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+        } else if(agentView) {
+          <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         <h1 class="govuk-heading-l">@messages("dueAndOverdueReturns.heading")</h1>

--- a/app/views/dueandoverduereturns/DueAndOverdueReturnsView.scala.html
+++ b/app/views/dueandoverduereturns/DueAndOverdueReturnsView.scala.html
@@ -46,9 +46,9 @@
 @layout(pageTitle = titleNoForm(messages("dueAndOverdueReturns.title")), bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
         @if(agentView && organisationName.isDefined) {
-          <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+          <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         } else if(agentView) {
-          <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+          <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         <h1 class="govuk-heading-l">@messages("dueAndOverdueReturns.heading")</h1>

--- a/app/views/outstandingpayments/OutstandingPaymentsView.scala.html
+++ b/app/views/outstandingpayments/OutstandingPaymentsView.scala.html
@@ -54,7 +54,7 @@
 @layout(pageTitle = titleNoForm(messages("payments.outstanding.title")), twoThirdsPagelayout = false, bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
     @if(isAgent) {
-        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @orgName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+        <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @orgName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
     }
 
     <div class="govuk-grid-row">

--- a/app/views/outstandingpayments/OutstandingPaymentsView.scala.html
+++ b/app/views/outstandingpayments/OutstandingPaymentsView.scala.html
@@ -54,14 +54,7 @@
 @layout(pageTitle = titleNoForm(messages("payments.outstanding.title")), twoThirdsPagelayout = false, bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
     @if(isAgent) {
-        <div class="govuk-hint govuk-!-margin-top-0">
-            <span><strong>@{
-                messages("homepage.group")
-            }:</strong> @orgName</span>
-            <span><strong>@{
-                messages("homepage.id")
-            }:</strong> @plrReference</span>
-        </div>
+        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @orgName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
     }
 
     <div class="govuk-grid-row">

--- a/app/views/paymenthistory/NoTransactionHistoryView.scala.html
+++ b/app/views/paymenthistory/NoTransactionHistoryView.scala.html
@@ -32,7 +32,7 @@
 
 @layout(pageTitle = titleNoForm(messages("transactionHistory.none.title")), twoThirdsPagelayout = false, bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
     @if(isAgent) {
-        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @orgName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
+        <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @orgName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
     }
 
     @heading(messages("transactionHistory.none.heading"))

--- a/app/views/paymenthistory/NoTransactionHistoryView.scala.html
+++ b/app/views/paymenthistory/NoTransactionHistoryView.scala.html
@@ -32,10 +32,7 @@
 
 @layout(pageTitle = titleNoForm(messages("transactionHistory.none.title")), twoThirdsPagelayout = false, bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
     @if(isAgent) {
-        <div class="govuk-caption-m">
-            <span><strong>@{messages("homepage.group")}:</strong> @orgName</span>
-            <span><strong>@{messages("homepage.id")}:</strong> @plrRef</span>
-        </div>
+        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @orgName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
     }
 
     @heading(messages("transactionHistory.none.heading"))

--- a/app/views/paymenthistory/TransactionHistoryView.scala.html
+++ b/app/views/paymenthistory/TransactionHistoryView.scala.html
@@ -39,11 +39,8 @@
 @layout(pageTitle = titleNoForm(messages("transactionHistory.title")), twoThirdsPagelayout = false, bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
   @if(isAgent) {
-      <div class="govuk-caption-m">
-          <span><strong>@{messages("homepage.group")}:</strong> @orgName</span>
-          <span><strong>@{messages("homepage.id")}:</strong> @plrRef</span>
-      </div>
-    }
+    <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @orgName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
+  }
 
   @h1(messages("transactionHistory.heading"))
 

--- a/app/views/paymenthistory/TransactionHistoryView.scala.html
+++ b/app/views/paymenthistory/TransactionHistoryView.scala.html
@@ -39,7 +39,7 @@
 @layout(pageTitle = titleNoForm(messages("transactionHistory.title")), twoThirdsPagelayout = false, bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
   @if(isAgent) {
-    <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @orgName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
+    <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @orgName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
   }
 
   @h1(messages("transactionHistory.heading"))

--- a/app/views/repayments/BankAccountDetailsView.scala.html
+++ b/app/views/repayments/BankAccountDetailsView.scala.html
@@ -38,7 +38,7 @@
             }
 
             @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
-                <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+                <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
             }
 
             @heading(messages("repayments.bankAccountDetails.heading"), Some(messages("repayments.bankAccountDetails.hint")))

--- a/app/views/repayments/BankAccountDetailsView.scala.html
+++ b/app/views/repayments/BankAccountDetailsView.scala.html
@@ -38,7 +38,7 @@
             }
 
             @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
-                <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
+                <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
             }
 
             @heading(messages("repayments.bankAccountDetails.heading"), Some(messages("repayments.bankAccountDetails.hint")))

--- a/app/views/repayments/NonUKBankView.scala.html
+++ b/app/views/repayments/NonUKBankView.scala.html
@@ -39,7 +39,7 @@
         }
 
         @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @heading(messages("repayments.nonUKBank.heading"), Some(messages("repayments.nonUKBank.hint")))

--- a/app/views/repayments/NonUKBankView.scala.html
+++ b/app/views/repayments/NonUKBankView.scala.html
@@ -39,7 +39,7 @@
         }
 
         @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @heading(messages("repayments.nonUKBank.heading"), Some(messages("repayments.nonUKBank.hint")))

--- a/app/views/repayments/ReasonForRequestingRefundView.scala.html
+++ b/app/views/repayments/ReasonForRequestingRefundView.scala.html
@@ -36,7 +36,7 @@
         }
 
         @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @govukCharacterCount(CharacterCount(

--- a/app/views/repayments/ReasonForRequestingRefundView.scala.html
+++ b/app/views/repayments/ReasonForRequestingRefundView.scala.html
@@ -36,7 +36,7 @@
         }
 
         @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @govukCharacterCount(CharacterCount(

--- a/app/views/repayments/RepaymentsCheckYourAnswersView.scala.html
+++ b/app/views/repayments/RepaymentsCheckYourAnswersView.scala.html
@@ -38,7 +38,7 @@
     @formHelper(action = controllers.repayments.routes.RepaymentsCheckYourAnswersController.onSubmit()) {
 
         @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @heading(messages("repaymentsCheckYourAnswers.heading"), classes = "govuk-heading-l")

--- a/app/views/repayments/RepaymentsCheckYourAnswersView.scala.html
+++ b/app/views/repayments/RepaymentsCheckYourAnswersView.scala.html
@@ -38,7 +38,7 @@
     @formHelper(action = controllers.repayments.routes.RepaymentsCheckYourAnswersController.onSubmit()) {
 
         @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @heading(messages("repaymentsCheckYourAnswers.heading"), classes = "govuk-heading-l")

--- a/app/views/repayments/RepaymentsConfirmationView.scala.html
+++ b/app/views/repayments/RepaymentsConfirmationView.scala.html
@@ -41,7 +41,7 @@
   bannerUrl = Some(routes.HomepageController.onPageLoad().url)
 ) {
   @if(isAgent) {
-    <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @orgName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
+    <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @orgName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
   }
   @govukPanel(Panel(
     title = Text(messages("repayments.confirmation.bannerText"))

--- a/app/views/repayments/RepaymentsConfirmationView.scala.html
+++ b/app/views/repayments/RepaymentsConfirmationView.scala.html
@@ -41,10 +41,7 @@
   bannerUrl = Some(routes.HomepageController.onPageLoad().url)
 ) {
   @if(isAgent) {
-      <div class="govuk-caption-m">
-          <span><strong>@{messages("homepage.group")}:</strong> @orgName</span>
-          <span><strong>@{messages("homepage.id")}:</strong> @plrRef</span>
-      </div>
+    <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @orgName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
   }
   @govukPanel(Panel(
     title = Text(messages("repayments.confirmation.bannerText"))

--- a/app/views/repayments/RepaymentsContactByPhoneView.scala.html
+++ b/app/views/repayments/RepaymentsContactByPhoneView.scala.html
@@ -37,7 +37,7 @@
         }
 
         @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @govukRadios(

--- a/app/views/repayments/RepaymentsContactByPhoneView.scala.html
+++ b/app/views/repayments/RepaymentsContactByPhoneView.scala.html
@@ -37,7 +37,7 @@
         }
 
         @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @govukRadios(

--- a/app/views/repayments/RepaymentsContactEmailView.scala.html
+++ b/app/views/repayments/RepaymentsContactEmailView.scala.html
@@ -37,7 +37,7 @@
         }
 
         @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @govukInput(

--- a/app/views/repayments/RepaymentsContactEmailView.scala.html
+++ b/app/views/repayments/RepaymentsContactEmailView.scala.html
@@ -37,7 +37,7 @@
         }
 
         @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @govukInput(

--- a/app/views/repayments/RepaymentsContactNameView.scala.html
+++ b/app/views/repayments/RepaymentsContactNameView.scala.html
@@ -37,7 +37,7 @@
         }
 
         @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @govukInput(

--- a/app/views/repayments/RepaymentsContactNameView.scala.html
+++ b/app/views/repayments/RepaymentsContactNameView.scala.html
@@ -37,7 +37,7 @@
         }
 
         @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @govukInput(

--- a/app/views/repayments/RepaymentsPhoneDetailsView.scala.html
+++ b/app/views/repayments/RepaymentsPhoneDetailsView.scala.html
@@ -40,7 +40,7 @@
         }
 
         @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @govukInput(

--- a/app/views/repayments/RepaymentsPhoneDetailsView.scala.html
+++ b/app/views/repayments/RepaymentsPhoneDetailsView.scala.html
@@ -40,7 +40,7 @@
         }
 
         @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @govukInput(

--- a/app/views/repayments/RequestRefundAmountView.scala.html
+++ b/app/views/repayments/RequestRefundAmountView.scala.html
@@ -39,7 +39,7 @@
         }
 
         @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @govukInput(

--- a/app/views/repayments/RequestRefundAmountView.scala.html
+++ b/app/views/repayments/RequestRefundAmountView.scala.html
@@ -39,7 +39,7 @@
         }
 
         @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @govukInput(

--- a/app/views/repayments/RequestRefundBeforeStartView.scala.html
+++ b/app/views/repayments/RequestRefundBeforeStartView.scala.html
@@ -37,7 +37,7 @@
     bannerUrl = Some(routes.HomepageController.onPageLoad().url)
 ) {
     @if(agentView && plrReference.isDefined && organisationName.isDefined) {
-        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+        <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
     }
     @heading(messages("repayment.requestRepaymentBeforeStart.header"), classes = "govuk-heading-l")
     @if(agentView) {

--- a/app/views/repayments/RequestRefundBeforeStartView.scala.html
+++ b/app/views/repayments/RequestRefundBeforeStartView.scala.html
@@ -37,7 +37,7 @@
     bannerUrl = Some(routes.HomepageController.onPageLoad().url)
 ) {
     @if(agentView && plrReference.isDefined && organisationName.isDefined) {
-        <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
+        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
     }
     @heading(messages("repayment.requestRepaymentBeforeStart.header"), classes = "govuk-heading-l")
     @if(agentView) {

--- a/app/views/repayments/UkOrAbroadBankAccountView.scala.html
+++ b/app/views/repayments/UkOrAbroadBankAccountView.scala.html
@@ -35,7 +35,7 @@
         }
 
         @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @govukRadios(

--- a/app/views/repayments/UkOrAbroadBankAccountView.scala.html
+++ b/app/views/repayments/UkOrAbroadBankAccountView.scala.html
@@ -35,7 +35,7 @@
         }
 
         @if(isAgent && plrReference.isDefined && organisationName.isDefined) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @govukRadios(

--- a/app/views/stoodoverCharges/StoodoverChargesView.scala.html
+++ b/app/views/stoodoverCharges/StoodoverChargesView.scala.html
@@ -36,7 +36,7 @@
 @layout(pageTitle = titleNoForm(messages("payments.stoodoverCharges.title")), twoThirdsPagelayout = false, bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
     @if(isAgent) {
-        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+        <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
     }
 
     <div class="govuk-grid-row">

--- a/app/views/stoodoverCharges/StoodoverChargesView.scala.html
+++ b/app/views/stoodoverCharges/StoodoverChargesView.scala.html
@@ -36,7 +36,7 @@
 @layout(pageTitle = titleNoForm(messages("payments.stoodoverCharges.title")), twoThirdsPagelayout = false, bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
     @if(isAgent) {
-        <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
+        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
     }
 
     <div class="govuk-grid-row">

--- a/app/views/submissionhistory/SubmissionHistoryNoSubmissionsView.scala.html
+++ b/app/views/submissionhistory/SubmissionHistoryNoSubmissionsView.scala.html
@@ -33,15 +33,10 @@
     bannerUrl = Some(routes.HomepageController.onPageLoad().url)
 ) {
     @if(isAgent && orgName.trim.nonEmpty) {
-        <div class="govuk-caption-m">
-            <span><strong>@{messages("homepage.group")}:</strong> @orgName</span>
-            <span><strong>@{messages("homepage.id")}:</strong> @plrRef</span>
-        </div>
+        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @orgName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
     }
     @if(isAgent && orgName.trim.isEmpty) {
-        <div class="govuk-caption-m">
-            <span><strong>@{messages("homepage.id")}:</strong> @plrRef</span>
-        </div>
+        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
     }
     @heading(messages("submissionHistoryNoSubmissions.heading"), classes = "govuk-heading-l")
     @if(isAgent) {

--- a/app/views/submissionhistory/SubmissionHistoryNoSubmissionsView.scala.html
+++ b/app/views/submissionhistory/SubmissionHistoryNoSubmissionsView.scala.html
@@ -33,10 +33,10 @@
     bannerUrl = Some(routes.HomepageController.onPageLoad().url)
 ) {
     @if(isAgent && orgName.trim.nonEmpty) {
-        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @orgName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
+        <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @orgName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
     }
     @if(isAgent && orgName.trim.isEmpty) {
-        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
+        <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
     }
     @heading(messages("submissionHistoryNoSubmissions.heading"), classes = "govuk-heading-l")
     @if(isAgent) {

--- a/app/views/submissionhistory/SubmissionHistoryView.scala.html
+++ b/app/views/submissionhistory/SubmissionHistoryView.scala.html
@@ -38,10 +38,10 @@
     bannerUrl = Some(routes.HomepageController.onPageLoad().url)
 ) {
     @if(isAgent && orgName.trim.nonEmpty) {
-        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @orgName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
+        <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @orgName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
     }
     @if(isAgent && orgName.trim.isEmpty) {
-        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
+        <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
     }
     @heading(messages("submissionHistory.heading"), classes = "govuk-heading-l")
     @if(isAgent) {

--- a/app/views/submissionhistory/SubmissionHistoryView.scala.html
+++ b/app/views/submissionhistory/SubmissionHistoryView.scala.html
@@ -38,15 +38,10 @@
     bannerUrl = Some(routes.HomepageController.onPageLoad().url)
 ) {
     @if(isAgent && orgName.trim.nonEmpty) {
-        <div class="govuk-caption-m">
-            <span><strong>@{messages("homepage.group")}:</strong> @orgName</span>
-            <span><strong>@{messages("homepage.id")}:</strong> @plrRef</span>
-        </div>
+        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @orgName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
     }
     @if(isAgent && orgName.trim.isEmpty) {
-        <div class="govuk-caption-m">
-            <span><strong>@{messages("homepage.id")}:</strong> @plrRef</span>
-        </div>
+        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
     }
     @heading(messages("submissionHistory.heading"), classes = "govuk-heading-l")
     @if(isAgent) {

--- a/app/views/subscriptionview/manageAccount/AddSecondaryContactView.scala.html
+++ b/app/views/subscriptionview/manageAccount/AddSecondaryContactView.scala.html
@@ -40,7 +40,7 @@
         }
 
         @if(isAgent) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
         } else {
             @sectionHeader(messages("contactEmailAddress.heading.caption"))
         }

--- a/app/views/subscriptionview/manageAccount/AddSecondaryContactView.scala.html
+++ b/app/views/subscriptionview/manageAccount/AddSecondaryContactView.scala.html
@@ -40,14 +40,7 @@
         }
 
         @if(isAgent) {
-            <div class="govuk-caption-m">
-                <span><strong>@{
-                    messages("homepage.group")
-                }:</strong> @organisationName</span>
-                <span><strong>@{
-                    messages("homepage.id")
-                }:</strong> @plrRef</span>
-            </div>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
         } else {
             @sectionHeader(messages("contactEmailAddress.heading.caption"))
         }

--- a/app/views/subscriptionview/manageAccount/AmendAccountingPeriodCYAView.scala.html
+++ b/app/views/subscriptionview/manageAccount/AmendAccountingPeriodCYAView.scala.html
@@ -35,9 +35,9 @@
     @formHelper(action = controllers.subscription.manageAccount.routes.AmendAccountingPeriodCYAController.onSubmit()) {
 
         @if(isAgent && organisationName.isDefined) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         } else if(isAgent) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @heading(messages("amendAccountingPeriodCYA.heading"), "govuk-heading-l")

--- a/app/views/subscriptionview/manageAccount/AmendAccountingPeriodCYAView.scala.html
+++ b/app/views/subscriptionview/manageAccount/AmendAccountingPeriodCYAView.scala.html
@@ -35,9 +35,9 @@
     @formHelper(action = controllers.subscription.manageAccount.routes.AmendAccountingPeriodCYAController.onSubmit()) {
 
         @if(isAgent && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName <strong>@{messages("homepage.id")}:</strong> @plrReference</span>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         } else if(isAgent) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.id")}:</strong> @plrReference</span>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @heading(messages("amendAccountingPeriodCYA.heading"), "govuk-heading-l")

--- a/app/views/subscriptionview/manageAccount/AmendAccountingPeriodConfirmationView.scala.html
+++ b/app/views/subscriptionview/manageAccount/AmendAccountingPeriodConfirmationView.scala.html
@@ -35,10 +35,7 @@
 @layout(pageTitle = titleNoForm(messages("amendAccountingPeriod.confirmation.title")), showBackLink = false, bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
     @if(isAgent) {
-        <div class="govuk-hint govuk-!-margin-top-0">
-            <span><strong>@messages("amendAccountingPeriod.confirmation.group"):</strong> @organisationName</span>
-            <span><strong>@messages("amendAccountingPeriod.confirmation.id"):</strong> @plrReference</span>
-        </div>
+        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
     }
 
     @govukPanel(Panel(

--- a/app/views/subscriptionview/manageAccount/AmendAccountingPeriodConfirmationView.scala.html
+++ b/app/views/subscriptionview/manageAccount/AmendAccountingPeriodConfirmationView.scala.html
@@ -35,7 +35,7 @@
 @layout(pageTitle = titleNoForm(messages("amendAccountingPeriod.confirmation.title")), showBackLink = false, bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
     @if(isAgent) {
-        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+        <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
     }
 
     @govukPanel(Panel(

--- a/app/views/subscriptionview/manageAccount/CaptureSubscriptionAddressView.scala.html
+++ b/app/views/subscriptionview/manageAccount/CaptureSubscriptionAddressView.scala.html
@@ -45,14 +45,7 @@
         }
 
         @if(isAgent) {
-            <div class="govuk-caption-m">
-                <span><strong>@{
-                    messages("homepage.group")
-                }:</strong> @organisationName</span>
-                <span><strong>@{
-                    messages("homepage.id")
-                }:</strong> @plrRef</span>
-            </div>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
         } else {
             @sectionHeader(messages("contactEmailAddress.heading.caption"))
         }

--- a/app/views/subscriptionview/manageAccount/CaptureSubscriptionAddressView.scala.html
+++ b/app/views/subscriptionview/manageAccount/CaptureSubscriptionAddressView.scala.html
@@ -45,7 +45,7 @@
         }
 
         @if(isAgent) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
         } else {
             @sectionHeader(messages("contactEmailAddress.heading.caption"))
         }

--- a/app/views/subscriptionview/manageAccount/ContactByPhoneView.scala.html
+++ b/app/views/subscriptionview/manageAccount/ContactByPhoneView.scala.html
@@ -41,7 +41,7 @@
         }
 
         @if(isAgent) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
         } else {
             @sectionHeader(messages("contactEmailAddress.heading.caption"))
         }

--- a/app/views/subscriptionview/manageAccount/ContactByPhoneView.scala.html
+++ b/app/views/subscriptionview/manageAccount/ContactByPhoneView.scala.html
@@ -41,14 +41,7 @@
         }
 
         @if(isAgent) {
-            <div class="govuk-caption-m">
-                <span><strong>@{
-                    messages("homepage.group")
-                }:</strong> @organisationName</span>
-                <span><strong>@{
-                    messages("homepage.id")
-                }:</strong> @plrRef</span>
-            </div>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
         } else {
             @sectionHeader(messages("contactEmailAddress.heading.caption"))
         }

--- a/app/views/subscriptionview/manageAccount/ContactCapturePhoneDetailsView.scala.html
+++ b/app/views/subscriptionview/manageAccount/ContactCapturePhoneDetailsView.scala.html
@@ -42,7 +42,7 @@
         }
 
         @if(isAgent) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
         } else {
             @sectionHeader(messages("contactEmailAddress.heading.caption"))
         }

--- a/app/views/subscriptionview/manageAccount/ContactCapturePhoneDetailsView.scala.html
+++ b/app/views/subscriptionview/manageAccount/ContactCapturePhoneDetailsView.scala.html
@@ -42,14 +42,7 @@
         }
 
         @if(isAgent) {
-            <div class="govuk-caption-m">
-                <span><strong>@{
-                    messages("homepage.group")
-                }:</strong> @organisationName</span>
-                <span><strong>@{
-                    messages("homepage.id")
-                }:</strong> @plrRef</span>
-            </div>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
         } else {
             @sectionHeader(messages("contactEmailAddress.heading.caption"))
         }

--- a/app/views/subscriptionview/manageAccount/ContactEmailAddressView.scala.html
+++ b/app/views/subscriptionview/manageAccount/ContactEmailAddressView.scala.html
@@ -40,7 +40,7 @@
         }
 
         @if(isAgent) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
         } else {
             @sectionHeader(messages("contactEmailAddress.heading.caption"))
         }

--- a/app/views/subscriptionview/manageAccount/ContactEmailAddressView.scala.html
+++ b/app/views/subscriptionview/manageAccount/ContactEmailAddressView.scala.html
@@ -40,14 +40,7 @@
         }
 
         @if(isAgent) {
-            <div class="govuk-caption-m">
-                <span><strong>@{
-                    messages("homepage.group")
-                }:</strong> @organisationName</span>
-                <span><strong>@{
-                    messages("homepage.id")
-                }:</strong> @plrRef</span>
-            </div>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
         } else {
             @sectionHeader(messages("contactEmailAddress.heading.caption"))
         }

--- a/app/views/subscriptionview/manageAccount/ContactNameComplianceView.scala.html
+++ b/app/views/subscriptionview/manageAccount/ContactNameComplianceView.scala.html
@@ -40,7 +40,7 @@
         }
 
         @if(isAgent) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
         } else {
             @sectionHeader(messages("contactEmailAddress.heading.caption"))
         }

--- a/app/views/subscriptionview/manageAccount/ContactNameComplianceView.scala.html
+++ b/app/views/subscriptionview/manageAccount/ContactNameComplianceView.scala.html
@@ -40,14 +40,7 @@
         }
 
         @if(isAgent) {
-            <div class="govuk-caption-m">
-                <span><strong>@{
-                    messages("homepage.group")
-                }:</strong> @organisationName</span>
-                <span><strong>@{
-                    messages("homepage.id")
-                }:</strong> @plrRef</span>
-            </div>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
         } else {
             @sectionHeader(messages("contactEmailAddress.heading.caption"))
         }

--- a/app/views/subscriptionview/manageAccount/ManageContactCheckYourAnswersView.scala.html
+++ b/app/views/subscriptionview/manageAccount/ManageContactCheckYourAnswersView.scala.html
@@ -33,10 +33,7 @@
     @formHelper(action = controllers.subscription.manageAccount.routes.ManageContactCheckYourAnswersController.onSubmit()) {
 
             @if(isAgent) {
-                <div class="govuk-caption-m">
-                    <span><strong>@{messages("homepage.group")}:</strong> @organisationName</span>
-                    <span><strong>@{messages("homepage.id")}:</strong> @plrRef</span>
-                </div>
+                <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
             }
 
             @h1(messages("manageContactCheckYourAnswers.heading.caption"), classes = "govuk-heading-l")

--- a/app/views/subscriptionview/manageAccount/ManageContactCheckYourAnswersView.scala.html
+++ b/app/views/subscriptionview/manageAccount/ManageContactCheckYourAnswersView.scala.html
@@ -33,7 +33,7 @@
     @formHelper(action = controllers.subscription.manageAccount.routes.ManageContactCheckYourAnswersController.onSubmit()) {
 
             @if(isAgent) {
-                <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
+                <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
             }
 
             @h1(messages("manageContactCheckYourAnswers.heading.caption"), classes = "govuk-heading-l")

--- a/app/views/subscriptionview/manageAccount/ManageGroupDetailsMultiPeriodView.scala.html
+++ b/app/views/subscriptionview/manageAccount/ManageGroupDetailsMultiPeriodView.scala.html
@@ -29,7 +29,7 @@
 @layout(pageTitle = titleNoForm(messages("manageGroupDetails.multiPeriod.title")), showBackLink = true, bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
     @if(isAgent && organisationName.nonEmpty) {
-        <h2 class="govuk-caption-l hmrc-caption-l"><span id="section-header"><strong>Group:</strong> @organisationName.get <strong>ID:</strong> @plrReference</span></h2>
+        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
     }
 
     @heading(messages("manageGroupDetails.multiPeriod.heading"), classes = "govuk-heading-l")

--- a/app/views/subscriptionview/manageAccount/ManageGroupDetailsMultiPeriodView.scala.html
+++ b/app/views/subscriptionview/manageAccount/ManageGroupDetailsMultiPeriodView.scala.html
@@ -29,7 +29,7 @@
 @layout(pageTitle = titleNoForm(messages("manageGroupDetails.multiPeriod.title")), showBackLink = true, bannerUrl = Some(routes.HomepageController.onPageLoad().url)) {
 
     @if(isAgent && organisationName.nonEmpty) {
-        <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+        <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
     }
 
     @heading(messages("manageGroupDetails.multiPeriod.heading"), classes = "govuk-heading-l")

--- a/app/views/subscriptionview/manageAccount/NewAccountingPeriodView.scala.html
+++ b/app/views/subscriptionview/manageAccount/NewAccountingPeriodView.scala.html
@@ -49,9 +49,9 @@
         }
 
         @if(isAgent && organisationName.isDefined) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.group")}:</strong> @organisationName<strong> @{messages("homepage.id")}:</strong> @plrReference</span>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         } else if(isAgent) {
-            <span class="govuk-caption-m"><strong>@{messages("homepage.id")}: </strong>@plrReference</span>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @heading(messages("newAccountingPeriod.heading"), "govuk-heading-l")

--- a/app/views/subscriptionview/manageAccount/NewAccountingPeriodView.scala.html
+++ b/app/views/subscriptionview/manageAccount/NewAccountingPeriodView.scala.html
@@ -49,9 +49,9 @@
         }
 
         @if(isAgent && organisationName.isDefined) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         } else if(isAgent) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrReference</h2>
         }
 
         @heading(messages("newAccountingPeriod.heading"), "govuk-heading-l")

--- a/app/views/subscriptionview/manageAccount/SecondaryContactEmailView.scala.html
+++ b/app/views/subscriptionview/manageAccount/SecondaryContactEmailView.scala.html
@@ -40,7 +40,7 @@
         }
 
         @if(isAgent) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
         } else {
             @sectionHeader(messages("contactEmailAddress.heading.caption"))
         }

--- a/app/views/subscriptionview/manageAccount/SecondaryContactEmailView.scala.html
+++ b/app/views/subscriptionview/manageAccount/SecondaryContactEmailView.scala.html
@@ -40,14 +40,7 @@
         }
 
         @if(isAgent) {
-            <div class="govuk-caption-m">
-                <span><strong>@{
-                    messages("homepage.group")
-                }:</strong> @organisationName</span>
-                <span><strong>@{
-                    messages("homepage.id")
-                }:</strong> @plrRef</span>
-            </div>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
         } else {
             @sectionHeader(messages("contactEmailAddress.heading.caption"))
         }

--- a/app/views/subscriptionview/manageAccount/SecondaryContactNameView.scala.html
+++ b/app/views/subscriptionview/manageAccount/SecondaryContactNameView.scala.html
@@ -40,14 +40,7 @@
         }
 
         @if(isAgent) {
-            <div class="govuk-caption-m">
-                <span><strong>@{
-                    messages("homepage.group")
-                }:</strong> @organisationName</span>
-                <span><strong>@{
-                    messages("homepage.id")
-                }:</strong> @plrRef</span>
-            </div>
+          <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
         } else {
             @sectionHeader(messages("contactEmailAddress.heading.caption"))
         }

--- a/app/views/subscriptionview/manageAccount/SecondaryContactNameView.scala.html
+++ b/app/views/subscriptionview/manageAccount/SecondaryContactNameView.scala.html
@@ -40,7 +40,7 @@
         }
 
         @if(isAgent) {
-          <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
+          <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
         } else {
             @sectionHeader(messages("contactEmailAddress.heading.caption"))
         }

--- a/app/views/subscriptionview/manageAccount/SecondaryPhonePreferenceView.scala.html
+++ b/app/views/subscriptionview/manageAccount/SecondaryPhonePreferenceView.scala.html
@@ -38,7 +38,7 @@
         }
 
         @if(isAgent) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
         } else {
             @sectionHeader(messages("contactEmailAddress.heading.caption"))
         }

--- a/app/views/subscriptionview/manageAccount/SecondaryPhonePreferenceView.scala.html
+++ b/app/views/subscriptionview/manageAccount/SecondaryPhonePreferenceView.scala.html
@@ -38,14 +38,7 @@
         }
 
         @if(isAgent) {
-            <div class="govuk-caption-m">
-                <span><strong>@{
-                    messages("homepage.group")
-                }:</strong> @organisationName</span>
-                <span><strong>@{
-                    messages("homepage.id")
-                }:</strong> @plrRef</span>
-            </div>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
         } else {
             @sectionHeader(messages("contactEmailAddress.heading.caption"))
         }

--- a/app/views/subscriptionview/manageAccount/SecondaryPhoneView.scala.html
+++ b/app/views/subscriptionview/manageAccount/SecondaryPhoneView.scala.html
@@ -39,7 +39,7 @@
         }
 
         @if(isAgent) {
-            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
+            <h2 class="govuk-caption-m hmrc-caption-m govuk-!-margin-bottom-0"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
         } else {
             @sectionHeader(messages("contactEmailAddress.heading.caption"))
         }

--- a/app/views/subscriptionview/manageAccount/SecondaryPhoneView.scala.html
+++ b/app/views/subscriptionview/manageAccount/SecondaryPhoneView.scala.html
@@ -39,14 +39,7 @@
         }
 
         @if(isAgent) {
-            <div class="govuk-caption-m">
-                <span><strong>@{
-                    messages("homepage.group")
-                }:</strong> @organisationName</span>
-                <span><strong>@{
-                    messages("homepage.id")
-                }:</strong> @plrRef</span>
-            </div>
+            <h2 class="govuk-caption-m hmrc-caption-m no-margin-bottom"><span class="govuk-!-font-weight-bold">@{messages("homepage.group")}:</span> @organisationName <span class="govuk-!-font-weight-bold">@{messages("homepage.id")}:</span> @plrRef</h2>
         } else {
             @sectionHeader(messages("contactEmailAddress.heading.caption"))
         }

--- a/test/views/btn/BTNAccountingPeriodViewSpec.scala
+++ b/test/views/btn/BTNAccountingPeriodViewSpec.scala
@@ -163,9 +163,16 @@ class BTNAccountingPeriodViewSpec extends ViewSpecBase {
         agentView().getElementsByClass(bannerClassName).attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
-      "have a caption" in {
-        agentView().getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
-        agentNoOrgView().getElementsByClass("govuk-caption-m").text mustBe "ID: XMPLR0123456789"
+      "have a caption for agent view" in {
+        val caption: Element = agentView().select("h2.no-margin-bottom").first()
+        caption.text mustBe "Group: orgName ID: XMPLR0123456789"
+        caption.hasClass("govuk-caption-m") mustBe true
+        caption.hasClass("hmrc-caption-m") mustBe true
+
+        val captionNoOrg: Element = agentNoOrgView().select("h2.no-margin-bottom").first()
+        captionNoOrg.text mustBe "ID: XMPLR0123456789"
+        captionNoOrg.hasClass("govuk-caption-m") mustBe true
+        captionNoOrg.hasClass("hmrc-caption-m") mustBe true
       }
 
       "have a paragraph" in {

--- a/test/views/btn/BTNAccountingPeriodViewSpec.scala
+++ b/test/views/btn/BTNAccountingPeriodViewSpec.scala
@@ -164,12 +164,12 @@ class BTNAccountingPeriodViewSpec extends ViewSpecBase {
       }
 
       "have a caption for agent view" in {
-        val caption: Element = agentView().select("h2.no-margin-bottom").first()
+        val caption: Element = agentView().select("h2.hmrc-caption-m").first()
         caption.text mustBe "Group: orgName ID: XMPLR0123456789"
         caption.hasClass("govuk-caption-m") mustBe true
         caption.hasClass("hmrc-caption-m") mustBe true
 
-        val captionNoOrg: Element = agentNoOrgView().select("h2.no-margin-bottom").first()
+        val captionNoOrg: Element = agentNoOrgView().select("h2.hmrc-caption-m").first()
         captionNoOrg.text mustBe "ID: XMPLR0123456789"
         captionNoOrg.hasClass("govuk-caption-m") mustBe true
         captionNoOrg.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/btn/BTNAlreadyInPlaceViewSpec.scala
+++ b/test/views/btn/BTNAlreadyInPlaceViewSpec.scala
@@ -63,12 +63,12 @@ class BTNAlreadyInPlaceViewSpec extends ViewSpecBase {
     }
 
     "have a caption for an agent view" in {
-      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      val caption: Element = agentView.select("h2.hmrc-caption-m").first()
       caption.text mustBe "Group: orgName ID: XMPLR0123456789"
       caption.hasClass("govuk-caption-m") mustBe true
       caption.hasClass("hmrc-caption-m") mustBe true
 
-      val captionNoOrg: Element = agentNoOrgView.select("h2.no-margin-bottom").first()
+      val captionNoOrg: Element = agentNoOrgView.select("h2.hmrc-caption-m").first()
       captionNoOrg.text mustBe "ID: XMPLR0123456789"
       captionNoOrg.hasClass("govuk-caption-m") mustBe true
       captionNoOrg.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/btn/BTNAlreadyInPlaceViewSpec.scala
+++ b/test/views/btn/BTNAlreadyInPlaceViewSpec.scala
@@ -63,8 +63,15 @@ class BTNAlreadyInPlaceViewSpec extends ViewSpecBase {
     }
 
     "have a caption for an agent view" in {
-      agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
-      agentNoOrgView.getElementsByClass("govuk-caption-m").text mustBe "ID: XMPLR0123456789"
+      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      caption.text mustBe "Group: orgName ID: XMPLR0123456789"
+      caption.hasClass("govuk-caption-m") mustBe true
+      caption.hasClass("hmrc-caption-m") mustBe true
+
+      val captionNoOrg: Element = agentNoOrgView.select("h2.no-margin-bottom").first()
+      captionNoOrg.text mustBe "ID: XMPLR0123456789"
+      captionNoOrg.hasClass("govuk-caption-m") mustBe true
+      captionNoOrg.hasClass("hmrc-caption-m") mustBe true
     }
 
     val viewScenarios: Seq[ViewScenario] =

--- a/test/views/btn/BTNAmendDetailsViewSpec.scala
+++ b/test/views/btn/BTNAmendDetailsViewSpec.scala
@@ -95,22 +95,22 @@ class BTNAmendDetailsViewSpec extends ViewSpecBase {
       }
 
       "have a caption" in {
-        val captionUkOnly: Element = agentViewUkOnly().select("h2.no-margin-bottom").first()
+        val captionUkOnly: Element = agentViewUkOnly().select("h2.hmrc-caption-m").first()
         captionUkOnly.text mustBe "Group: orgName ID: XMPLR0123456789"
         captionUkOnly.hasClass("govuk-caption-m") mustBe true
         captionUkOnly.hasClass("hmrc-caption-m") mustBe true
 
-        val captionUkAndOther: Element = agentViewUkAndOther().select("h2.no-margin-bottom").first()
+        val captionUkAndOther: Element = agentViewUkAndOther().select("h2.hmrc-caption-m").first()
         captionUkAndOther.text mustBe "Group: orgName ID: XMPLR0123456789"
         captionUkAndOther.hasClass("govuk-caption-m") mustBe true
         captionUkAndOther.hasClass("hmrc-caption-m") mustBe true
 
-        val captionUkOnlyNoOrg: Element = agentViewUkOnly(organisationName = None).select("h2.no-margin-bottom").first()
+        val captionUkOnlyNoOrg: Element = agentViewUkOnly(organisationName = None).select("h2.hmrc-caption-m").first()
         captionUkOnlyNoOrg.text mustBe "ID: XMPLR0123456789"
         captionUkOnlyNoOrg.hasClass("govuk-caption-m") mustBe true
         captionUkOnlyNoOrg.hasClass("hmrc-caption-m") mustBe true
 
-        val captionUkAndOtherNoOrg: Element = agentViewUkAndOther(organisationName = None).select("h2.no-margin-bottom").first()
+        val captionUkAndOtherNoOrg: Element = agentViewUkAndOther(organisationName = None).select("h2.hmrc-caption-m").first()
         captionUkAndOtherNoOrg.text mustBe "ID: XMPLR0123456789"
         captionUkAndOtherNoOrg.hasClass("govuk-caption-m") mustBe true
         captionUkAndOtherNoOrg.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/btn/BTNAmendDetailsViewSpec.scala
+++ b/test/views/btn/BTNAmendDetailsViewSpec.scala
@@ -20,7 +20,7 @@ import base.ViewSpecBase
 import controllers.routes
 import models.MneOrDomestic
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
+import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
 import views.behaviours.ViewScenario
 import views.html.btn.BTNAmendDetailsView
@@ -95,10 +95,25 @@ class BTNAmendDetailsViewSpec extends ViewSpecBase {
       }
 
       "have a caption" in {
-        agentViewUkOnly().getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
-        agentViewUkAndOther().getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
-        agentViewUkOnly(organisationName = None).getElementsByClass("govuk-caption-m").text mustBe "ID: XMPLR0123456789"
-        agentViewUkAndOther(organisationName = None).getElementsByClass("govuk-caption-m").text mustBe "ID: XMPLR0123456789"
+        val captionUkOnly: Element = agentViewUkOnly().select("h2.no-margin-bottom").first()
+        captionUkOnly.text mustBe "Group: orgName ID: XMPLR0123456789"
+        captionUkOnly.hasClass("govuk-caption-m") mustBe true
+        captionUkOnly.hasClass("hmrc-caption-m") mustBe true
+
+        val captionUkAndOther: Element = agentViewUkAndOther().select("h2.no-margin-bottom").first()
+        captionUkAndOther.text mustBe "Group: orgName ID: XMPLR0123456789"
+        captionUkAndOther.hasClass("govuk-caption-m") mustBe true
+        captionUkAndOther.hasClass("hmrc-caption-m") mustBe true
+
+        val captionUkOnlyNoOrg: Element = agentViewUkOnly(organisationName = None).select("h2.no-margin-bottom").first()
+        captionUkOnlyNoOrg.text mustBe "ID: XMPLR0123456789"
+        captionUkOnlyNoOrg.hasClass("govuk-caption-m") mustBe true
+        captionUkOnlyNoOrg.hasClass("hmrc-caption-m") mustBe true
+
+        val captionUkAndOtherNoOrg: Element = agentViewUkAndOther(organisationName = None).select("h2.no-margin-bottom").first()
+        captionUkAndOtherNoOrg.text mustBe "ID: XMPLR0123456789"
+        captionUkAndOtherNoOrg.hasClass("govuk-caption-m") mustBe true
+        captionUkAndOtherNoOrg.hasClass("hmrc-caption-m") mustBe true
       }
 
       "have a unique H1 heading" in {

--- a/test/views/btn/BTNBeforeStartViewSpec.scala
+++ b/test/views/btn/BTNBeforeStartViewSpec.scala
@@ -90,9 +90,15 @@ class BTNBeforeStartViewSpec extends ViewSpecBase {
     }
 
     "have agent specific content" in {
+      val caption: Element = agentView().select("h2.no-margin-bottom").first()
+      caption.text mustBe "Group: orgName ID: XMPLR0123456789"
+      caption.hasClass("govuk-caption-m") mustBe true
+      caption.hasClass("hmrc-caption-m") mustBe true
 
-      agentView().getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
-      agentViewNoOrg().getElementsByClass("govuk-caption-m").text mustBe "ID: XMPLR0123456789"
+      val captionNoOrg: Element = agentViewNoOrg().select("h2.no-margin-bottom").first()
+      captionNoOrg.text mustBe "ID: XMPLR0123456789"
+      captionNoOrg.hasClass("govuk-caption-m") mustBe true
+      captionNoOrg.hasClass("hmrc-caption-m") mustBe true
 
       val paragraphs: Elements = agentView().getElementsByClass("govuk-body")
 

--- a/test/views/btn/BTNBeforeStartViewSpec.scala
+++ b/test/views/btn/BTNBeforeStartViewSpec.scala
@@ -90,12 +90,12 @@ class BTNBeforeStartViewSpec extends ViewSpecBase {
     }
 
     "have agent specific content" in {
-      val caption: Element = agentView().select("h2.no-margin-bottom").first()
+      val caption: Element = agentView().select("h2.hmrc-caption-m").first()
       caption.text mustBe "Group: orgName ID: XMPLR0123456789"
       caption.hasClass("govuk-caption-m") mustBe true
       caption.hasClass("hmrc-caption-m") mustBe true
 
-      val captionNoOrg: Element = agentViewNoOrg().select("h2.no-margin-bottom").first()
+      val captionNoOrg: Element = agentViewNoOrg().select("h2.hmrc-caption-m").first()
       captionNoOrg.text mustBe "ID: XMPLR0123456789"
       captionNoOrg.hasClass("govuk-caption-m") mustBe true
       captionNoOrg.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/btn/BTNChooseAccountingPeriodViewSpec.scala
+++ b/test/views/btn/BTNChooseAccountingPeriodViewSpec.scala
@@ -76,8 +76,15 @@ class BTNChooseAccountingPeriodViewSpec extends ViewSpecBase {
     }
 
     "have a caption for an agent view" in {
-      agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
-      agentNoOrgView.getElementsByClass("govuk-caption-m").text mustBe "ID: XMPLR0123456789"
+      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      caption.text mustBe "Group: orgName ID: XMPLR0123456789"
+      caption.hasClass("govuk-caption-m") mustBe true
+      caption.hasClass("hmrc-caption-m") mustBe true
+
+      val captionNoOrg: Element = agentNoOrgView.select("h2.no-margin-bottom").first()
+      captionNoOrg.text mustBe "ID: XMPLR0123456789"
+      captionNoOrg.hasClass("govuk-caption-m") mustBe true
+      captionNoOrg.hasClass("hmrc-caption-m") mustBe true
     }
 
     "not have a caption for organisation view" in {

--- a/test/views/btn/BTNChooseAccountingPeriodViewSpec.scala
+++ b/test/views/btn/BTNChooseAccountingPeriodViewSpec.scala
@@ -76,12 +76,12 @@ class BTNChooseAccountingPeriodViewSpec extends ViewSpecBase {
     }
 
     "have a caption for an agent view" in {
-      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      val caption: Element = agentView.select("h2.hmrc-caption-m").first()
       caption.text mustBe "Group: orgName ID: XMPLR0123456789"
       caption.hasClass("govuk-caption-m") mustBe true
       caption.hasClass("hmrc-caption-m") mustBe true
 
-      val captionNoOrg: Element = agentNoOrgView.select("h2.no-margin-bottom").first()
+      val captionNoOrg: Element = agentNoOrgView.select("h2.hmrc-caption-m").first()
       captionNoOrg.text mustBe "ID: XMPLR0123456789"
       captionNoOrg.hasClass("govuk-caption-m") mustBe true
       captionNoOrg.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/btn/BTNConfirmationViewSpec.scala
+++ b/test/views/btn/BTNConfirmationViewSpec.scala
@@ -112,12 +112,12 @@ class BTNConfirmationViewSpec extends ViewSpecBase {
     "have paragraph content (containing company name) and a link when in an agent flow" in {
       val paragraphs: Elements = agentView().getElementsByClass("govuk-body")
 
-      val caption: Element = agentView().select("h2.no-margin-bottom").first()
+      val caption: Element = agentView().select("h2.hmrc-caption-m").first()
       caption.text mustBe s"Group: $companyName ID: $plrRef"
       caption.hasClass("govuk-caption-m") mustBe true
       caption.hasClass("hmrc-caption-m") mustBe true
 
-      val captionNoOrg: Element = agentNoOrgView().select("h2.no-margin-bottom").first()
+      val captionNoOrg: Element = agentNoOrgView().select("h2.hmrc-caption-m").first()
       captionNoOrg.text mustBe s"ID: $plrRef"
       captionNoOrg.hasClass("govuk-caption-m") mustBe true
       captionNoOrg.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/btn/BTNConfirmationViewSpec.scala
+++ b/test/views/btn/BTNConfirmationViewSpec.scala
@@ -19,7 +19,7 @@ package views.btn
 import base.ViewSpecBase
 import controllers.routes
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
+import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
 import views.behaviours.ViewScenario
 import views.html.btn.BTNConfirmationView
@@ -112,8 +112,15 @@ class BTNConfirmationViewSpec extends ViewSpecBase {
     "have paragraph content (containing company name) and a link when in an agent flow" in {
       val paragraphs: Elements = agentView().getElementsByClass("govuk-body")
 
-      agentView().getElementsByClass("govuk-caption-m").text mustBe "Group: Test Company ID: somePillar2Id"
-      agentNoOrgView().getElementsByClass("govuk-caption-m").text mustBe "ID: somePillar2Id"
+      val caption: Element = agentView().select("h2.no-margin-bottom").first()
+      caption.text mustBe s"Group: $companyName ID: $plrRef"
+      caption.hasClass("govuk-caption-m") mustBe true
+      caption.hasClass("hmrc-caption-m") mustBe true
+
+      val captionNoOrg: Element = agentNoOrgView().select("h2.no-margin-bottom").first()
+      captionNoOrg.text mustBe s"ID: $plrRef"
+      captionNoOrg.hasClass("govuk-caption-m") mustBe true
+      captionNoOrg.hasClass("hmrc-caption-m") mustBe true
 
       paragraphs.get(0).text() mustBe
         s"You have submitted a Below-Threshold Notification on: $submissionDateTime."

--- a/test/views/btn/BTNEntitiesInUKOnlyViewSpec.scala
+++ b/test/views/btn/BTNEntitiesInUKOnlyViewSpec.scala
@@ -73,8 +73,15 @@ class BTNEntitiesInUKOnlyViewSpec extends ViewSpecBase {
     }
 
     "have a caption for agent view" in {
-      agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
-      agentNoOrgView.getElementsByClass("govuk-caption-m").text mustBe "ID: XMPLR0123456789"
+      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      caption.text mustBe "Group: orgName ID: XMPLR0123456789"
+      caption.hasClass("govuk-caption-m") mustBe true
+      caption.hasClass("hmrc-caption-m") mustBe true
+
+      val captionNoOrg: Element = agentNoOrgView.select("h2.no-margin-bottom").first()
+      captionNoOrg.text mustBe "ID: XMPLR0123456789"
+      captionNoOrg.hasClass("govuk-caption-m") mustBe true
+      captionNoOrg.hasClass("hmrc-caption-m") mustBe true
     }
 
     val viewScenarios: Seq[ViewScenario] =

--- a/test/views/btn/BTNEntitiesInUKOnlyViewSpec.scala
+++ b/test/views/btn/BTNEntitiesInUKOnlyViewSpec.scala
@@ -73,12 +73,12 @@ class BTNEntitiesInUKOnlyViewSpec extends ViewSpecBase {
     }
 
     "have a caption for agent view" in {
-      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      val caption: Element = agentView.select("h2.hmrc-caption-m").first()
       caption.text mustBe "Group: orgName ID: XMPLR0123456789"
       caption.hasClass("govuk-caption-m") mustBe true
       caption.hasClass("hmrc-caption-m") mustBe true
 
-      val captionNoOrg: Element = agentNoOrgView.select("h2.no-margin-bottom").first()
+      val captionNoOrg: Element = agentNoOrgView.select("h2.hmrc-caption-m").first()
       captionNoOrg.text mustBe "ID: XMPLR0123456789"
       captionNoOrg.hasClass("govuk-caption-m") mustBe true
       captionNoOrg.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/btn/BTNEntitiesInsideOutsideUKViewSpec.scala
+++ b/test/views/btn/BTNEntitiesInsideOutsideUKViewSpec.scala
@@ -74,12 +74,12 @@ class BTNEntitiesInsideOutsideUKViewSpec extends ViewSpecBase {
     }
 
     "have a caption for agent view" in {
-      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      val caption: Element = agentView.select("h2.hmrc-caption-m").first()
       caption.text mustBe "Group: orgName ID: XMPLR0123456789"
       caption.hasClass("govuk-caption-m") mustBe true
       caption.hasClass("hmrc-caption-m") mustBe true
 
-      val captionNoOrg: Element = agentNoOrgView.select("h2.no-margin-bottom").first()
+      val captionNoOrg: Element = agentNoOrgView.select("h2.hmrc-caption-m").first()
       captionNoOrg.text mustBe "ID: XMPLR0123456789"
       captionNoOrg.hasClass("govuk-caption-m") mustBe true
       captionNoOrg.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/btn/BTNEntitiesInsideOutsideUKViewSpec.scala
+++ b/test/views/btn/BTNEntitiesInsideOutsideUKViewSpec.scala
@@ -74,8 +74,15 @@ class BTNEntitiesInsideOutsideUKViewSpec extends ViewSpecBase {
     }
 
     "have a caption for agent view" in {
-      agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
-      agentNoOrgView.getElementsByClass("govuk-caption-m").text mustBe "ID: XMPLR0123456789"
+      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      caption.text mustBe "Group: orgName ID: XMPLR0123456789"
+      caption.hasClass("govuk-caption-m") mustBe true
+      caption.hasClass("hmrc-caption-m") mustBe true
+
+      val captionNoOrg: Element = agentNoOrgView.select("h2.no-margin-bottom").first()
+      captionNoOrg.text mustBe "ID: XMPLR0123456789"
+      captionNoOrg.hasClass("govuk-caption-m") mustBe true
+      captionNoOrg.hasClass("hmrc-caption-m") mustBe true
     }
 
     val viewScenarios: Seq[ViewScenario] =

--- a/test/views/btn/BTNReturnSubmittedViewSpec.scala
+++ b/test/views/btn/BTNReturnSubmittedViewSpec.scala
@@ -110,8 +110,15 @@ class BTNReturnSubmittedViewSpec extends ViewSpecBase {
       }
 
       "have a caption" in {
-        agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
-        agentNoOrgView.getElementsByClass("govuk-caption-m").text mustBe "ID: XMPLR0123456789"
+        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        caption.text mustBe "Group: orgName ID: XMPLR0123456789"
+        caption.hasClass("govuk-caption-m") mustBe true
+        caption.hasClass("hmrc-caption-m") mustBe true
+
+        val captionNoOrg: Element = agentNoOrgView.select("h2.no-margin-bottom").first()
+        captionNoOrg.text mustBe "ID: XMPLR0123456789"
+        captionNoOrg.hasClass("govuk-caption-m") mustBe true
+        captionNoOrg.hasClass("hmrc-caption-m") mustBe true
       }
 
       "have a unique H1 heading" in {

--- a/test/views/btn/BTNReturnSubmittedViewSpec.scala
+++ b/test/views/btn/BTNReturnSubmittedViewSpec.scala
@@ -110,12 +110,12 @@ class BTNReturnSubmittedViewSpec extends ViewSpecBase {
       }
 
       "have a caption" in {
-        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        val caption: Element = agentView.select("h2.hmrc-caption-m").first()
         caption.text mustBe "Group: orgName ID: XMPLR0123456789"
         caption.hasClass("govuk-caption-m") mustBe true
         caption.hasClass("hmrc-caption-m") mustBe true
 
-        val captionNoOrg: Element = agentNoOrgView.select("h2.no-margin-bottom").first()
+        val captionNoOrg: Element = agentNoOrgView.select("h2.hmrc-caption-m").first()
         captionNoOrg.text mustBe "ID: XMPLR0123456789"
         captionNoOrg.hasClass("govuk-caption-m") mustBe true
         captionNoOrg.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/btn/BTNUnderEnquiryWarningViewSpec.scala
+++ b/test/views/btn/BTNUnderEnquiryWarningViewSpec.scala
@@ -66,12 +66,12 @@ class BTNUnderEnquiryWarningViewSpec extends ViewSpecBase {
     }
 
     "have a caption for agent view" in {
-      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      val caption: Element = agentView.select("h2.hmrc-caption-m").first()
       caption.text mustBe "Group: orgName ID: XMPLR0123456789"
       caption.hasClass("govuk-caption-m") mustBe true
       caption.hasClass("hmrc-caption-m") mustBe true
 
-      val captionNoOrg: Element = agentNoOrgView.select("h2.no-margin-bottom").first()
+      val captionNoOrg: Element = agentNoOrgView.select("h2.hmrc-caption-m").first()
       captionNoOrg.text mustBe "ID: XMPLR0123456789"
       captionNoOrg.hasClass("govuk-caption-m") mustBe true
       captionNoOrg.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/btn/BTNUnderEnquiryWarningViewSpec.scala
+++ b/test/views/btn/BTNUnderEnquiryWarningViewSpec.scala
@@ -19,7 +19,7 @@ package views.btn
 import base.ViewSpecBase
 import controllers.routes
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
+import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
 import views.behaviours.ViewScenario
 import views.html.btn.BTNUnderEnquiryWarningView
@@ -66,8 +66,15 @@ class BTNUnderEnquiryWarningViewSpec extends ViewSpecBase {
     }
 
     "have a caption for agent view" in {
-      agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
-      agentNoOrgView.getElementsByClass("govuk-caption-m").text mustBe "ID: XMPLR0123456789"
+      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      caption.text mustBe "Group: orgName ID: XMPLR0123456789"
+      caption.hasClass("govuk-caption-m") mustBe true
+      caption.hasClass("hmrc-caption-m") mustBe true
+
+      val captionNoOrg: Element = agentNoOrgView.select("h2.no-margin-bottom").first()
+      captionNoOrg.text mustBe "ID: XMPLR0123456789"
+      captionNoOrg.hasClass("govuk-caption-m") mustBe true
+      captionNoOrg.hasClass("hmrc-caption-m") mustBe true
     }
 
     val viewScenarios: Seq[ViewScenario] =

--- a/test/views/btn/CheckYourAnswersViewSpec.scala
+++ b/test/views/btn/CheckYourAnswersViewSpec.scala
@@ -195,12 +195,12 @@ class CheckYourAnswersViewSpec extends ViewSpecBase {
     }
 
     "have a caption displaying the organisation name for an agent view" in {
-      val caption: Element = agentView().select("h2.no-margin-bottom").first()
+      val caption: Element = agentView().select("h2.hmrc-caption-m").first()
       caption.text mustBe "Group: orgName ID: XMPLR0123456789"
       caption.hasClass("govuk-caption-m") mustBe true
       caption.hasClass("hmrc-caption-m") mustBe true
 
-      val captionNoOrg: Element = agentNoOrgView().select("h2.no-margin-bottom").first()
+      val captionNoOrg: Element = agentNoOrgView().select("h2.hmrc-caption-m").first()
       captionNoOrg.text mustBe "ID: XMPLR0123456789"
       captionNoOrg.hasClass("govuk-caption-m") mustBe true
       captionNoOrg.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/btn/CheckYourAnswersViewSpec.scala
+++ b/test/views/btn/CheckYourAnswersViewSpec.scala
@@ -195,8 +195,15 @@ class CheckYourAnswersViewSpec extends ViewSpecBase {
     }
 
     "have a caption displaying the organisation name for an agent view" in {
-      agentView().getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
-      agentNoOrgView().getElementsByClass("govuk-caption-m").text mustBe "ID: XMPLR0123456789"
+      val caption: Element = agentView().select("h2.no-margin-bottom").first()
+      caption.text mustBe "Group: orgName ID: XMPLR0123456789"
+      caption.hasClass("govuk-caption-m") mustBe true
+      caption.hasClass("hmrc-caption-m") mustBe true
+
+      val captionNoOrg: Element = agentNoOrgView().select("h2.no-margin-bottom").first()
+      captionNoOrg.text mustBe "ID: XMPLR0123456789"
+      captionNoOrg.hasClass("govuk-caption-m") mustBe true
+      captionNoOrg.hasClass("hmrc-caption-m") mustBe true
     }
 
     val viewScenarios: Seq[ViewScenario] =

--- a/test/views/dueandoverduereturns/DueAndOverdueReturnsViewSpec.scala
+++ b/test/views/dueandoverduereturns/DueAndOverdueReturnsViewSpec.scala
@@ -345,10 +345,22 @@ class DueAndOverdueReturnsViewSpec extends ViewSpecBase with ObligationsAndSubmi
       }
 
       "displaying caption for agent view" in {
-        lazy val view: Document =
+        lazy val agentView: Document =
           Jsoup.parse(page(emptyResponse, fromDate, toDate, agentView = true, plrRef, Some("orgName"))(request, appConfig, messages).toString())
 
-        view.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0012345678"
+        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        caption.text mustBe s"Group: orgName ID: $plrRef"
+        caption.hasClass("govuk-caption-m") mustBe true
+        caption.hasClass("hmrc-caption-m") mustBe true
+
+        lazy val agentViewNoOrg: Document =
+          Jsoup.parse(page(emptyResponse, fromDate, toDate, agentView = true, plrRef, None)(request, appConfig, messages).toString())
+        agentViewNoOrg.getElementsByClass("govuk-caption-m").text mustBe s"ID: $plrRef"
+
+        val captionNoOrg: Element = agentViewNoOrg.select("h2.no-margin-bottom").first()
+        captionNoOrg.text mustBe s"ID: $plrRef"
+        captionNoOrg.hasClass("govuk-caption-m") mustBe true
+        captionNoOrg.hasClass("hmrc-caption-m") mustBe true
       }
     }
 

--- a/test/views/dueandoverduereturns/DueAndOverdueReturnsViewSpec.scala
+++ b/test/views/dueandoverduereturns/DueAndOverdueReturnsViewSpec.scala
@@ -348,7 +348,7 @@ class DueAndOverdueReturnsViewSpec extends ViewSpecBase with ObligationsAndSubmi
         lazy val agentView: Document =
           Jsoup.parse(page(emptyResponse, fromDate, toDate, agentView = true, plrRef, Some("orgName"))(request, appConfig, messages).toString())
 
-        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        val caption: Element = agentView.select("h2.hmrc-caption-m").first()
         caption.text mustBe s"Group: orgName ID: $plrRef"
         caption.hasClass("govuk-caption-m") mustBe true
         caption.hasClass("hmrc-caption-m") mustBe true
@@ -357,7 +357,7 @@ class DueAndOverdueReturnsViewSpec extends ViewSpecBase with ObligationsAndSubmi
           Jsoup.parse(page(emptyResponse, fromDate, toDate, agentView = true, plrRef, None)(request, appConfig, messages).toString())
         agentViewNoOrg.getElementsByClass("govuk-caption-m").text mustBe s"ID: $plrRef"
 
-        val captionNoOrg: Element = agentViewNoOrg.select("h2.no-margin-bottom").first()
+        val captionNoOrg: Element = agentViewNoOrg.select("h2.hmrc-caption-m").first()
         captionNoOrg.text mustBe s"ID: $plrRef"
         captionNoOrg.hasClass("govuk-caption-m") mustBe true
         captionNoOrg.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/outstandingpayments/OutstandingPaymentsViewSpec.scala
+++ b/test/views/outstandingpayments/OutstandingPaymentsViewSpec.scala
@@ -363,7 +363,7 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
 
     "display agent-specific content" should {
       "show company name and pillar 2 ID at the top of the page" in {
-        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        val caption: Element = agentView.select("h2.hmrc-caption-m").first()
         caption.text mustBe s"Group: $orgName ID: $plrRef"
         caption.hasClass("govuk-caption-m") mustBe true
         caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/outstandingpayments/OutstandingPaymentsViewSpec.scala
+++ b/test/views/outstandingpayments/OutstandingPaymentsViewSpec.scala
@@ -363,8 +363,10 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
 
     "display agent-specific content" should {
       "show company name and pillar 2 ID at the top of the page" in {
-        val hintText: Elements = accountActivityAgentView.getElementsByClass("govuk-hint")
-        hintText.get(0).text mustBe s"Group: $orgName ID: $plrRef"
+        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        caption.text mustBe s"Group: $orgName ID: $plrRef"
+        caption.hasClass("govuk-caption-m") mustBe true
+        caption.hasClass("hmrc-caption-m") mustBe true
       }
 
       "should display agent-specific paragraphs" in {

--- a/test/views/paymenthistory/NoTransactionHistoryViewSpec.scala
+++ b/test/views/paymenthistory/NoTransactionHistoryViewSpec.scala
@@ -94,7 +94,7 @@ class NoTransactionHistoryViewSpec extends ViewSpecBase {
     }
 
     "have correct text for agents at the top of the page" in {
-      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      val caption: Element = agentView.select("h2.hmrc-caption-m").first()
       caption.text mustBe s"Group: $orgName ID: $plrRef"
       caption.hasClass("govuk-caption-m") mustBe true
       caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/paymenthistory/NoTransactionHistoryViewSpec.scala
+++ b/test/views/paymenthistory/NoTransactionHistoryViewSpec.scala
@@ -19,7 +19,7 @@ package views.paymenthistory
 import base.ViewSpecBase
 import controllers.routes
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
+import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
 import views.behaviours.ViewScenario
 import views.html.paymenthistory.NoTransactionHistoryView
@@ -94,7 +94,11 @@ class NoTransactionHistoryViewSpec extends ViewSpecBase {
     }
 
     "have correct text for agents at the top of the page" in {
-      agentView.getElementsByClass("govuk-caption-m").get(0).text mustBe s"Group: $orgName ID: $plrRef"
+      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      caption.text mustBe s"Group: $orgName ID: $plrRef"
+      caption.hasClass("govuk-caption-m") mustBe true
+      caption.hasClass("hmrc-caption-m") mustBe true
+
     }
 
     "have paragraph 1" in {

--- a/test/views/paymenthistory/TransactionHistoryViewSpec.scala
+++ b/test/views/paymenthistory/TransactionHistoryViewSpec.scala
@@ -114,7 +114,10 @@ class TransactionHistoryViewSpec extends ViewSpecBase {
     }
 
     "have correct text for agents at the top of the page" in {
-      agentView.getElementsByClass("govuk-caption-m").get(0).text mustBe s"Group: $orgName ID: $plrRef"
+      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      caption.text mustBe s"Group: $orgName ID: $plrRef"
+      caption.hasClass("govuk-caption-m") mustBe true
+      caption.hasClass("hmrc-caption-m") mustBe true
     }
 
     "have correct paragraphs for a group" in {

--- a/test/views/paymenthistory/TransactionHistoryViewSpec.scala
+++ b/test/views/paymenthistory/TransactionHistoryViewSpec.scala
@@ -114,7 +114,7 @@ class TransactionHistoryViewSpec extends ViewSpecBase {
     }
 
     "have correct text for agents at the top of the page" in {
-      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      val caption: Element = agentView.select("h2.hmrc-caption-m").first()
       caption.text mustBe s"Group: $orgName ID: $plrRef"
       caption.hasClass("govuk-caption-m") mustBe true
       caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/repayments/BankAccountDetailsViewSpec.scala
+++ b/test/views/repayments/BankAccountDetailsViewSpec.scala
@@ -57,7 +57,10 @@ class BankAccountDetailsViewSpec extends ViewSpecBase with StringGenerators {
     }
 
     "have a caption for an agent view" in {
-      agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
+      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      caption.text mustBe "Group: orgName ID: XMPLR0123456789"
+      caption.hasClass("govuk-caption-m") mustBe true
+      caption.hasClass("hmrc-caption-m") mustBe true
     }
 
     "have a unique H1 heading" in {

--- a/test/views/repayments/BankAccountDetailsViewSpec.scala
+++ b/test/views/repayments/BankAccountDetailsViewSpec.scala
@@ -57,7 +57,7 @@ class BankAccountDetailsViewSpec extends ViewSpecBase with StringGenerators {
     }
 
     "have a caption for an agent view" in {
-      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      val caption: Element = agentView.select("h2.hmrc-caption-m").first()
       caption.text mustBe "Group: orgName ID: XMPLR0123456789"
       caption.hasClass("govuk-caption-m") mustBe true
       caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/repayments/NonUKBankViewSpec.scala
+++ b/test/views/repayments/NonUKBankViewSpec.scala
@@ -50,7 +50,10 @@ class NonUKBankViewSpec extends ViewSpecBase with StringGenerators {
       }
 
       "have a caption for an agent view" in {
-        agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
+        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        caption.text mustBe "Group: orgName ID: XMPLR0123456789"
+        caption.hasClass("govuk-caption-m") mustBe true
+        caption.hasClass("hmrc-caption-m") mustBe true
       }
 
       "have a unique H1 heading" in {

--- a/test/views/repayments/NonUKBankViewSpec.scala
+++ b/test/views/repayments/NonUKBankViewSpec.scala
@@ -50,7 +50,7 @@ class NonUKBankViewSpec extends ViewSpecBase with StringGenerators {
       }
 
       "have a caption for an agent view" in {
-        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        val caption: Element = agentView.select("h2.hmrc-caption-m").first()
         caption.text mustBe "Group: orgName ID: XMPLR0123456789"
         caption.hasClass("govuk-caption-m") mustBe true
         caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/repayments/ReasonForRequestingRefundViewSpec.scala
+++ b/test/views/repayments/ReasonForRequestingRefundViewSpec.scala
@@ -49,7 +49,7 @@ class ReasonForRequestingRefundViewSpec extends ViewSpecBase with Generators wit
       }
 
       "have a caption for an agent view" in {
-        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        val caption: Element = agentView.select("h2.hmrc-caption-m").first()
         caption.text mustBe "Group: orgName ID: XMPLR0123456789"
         caption.hasClass("govuk-caption-m") mustBe true
         caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/repayments/ReasonForRequestingRefundViewSpec.scala
+++ b/test/views/repayments/ReasonForRequestingRefundViewSpec.scala
@@ -49,7 +49,10 @@ class ReasonForRequestingRefundViewSpec extends ViewSpecBase with Generators wit
       }
 
       "have a caption for an agent view" in {
-        agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
+        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        caption.text mustBe "Group: orgName ID: XMPLR0123456789"
+        caption.hasClass("govuk-caption-m") mustBe true
+        caption.hasClass("hmrc-caption-m") mustBe true
       }
 
       "have a unique H1 heading" in {

--- a/test/views/repayments/RepaymentsCheckYourAnswersViewSpec.scala
+++ b/test/views/repayments/RepaymentsCheckYourAnswersViewSpec.scala
@@ -87,7 +87,10 @@ class RepaymentsCheckYourAnswersViewSpec extends ViewSpecBase {
     }
 
     "have a caption for an agent view" in {
-      agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
+      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      caption.text mustBe "Group: orgName ID: XMPLR0123456789"
+      caption.hasClass("govuk-caption-m") mustBe true
+      caption.hasClass("hmrc-caption-m") mustBe true
     }
 
     "have a unique H1 heading" in {

--- a/test/views/repayments/RepaymentsCheckYourAnswersViewSpec.scala
+++ b/test/views/repayments/RepaymentsCheckYourAnswersViewSpec.scala
@@ -87,7 +87,7 @@ class RepaymentsCheckYourAnswersViewSpec extends ViewSpecBase {
     }
 
     "have a caption for an agent view" in {
-      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      val caption: Element = agentView.select("h2.hmrc-caption-m").first()
       caption.text mustBe "Group: orgName ID: XMPLR0123456789"
       caption.hasClass("govuk-caption-m") mustBe true
       caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/repayments/RepaymentsConfirmationViewSpec.scala
+++ b/test/views/repayments/RepaymentsConfirmationViewSpec.scala
@@ -85,7 +85,10 @@ class RepaymentsConfirmationViewSpec extends ViewSpecBase {
 
   "Agent view" should {
     "show the correct hint text above the confirmation panel" in {
-      agentView.getElementsByClass("govuk-caption-m").text mustBe s"Group: $testOrgName ID: $testPillar2Ref"
+      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      caption.text mustBe s"Group: $testOrgName ID: $testPillar2Ref"
+      caption.hasClass("govuk-caption-m") mustBe true
+      caption.hasClass("hmrc-caption-m") mustBe true
     }
 
     "show the extended confirmation message below the existing text" in {

--- a/test/views/repayments/RepaymentsConfirmationViewSpec.scala
+++ b/test/views/repayments/RepaymentsConfirmationViewSpec.scala
@@ -85,7 +85,7 @@ class RepaymentsConfirmationViewSpec extends ViewSpecBase {
 
   "Agent view" should {
     "show the correct hint text above the confirmation panel" in {
-      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      val caption: Element = agentView.select("h2.hmrc-caption-m").first()
       caption.text mustBe s"Group: $testOrgName ID: $testPillar2Ref"
       caption.hasClass("govuk-caption-m") mustBe true
       caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/repayments/RepaymentsContactByPhoneViewSpec.scala
+++ b/test/views/repayments/RepaymentsContactByPhoneViewSpec.scala
@@ -53,7 +53,10 @@ class RepaymentsContactByPhoneViewSpec extends ViewSpecBase with StringGenerator
       }
 
       "have a caption for an agent view" in {
-        agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
+        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        caption.text mustBe "Group: orgName ID: XMPLR0123456789"
+        caption.hasClass("govuk-caption-m") mustBe true
+        caption.hasClass("hmrc-caption-m") mustBe true
       }
 
       "have a unique H1 heading" in {

--- a/test/views/repayments/RepaymentsContactByPhoneViewSpec.scala
+++ b/test/views/repayments/RepaymentsContactByPhoneViewSpec.scala
@@ -53,7 +53,7 @@ class RepaymentsContactByPhoneViewSpec extends ViewSpecBase with StringGenerator
       }
 
       "have a caption for an agent view" in {
-        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        val caption: Element = agentView.select("h2.hmrc-caption-m").first()
         caption.text mustBe "Group: orgName ID: XMPLR0123456789"
         caption.hasClass("govuk-caption-m") mustBe true
         caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/repayments/RepaymentsContactEmailViewSpec.scala
+++ b/test/views/repayments/RepaymentsContactEmailViewSpec.scala
@@ -53,7 +53,10 @@ class RepaymentsContactEmailViewSpec extends ViewSpecBase with StringGenerators 
       }
 
       "have a caption for an agent view" in {
-        agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
+        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        caption.text mustBe "Group: orgName ID: XMPLR0123456789"
+        caption.hasClass("govuk-caption-m") mustBe true
+        caption.hasClass("hmrc-caption-m") mustBe true
       }
 
       "have a unique H1 heading" in {

--- a/test/views/repayments/RepaymentsContactEmailViewSpec.scala
+++ b/test/views/repayments/RepaymentsContactEmailViewSpec.scala
@@ -53,7 +53,7 @@ class RepaymentsContactEmailViewSpec extends ViewSpecBase with StringGenerators 
       }
 
       "have a caption for an agent view" in {
-        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        val caption: Element = agentView.select("h2.hmrc-caption-m").first()
         caption.text mustBe "Group: orgName ID: XMPLR0123456789"
         caption.hasClass("govuk-caption-m") mustBe true
         caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/repayments/RepaymentsContactNameViewSpec.scala
+++ b/test/views/repayments/RepaymentsContactNameViewSpec.scala
@@ -49,7 +49,7 @@ class RepaymentsContactNameViewSpec extends ViewSpecBase with StringGenerators {
       }
 
       "have a caption for an agent view" in {
-        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        val caption: Element = agentView.select("h2.hmrc-caption-m").first()
         caption.text mustBe "Group: orgName ID: XMPLR0123456789"
         caption.hasClass("govuk-caption-m") mustBe true
         caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/repayments/RepaymentsContactNameViewSpec.scala
+++ b/test/views/repayments/RepaymentsContactNameViewSpec.scala
@@ -49,7 +49,10 @@ class RepaymentsContactNameViewSpec extends ViewSpecBase with StringGenerators {
       }
 
       "have a caption for an agent view" in {
-        agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
+        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        caption.text mustBe "Group: orgName ID: XMPLR0123456789"
+        caption.hasClass("govuk-caption-m") mustBe true
+        caption.hasClass("hmrc-caption-m") mustBe true
       }
 
       "have a unique H1 heading" in {

--- a/test/views/repayments/RepaymentsPhoneDetailsViewSpec.scala
+++ b/test/views/repayments/RepaymentsPhoneDetailsViewSpec.scala
@@ -52,7 +52,7 @@ class RepaymentsPhoneDetailsViewSpec extends ViewSpecBase {
       }
 
       "have a caption for an agent view" in {
-        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        val caption: Element = agentView.select("h2.hmrc-caption-m").first()
         caption.text mustBe "Group: orgName ID: XMPLR0123456789"
         caption.hasClass("govuk-caption-m") mustBe true
         caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/repayments/RepaymentsPhoneDetailsViewSpec.scala
+++ b/test/views/repayments/RepaymentsPhoneDetailsViewSpec.scala
@@ -52,7 +52,10 @@ class RepaymentsPhoneDetailsViewSpec extends ViewSpecBase {
       }
 
       "have a caption for an agent view" in {
-        agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
+        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        caption.text mustBe "Group: orgName ID: XMPLR0123456789"
+        caption.hasClass("govuk-caption-m") mustBe true
+        caption.hasClass("hmrc-caption-m") mustBe true
       }
 
       "have a unique H1 heading" in {

--- a/test/views/repayments/RequestRefundAmountViewSpec.scala
+++ b/test/views/repayments/RequestRefundAmountViewSpec.scala
@@ -46,7 +46,10 @@ class RequestRefundAmountViewSpec extends ViewSpecBase {
       }
 
       "have a caption for an agent view" in {
-        agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
+        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        caption.text mustBe "Group: orgName ID: XMPLR0123456789"
+        caption.hasClass("govuk-caption-m") mustBe true
+        caption.hasClass("hmrc-caption-m") mustBe true
       }
 
       "have a h1 heading" in {

--- a/test/views/repayments/RequestRefundAmountViewSpec.scala
+++ b/test/views/repayments/RequestRefundAmountViewSpec.scala
@@ -46,7 +46,7 @@ class RequestRefundAmountViewSpec extends ViewSpecBase {
       }
 
       "have a caption for an agent view" in {
-        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        val caption: Element = agentView.select("h2.hmrc-caption-m").first()
         caption.text mustBe "Group: orgName ID: XMPLR0123456789"
         caption.hasClass("govuk-caption-m") mustBe true
         caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/repayments/RequestRefundBeforeStartViewSpec.scala
+++ b/test/views/repayments/RequestRefundBeforeStartViewSpec.scala
@@ -19,7 +19,7 @@ package views.repayments
 import base.ViewSpecBase
 import controllers.routes
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
+import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
 import views.behaviours.ViewScenario
 import views.html.repayments.RequestRefundBeforeStartView
@@ -39,7 +39,10 @@ class RequestRefundBeforeStartViewSpec extends ViewSpecBase {
     }
 
     "have a caption for an agent view" in {
-      agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
+      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      caption.text mustBe "Group: orgName ID: XMPLR0123456789"
+      caption.hasClass("govuk-caption-m") mustBe true
+      caption.hasClass("hmrc-caption-m") mustBe true
     }
 
     "have a h1 heading" in {

--- a/test/views/repayments/RequestRefundBeforeStartViewSpec.scala
+++ b/test/views/repayments/RequestRefundBeforeStartViewSpec.scala
@@ -39,7 +39,7 @@ class RequestRefundBeforeStartViewSpec extends ViewSpecBase {
     }
 
     "have a caption for an agent view" in {
-      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      val caption: Element = agentView.select("h2.hmrc-caption-m").first()
       caption.text mustBe "Group: orgName ID: XMPLR0123456789"
       caption.hasClass("govuk-caption-m") mustBe true
       caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/repayments/UkOrAbroadBankAccountViewSpec.scala
+++ b/test/views/repayments/UkOrAbroadBankAccountViewSpec.scala
@@ -47,6 +47,13 @@ class UkOrAbroadBankAccountViewSpec extends ViewSpecBase {
         view.title() mustBe s"$pageTitle - Report Pillar 2 Top-up Taxes - GOV.UK"
       }
 
+      "have a caption for an agent view" in {
+        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        caption.text mustBe s"Group: orgName ID: $plrReference"
+        caption.hasClass("govuk-caption-m") mustBe true
+        caption.hasClass("hmrc-caption-m") mustBe true
+      }
+
       "have a unique H1 heading" in {
         val h1Elements: Elements = view.getElementsByTag("h1")
         h1Elements.size() mustBe 1

--- a/test/views/repayments/UkOrAbroadBankAccountViewSpec.scala
+++ b/test/views/repayments/UkOrAbroadBankAccountViewSpec.scala
@@ -48,7 +48,7 @@ class UkOrAbroadBankAccountViewSpec extends ViewSpecBase {
       }
 
       "have a caption for an agent view" in {
-        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        val caption: Element = agentView.select("h2.hmrc-caption-m").first()
         caption.text mustBe s"Group: orgName ID: $plrReference"
         caption.hasClass("govuk-caption-m") mustBe true
         caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/stoodovercharges/StoodoverChargesViewSpec.scala
+++ b/test/views/stoodovercharges/StoodoverChargesViewSpec.scala
@@ -178,7 +178,7 @@ class StoodoverChargesViewSpec extends ViewSpecBase {
 
   "display agent-specific content" should {
     "have caption" in {
-      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      val caption: Element = agentView.select("h2.hmrc-caption-m").first()
       caption.text mustBe "Group: orgName ID: XMPLR0012345678"
       caption.hasClass("govuk-caption-m") mustBe true
       caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/stoodovercharges/StoodoverChargesViewSpec.scala
+++ b/test/views/stoodovercharges/StoodoverChargesViewSpec.scala
@@ -178,7 +178,10 @@ class StoodoverChargesViewSpec extends ViewSpecBase {
 
   "display agent-specific content" should {
     "have caption" in {
-      agentView.getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0012345678"
+      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      caption.text mustBe "Group: orgName ID: XMPLR0012345678"
+      caption.hasClass("govuk-caption-m") mustBe true
+      caption.hasClass("hmrc-caption-m") mustBe true
     }
   }
 

--- a/test/views/submissionhistory/SubmissionHistoryNoSubmissionsViewSpec.scala
+++ b/test/views/submissionhistory/SubmissionHistoryNoSubmissionsViewSpec.scala
@@ -19,7 +19,7 @@ package views.submissionhistory
 import base.ViewSpecBase
 import controllers.routes
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
+import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
 import views.behaviours.ViewScenario
 import views.html.submissionhistory.SubmissionHistoryNoSubmissionsView
@@ -83,11 +83,17 @@ class SubmissionHistoryNoSubmissionsViewSpec extends ViewSpecBase {
     }
 
     "have correct text for agents at the top of the page" in {
-      agentView.getElementsByClass("govuk-caption-m").get(0).text mustBe s"Group: $orgName ID: $plrRef"
+      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      caption.text mustBe s"Group: $orgName ID: $plrRef"
+      caption.hasClass("govuk-caption-m") mustBe true
+      caption.hasClass("hmrc-caption-m") mustBe true
     }
 
     "show only group ID in the caption when the organisation name is empty" in {
-      agentViewIdOnly.getElementsByClass("govuk-caption-m").get(0).text mustBe s"ID: $plrRef"
+      val caption: Element = agentViewIdOnly.select("h2.no-margin-bottom").first()
+      caption.text mustBe s"ID: $plrRef"
+      caption.hasClass("govuk-caption-m") mustBe true
+      caption.hasClass("hmrc-caption-m") mustBe true
     }
 
     "have a first paragraph" in {

--- a/test/views/submissionhistory/SubmissionHistoryNoSubmissionsViewSpec.scala
+++ b/test/views/submissionhistory/SubmissionHistoryNoSubmissionsViewSpec.scala
@@ -83,14 +83,14 @@ class SubmissionHistoryNoSubmissionsViewSpec extends ViewSpecBase {
     }
 
     "have correct text for agents at the top of the page" in {
-      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      val caption: Element = agentView.select("h2.hmrc-caption-m").first()
       caption.text mustBe s"Group: $orgName ID: $plrRef"
       caption.hasClass("govuk-caption-m") mustBe true
       caption.hasClass("hmrc-caption-m") mustBe true
     }
 
     "show only group ID in the caption when the organisation name is empty" in {
-      val caption: Element = agentViewIdOnly.select("h2.no-margin-bottom").first()
+      val caption: Element = agentViewIdOnly.select("h2.hmrc-caption-m").first()
       caption.text mustBe s"ID: $plrRef"
       caption.hasClass("govuk-caption-m") mustBe true
       caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/submissionhistory/SubmissionHistoryViewSpec.scala
+++ b/test/views/submissionhistory/SubmissionHistoryViewSpec.scala
@@ -138,14 +138,14 @@ class SubmissionHistoryViewSpec extends ViewSpecBase with ObligationsAndSubmissi
     }
 
     "have correct text for agents at the top of the page" in {
-      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      val caption: Element = agentView.select("h2.hmrc-caption-m").first()
       caption.text mustBe s"Group: ${SubmissionHistoryViewSpec.orgName} ID: ${SubmissionHistoryViewSpec.plrRef}"
       caption.hasClass("govuk-caption-m") mustBe true
       caption.hasClass("hmrc-caption-m") mustBe true
     }
 
     "show only group ID in the caption when the organisation name is empty" in {
-      val captionNoOrg: Element = agentViewIdOnly.select("h2.no-margin-bottom").first()
+      val captionNoOrg: Element = agentViewIdOnly.select("h2.hmrc-caption-m").first()
       captionNoOrg.text mustBe s"ID: ${SubmissionHistoryViewSpec.plrRef}"
       captionNoOrg.hasClass("govuk-caption-m") mustBe true
       captionNoOrg.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/submissionhistory/SubmissionHistoryViewSpec.scala
+++ b/test/views/submissionhistory/SubmissionHistoryViewSpec.scala
@@ -138,14 +138,17 @@ class SubmissionHistoryViewSpec extends ViewSpecBase with ObligationsAndSubmissi
     }
 
     "have correct text for agents at the top of the page" in {
-      agentView
-        .getElementsByClass("govuk-caption-m")
-        .get(0)
-        .text mustBe s"Group: ${SubmissionHistoryViewSpec.orgName} ID: ${SubmissionHistoryViewSpec.plrRef}"
+      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      caption.text mustBe s"Group: ${SubmissionHistoryViewSpec.orgName} ID: ${SubmissionHistoryViewSpec.plrRef}"
+      caption.hasClass("govuk-caption-m") mustBe true
+      caption.hasClass("hmrc-caption-m") mustBe true
     }
 
     "show only group ID in the caption when the organisation name is empty" in {
-      agentViewIdOnly.getElementsByClass("govuk-caption-m").get(0).text mustBe s"ID: ${SubmissionHistoryViewSpec.plrRef}"
+      val captionNoOrg: Element = agentViewIdOnly.select("h2.no-margin-bottom").first()
+      captionNoOrg.text mustBe s"ID: ${SubmissionHistoryViewSpec.plrRef}"
+      captionNoOrg.hasClass("govuk-caption-m") mustBe true
+      captionNoOrg.hasClass("hmrc-caption-m") mustBe true
     }
 
     "have a paragraph detailing submission details" in {

--- a/test/views/subscriptionview/manageAccount/AddSecondaryContactViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/AddSecondaryContactViewSpec.scala
@@ -20,7 +20,7 @@ import base.ViewSpecBase
 import controllers.routes
 import forms.AddSecondaryContactFormProvider
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
+import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
 import views.behaviours.ViewScenario
 import views.html.subscriptionview.manageAccount.AddSecondaryContactView
@@ -73,6 +73,16 @@ class AddSecondaryContactViewSpec extends ViewSpecBase {
 
     "have a button" in {
       view.getElementsByClass("govuk-button").text mustBe "Continue"
+    }
+
+    "have agent specific content" in {
+      val agentView = Jsoup.parse(
+        page(formProvider(username), username, isAgent = true, Some("OrgName"), Some("somePillar2Ref"))(request, appConfig, messages).toString()
+      )
+      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      caption.text mustBe "Group: OrgName ID: somePillar2Ref"
+      caption.hasClass("govuk-caption-m") mustBe true
+      caption.hasClass("hmrc-caption-m") mustBe true
     }
 
     val viewScenarios: Seq[ViewScenario] =

--- a/test/views/subscriptionview/manageAccount/AddSecondaryContactViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/AddSecondaryContactViewSpec.scala
@@ -79,7 +79,7 @@ class AddSecondaryContactViewSpec extends ViewSpecBase {
       val agentView = Jsoup.parse(
         page(formProvider(username), username, isAgent = true, Some("OrgName"), Some("somePillar2Ref"))(request, appConfig, messages).toString()
       )
-      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      val caption: Element = agentView.select("h2.hmrc-caption-m").first()
       caption.text mustBe "Group: OrgName ID: somePillar2Ref"
       caption.hasClass("govuk-caption-m") mustBe true
       caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/subscriptionview/manageAccount/AmendAccountingPeriodCYAViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/AmendAccountingPeriodCYAViewSpec.scala
@@ -21,7 +21,7 @@ import controllers.routes
 import helpers.SubscriptionLocalDataFixture
 import models.subscription.AccountingPeriod
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
+import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
 import views.behaviours.ViewScenario
 import views.html.subscriptionview.manageAccount.AmendAccountingPeriodCYAView
@@ -61,7 +61,11 @@ class AmendAccountingPeriodCYAViewSpec extends ViewSpecBase with SubscriptionLoc
     }
 
     "caption for agent view" in {
-      view(isAgent = true).getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
+      val caption: Element = view(isAgent = true).select("h2.no-margin-bottom").first()
+      caption.text mustBe "Group: orgName ID: XMPLR0123456789"
+      caption.hasClass("govuk-caption-m") mustBe true
+      caption.hasClass("hmrc-caption-m") mustBe true
+
     }
 
     "have a unique H1 heading" in {

--- a/test/views/subscriptionview/manageAccount/AmendAccountingPeriodCYAViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/AmendAccountingPeriodCYAViewSpec.scala
@@ -61,7 +61,7 @@ class AmendAccountingPeriodCYAViewSpec extends ViewSpecBase with SubscriptionLoc
     }
 
     "caption for agent view" in {
-      val caption: Element = view(isAgent = true).select("h2.no-margin-bottom").first()
+      val caption: Element = view(isAgent = true).select("h2.hmrc-caption-m").first()
       caption.text mustBe "Group: orgName ID: XMPLR0123456789"
       caption.hasClass("govuk-caption-m") mustBe true
       caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/subscriptionview/manageAccount/AmendAccountingPeriodConfirmationViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/AmendAccountingPeriodConfirmationViewSpec.scala
@@ -141,13 +141,13 @@ class AmendAccountingPeriodConfirmationViewSpec extends ViewSpecBase {
     }
 
     "not show group/ID header for group (non-agent) view" in {
-      val caption = groupView().getElementsByClass("no-margin-bottom")
+      val caption = groupView().getElementsByClass("hmrc-caption-m")
       caption.text() must not include "Group:"
       caption.text() must not include plrReference
     }
 
     "show group/ID header for agent view" in {
-      val caption = agentView().select("h2.no-margin-bottom").first()
+      val caption = agentView().select("h2.hmrc-caption-m").first()
       caption.text() must include("Group:")
       caption.text() must include(plrReference)
       caption.hasClass("govuk-caption-m") mustBe true

--- a/test/views/subscriptionview/manageAccount/AmendAccountingPeriodConfirmationViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/AmendAccountingPeriodConfirmationViewSpec.scala
@@ -141,15 +141,17 @@ class AmendAccountingPeriodConfirmationViewSpec extends ViewSpecBase {
     }
 
     "not show group/ID header for group (non-agent) view" in {
-      val hints = groupView().getElementsByClass("govuk-hint")
-      hints.text() must not include "Group:"
-      hints.text() must not include plrReference
+      val caption = groupView().getElementsByClass("no-margin-bottom")
+      caption.text() must not include "Group:"
+      caption.text() must not include plrReference
     }
 
     "show group/ID header for agent view" in {
-      val hints = agentView().getElementsByClass("govuk-hint")
-      hints.text() must include("Group:")
-      hints.text() must include(plrReference)
+      val caption = agentView().select("h2.no-margin-bottom").first()
+      caption.text() must include("Group:")
+      caption.text() must include(plrReference)
+      caption.hasClass("govuk-caption-m") mustBe true
+      caption.hasClass("hmrc-caption-m") mustBe true
     }
 
     val viewScenarios: Seq[ViewScenario] =

--- a/test/views/subscriptionview/manageAccount/CaptureSubscriptionAddressViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/CaptureSubscriptionAddressViewSpec.scala
@@ -62,10 +62,10 @@ class CaptureSubscriptionAddressViewSpec extends ViewSpecBase with StringGenerat
           ).toString()
         )
 
-        agentView
-          .getElementsByClass("govuk-caption-m")
-          .get(0)
-          .text mustBe s"Group: ${Some("Organisation Inc").value} ID: ${Some("somePillar2Ref").value}"
+        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        caption.text mustBe "Group: Organisation Inc ID: somePillar2Ref"
+        caption.hasClass("govuk-caption-m") mustBe true
+        caption.hasClass("hmrc-caption-m") mustBe true
       }
 
       "have a unique H1 heading" in {

--- a/test/views/subscriptionview/manageAccount/CaptureSubscriptionAddressViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/CaptureSubscriptionAddressViewSpec.scala
@@ -62,7 +62,7 @@ class CaptureSubscriptionAddressViewSpec extends ViewSpecBase with StringGenerat
           ).toString()
         )
 
-        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        val caption: Element = agentView.select("h2.hmrc-caption-m").first()
         caption.text mustBe "Group: Organisation Inc ID: somePillar2Ref"
         caption.hasClass("govuk-caption-m") mustBe true
         caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/subscriptionview/manageAccount/ContactByPhoneViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/ContactByPhoneViewSpec.scala
@@ -63,10 +63,10 @@ class ContactByPhoneViewSpec extends ViewSpecBase with StringGenerators {
           ).toString()
         )
 
-        agentView
-          .getElementsByClass("govuk-caption-m")
-          .get(0)
-          .text mustBe s"Group: ${Some("Organisation Inc").value} ID: ${Some("somePillar2Ref").value}"
+        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        caption.text mustBe "Group: Organisation Inc ID: somePillar2Ref"
+        caption.hasClass("govuk-caption-m") mustBe true
+        caption.hasClass("hmrc-caption-m") mustBe true
       }
 
       "have a unique H1 heading" in {

--- a/test/views/subscriptionview/manageAccount/ContactByPhoneViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/ContactByPhoneViewSpec.scala
@@ -63,7 +63,7 @@ class ContactByPhoneViewSpec extends ViewSpecBase with StringGenerators {
           ).toString()
         )
 
-        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        val caption: Element = agentView.select("h2.hmrc-caption-m").first()
         caption.text mustBe "Group: Organisation Inc ID: somePillar2Ref"
         caption.hasClass("govuk-caption-m") mustBe true
         caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/subscriptionview/manageAccount/ContactCapturePhoneDetailsViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/ContactCapturePhoneDetailsViewSpec.scala
@@ -20,7 +20,7 @@ import base.ViewSpecBase
 import controllers.routes
 import forms.CapturePhoneDetailsFormProvider
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
+import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
 import views.behaviours.ViewScenario
 import views.html.subscriptionview.manageAccount.ContactCapturePhoneDetailsView
@@ -64,6 +64,18 @@ class ContactCapturePhoneDetailsViewSpec extends ViewSpecBase {
 
     "have a 'Continue' button" in {
       view.getElementsByClass("govuk-button").text mustBe "Continue"
+    }
+
+    "have agent specific content" in {
+      lazy val agentView: Document =
+        Jsoup.parse(
+          page(formProvider(username), username, isAgent = true, Some("OrgName"), Some("somePillar2Ref"))(request, appConfig, messages).toString()
+        )
+
+      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      caption.text mustBe "Group: OrgName ID: somePillar2Ref"
+      caption.hasClass("govuk-caption-m") mustBe true
+      caption.hasClass("hmrc-caption-m") mustBe true
     }
 
     val viewScenarios: Seq[ViewScenario] =

--- a/test/views/subscriptionview/manageAccount/ContactCapturePhoneDetailsViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/ContactCapturePhoneDetailsViewSpec.scala
@@ -72,7 +72,7 @@ class ContactCapturePhoneDetailsViewSpec extends ViewSpecBase {
           page(formProvider(username), username, isAgent = true, Some("OrgName"), Some("somePillar2Ref"))(request, appConfig, messages).toString()
         )
 
-      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      val caption: Element = agentView.select("h2.hmrc-caption-m").first()
       caption.text mustBe "Group: OrgName ID: somePillar2Ref"
       caption.hasClass("govuk-caption-m") mustBe true
       caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/subscriptionview/manageAccount/ContactEmailAddressViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/ContactEmailAddressViewSpec.scala
@@ -72,7 +72,7 @@ class ContactEmailAddressViewSpec extends ViewSpecBase {
         ).toString()
       )
 
-      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      val caption: Element = agentView.select("h2.hmrc-caption-m").first()
       caption.text mustBe "Group: Organisation Inc ID: somePillar2Ref"
       caption.hasClass("govuk-caption-m") mustBe true
       caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/subscriptionview/manageAccount/ContactEmailAddressViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/ContactEmailAddressViewSpec.scala
@@ -20,7 +20,7 @@ import base.ViewSpecBase
 import controllers.routes
 import forms.ContactEmailAddressFormProvider
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
+import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
 import play.api.data.Form
 import views.behaviours.ViewScenario
@@ -72,10 +72,10 @@ class ContactEmailAddressViewSpec extends ViewSpecBase {
         ).toString()
       )
 
-      agentView
-        .getElementsByClass("govuk-caption-m")
-        .get(0)
-        .text mustBe s"Group: ${Some("Organisation Inc").value} ID: ${Some("somePillar2Ref").value}"
+      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      caption.text mustBe "Group: Organisation Inc ID: somePillar2Ref"
+      caption.hasClass("govuk-caption-m") mustBe true
+      caption.hasClass("hmrc-caption-m") mustBe true
     }
 
     "have a hint description" in {

--- a/test/views/subscriptionview/manageAccount/ContactNameComplianceViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/ContactNameComplianceViewSpec.scala
@@ -57,7 +57,7 @@ class ContactNameComplianceViewSpec extends ViewSpecBase {
         ).toString()
       )
 
-      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      val caption: Element = agentView.select("h2.hmrc-caption-m").first()
       caption.text mustBe "Group: Organisation Inc ID: somePillar2Ref"
       caption.hasClass("govuk-caption-m") mustBe true
       caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/subscriptionview/manageAccount/ContactNameComplianceViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/ContactNameComplianceViewSpec.scala
@@ -20,7 +20,7 @@ import base.ViewSpecBase
 import controllers.routes
 import forms.ContactNameComplianceFormProvider
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
+import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
 import play.api.data.Form
 import views.behaviours.ViewScenario
@@ -57,10 +57,10 @@ class ContactNameComplianceViewSpec extends ViewSpecBase {
         ).toString()
       )
 
-      agentView
-        .getElementsByClass("govuk-caption-m")
-        .get(0)
-        .text mustBe s"Group: ${Some("Organisation Inc").value} ID: ${Some("somePillar2Ref").value}"
+      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      caption.text mustBe "Group: Organisation Inc ID: somePillar2Ref"
+      caption.hasClass("govuk-caption-m") mustBe true
+      caption.hasClass("hmrc-caption-m") mustBe true
 
     }
 

--- a/test/views/subscriptionview/manageAccount/ManageContactCheckYourAnswersViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/ManageContactCheckYourAnswersViewSpec.scala
@@ -21,7 +21,7 @@ import controllers.routes
 import helpers.SubscriptionLocalDataFixture
 import models.requests.SubscriptionDataRequest
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
+import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
 import play.api.mvc.AnyContent
 import utils.countryOptions.CountryOptions
@@ -196,11 +196,14 @@ class ManageContactCheckYourAnswersViewSpec extends ViewSpecBase with Subscripti
       }
 
       "show the correct caption text at the top of the page" in {
-        agentView.getElementsByClass("govuk-caption-m").get(0).text mustBe s"Group: ${orgName.get} ID: ${plrRef.get}"
+        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        caption.text mustBe s"Group: ${orgName.get} ID: ${plrRef.get}"
+        caption.hasClass("govuk-caption-m") mustBe true
+        caption.hasClass("hmrc-caption-m") mustBe true
       }
 
       "have first contact header" in {
-        agentView.getElementsByTag("h2").first.text mustBe "Primary contact"
+        agentView.getElementsByTag("h2").get(1).text mustBe "Primary contact"
       }
 
       "have a first contact summary list" in {
@@ -226,7 +229,7 @@ class ManageContactCheckYourAnswersViewSpec extends ViewSpecBase with Subscripti
       }
 
       "have second contact header" in {
-        agentView.getElementsByTag("h2").get(1).text mustBe "Secondary contact"
+        agentView.getElementsByTag("h2").get(2).text mustBe "Secondary contact"
       }
 
       "have a second contact summary list" in {
@@ -257,7 +260,7 @@ class ManageContactCheckYourAnswersViewSpec extends ViewSpecBase with Subscripti
       }
 
       "have a contact address header" in {
-        agentView.getElementsByTag("h2").get(2).text mustBe "Filing member contact address"
+        agentView.getElementsByTag("h2").get(3).text mustBe "Filing member contact address"
       }
 
       "have an address summary list" in {

--- a/test/views/subscriptionview/manageAccount/ManageContactCheckYourAnswersViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/ManageContactCheckYourAnswersViewSpec.scala
@@ -196,7 +196,7 @@ class ManageContactCheckYourAnswersViewSpec extends ViewSpecBase with Subscripti
       }
 
       "show the correct caption text at the top of the page" in {
-        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        val caption: Element = agentView.select("h2.hmrc-caption-m").first()
         caption.text mustBe s"Group: ${orgName.get} ID: ${plrRef.get}"
         caption.hasClass("govuk-caption-m") mustBe true
         caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/subscriptionview/manageAccount/ManageGroupDetailsMultiPeriodViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/ManageGroupDetailsMultiPeriodViewSpec.scala
@@ -86,7 +86,7 @@ class ManageGroupDetailsMultiPeriodViewSpec extends ViewSpecBase {
           )(request, appConfig, messages).toString()
         )
 
-        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        val caption: Element = agentView.select("h2.hmrc-caption-m").first()
         caption.text mustBe "Group: ABC Group ID: XMPLR0123456789"
         caption.hasClass("govuk-caption-m") mustBe true
         caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/subscriptionview/manageAccount/ManageGroupDetailsMultiPeriodViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/ManageGroupDetailsMultiPeriodViewSpec.scala
@@ -18,7 +18,7 @@ package views.subscriptionview.manageAccount
 
 import base.ViewSpecBase
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
+import org.jsoup.nodes.{Document, Element}
 import views.html.subscriptionview.manageAccount.ManageGroupDetailsMultiPeriodView
 
 class ManageGroupDetailsMultiPeriodViewSpec extends ViewSpecBase {
@@ -75,7 +75,7 @@ class ManageGroupDetailsMultiPeriodViewSpec extends ViewSpecBase {
 
     "rendering agent view" must {
       "show group header with name and ID" in {
-        val view: Document = Jsoup.parse(
+        val agentView: Document = Jsoup.parse(
           page(
             locationMessageKey = "mneOrDomestic.uk",
             periodCards = Seq.empty,
@@ -86,7 +86,10 @@ class ManageGroupDetailsMultiPeriodViewSpec extends ViewSpecBase {
           )(request, appConfig, messages).toString()
         )
 
-        view.text() must include("Group: ABC Group ID: XMPLR0123456789")
+        val caption: Element = agentView.select("h2.no-margin-bottom").first()
+        caption.text mustBe "Group: ABC Group ID: XMPLR0123456789"
+        caption.hasClass("govuk-caption-m") mustBe true
+        caption.hasClass("hmrc-caption-m") mustBe true
       }
     }
   }

--- a/test/views/subscriptionview/manageAccount/NewAccountingPeriodViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/NewAccountingPeriodViewSpec.scala
@@ -233,12 +233,12 @@ class NewAccountingPeriodViewSpec extends ViewSpecBase {
       }
 
       "have a caption" in {
-        val caption: Element = agentView().select("h2.no-margin-bottom").first()
+        val caption: Element = agentView().select("h2.hmrc-caption-m").first()
         caption.text mustBe "Group: orgName ID: XMPLR0123456789"
         caption.hasClass("govuk-caption-m") mustBe true
         caption.hasClass("hmrc-caption-m") mustBe true
 
-        val captionNoOrg: Element = agentNoOrgView().select("h2.no-margin-bottom").first()
+        val captionNoOrg: Element = agentNoOrgView().select("h2.hmrc-caption-m").first()
         captionNoOrg.text mustBe "ID: XMPLR0123456789"
         captionNoOrg.hasClass("govuk-caption-m") mustBe true
         captionNoOrg.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/subscriptionview/manageAccount/NewAccountingPeriodViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/NewAccountingPeriodViewSpec.scala
@@ -233,8 +233,15 @@ class NewAccountingPeriodViewSpec extends ViewSpecBase {
       }
 
       "have a caption" in {
-        agentView().getElementsByClass("govuk-caption-m").text mustBe "Group: orgName ID: XMPLR0123456789"
-        agentNoOrgView().getElementsByClass("govuk-caption-m").text mustBe "ID: XMPLR0123456789"
+        val caption: Element = agentView().select("h2.no-margin-bottom").first()
+        caption.text mustBe "Group: orgName ID: XMPLR0123456789"
+        caption.hasClass("govuk-caption-m") mustBe true
+        caption.hasClass("hmrc-caption-m") mustBe true
+
+        val captionNoOrg: Element = agentNoOrgView().select("h2.no-margin-bottom").first()
+        captionNoOrg.text mustBe "ID: XMPLR0123456789"
+        captionNoOrg.hasClass("govuk-caption-m") mustBe true
+        captionNoOrg.hasClass("hmrc-caption-m") mustBe true
       }
 
       "have a unique H1 heading" in {

--- a/test/views/subscriptionview/manageAccount/SecondaryContactEmailViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/SecondaryContactEmailViewSpec.scala
@@ -72,7 +72,7 @@ class SecondaryContactEmailViewSpec extends ViewSpecBase {
         ).toString()
       )
 
-      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      val caption: Element = agentView.select("h2.hmrc-caption-m").first()
       caption.text mustBe s"Group: ${Some("Organisation Inc").value} ID: ${Some("somePillar2Ref").value}"
       caption.hasClass("govuk-caption-m") mustBe true
       caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/subscriptionview/manageAccount/SecondaryContactEmailViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/SecondaryContactEmailViewSpec.scala
@@ -20,7 +20,7 @@ import base.ViewSpecBase
 import controllers.routes
 import forms.SecondaryContactEmailFormProvider
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
+import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
 import play.api.data.Form
 import views.behaviours.ViewScenario
@@ -72,10 +72,10 @@ class SecondaryContactEmailViewSpec extends ViewSpecBase {
         ).toString()
       )
 
-      agentView
-        .getElementsByClass("govuk-caption-m")
-        .get(0)
-        .text mustBe s"Group: ${Some("Organisation Inc").value} ID: ${Some("somePillar2Ref").value}"
+      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      caption.text mustBe s"Group: ${Some("Organisation Inc").value} ID: ${Some("somePillar2Ref").value}"
+      caption.hasClass("govuk-caption-m") mustBe true
+      caption.hasClass("hmrc-caption-m") mustBe true
     }
 
     "have a hint description" in {

--- a/test/views/subscriptionview/manageAccount/SecondaryContactNameViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/SecondaryContactNameViewSpec.scala
@@ -20,7 +20,7 @@ import base.ViewSpecBase
 import controllers.routes
 import forms.SecondaryContactNameFormProvider
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
+import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
 import play.api.data.Form
 import views.behaviours.ViewScenario
@@ -58,10 +58,10 @@ class SecondaryContactNameViewSpec extends ViewSpecBase {
         ).toString()
       )
 
-      agentView
-        .getElementsByClass("govuk-caption-m")
-        .get(0)
-        .text mustBe s"Group: ${Some("Organisation Inc").value} ID: ${Some("somePillar2Ref").value}"
+      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      caption.text mustBe s"Group: ${Some("Organisation Inc").value} ID: ${Some("somePillar2Ref").value}"
+      caption.hasClass("govuk-caption-m") mustBe true
+      caption.hasClass("hmrc-caption-m") mustBe true
     }
 
     "display the main heading asking for alternative contact details" in {

--- a/test/views/subscriptionview/manageAccount/SecondaryContactNameViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/SecondaryContactNameViewSpec.scala
@@ -58,7 +58,7 @@ class SecondaryContactNameViewSpec extends ViewSpecBase {
         ).toString()
       )
 
-      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      val caption: Element = agentView.select("h2.hmrc-caption-m").first()
       caption.text mustBe s"Group: ${Some("Organisation Inc").value} ID: ${Some("somePillar2Ref").value}"
       caption.hasClass("govuk-caption-m") mustBe true
       caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/subscriptionview/manageAccount/SecondaryPhonePreferenceViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/SecondaryPhonePreferenceViewSpec.scala
@@ -62,10 +62,10 @@ class SecondaryPhonePreferenceViewSpec extends ViewSpecBase with StringGenerator
         ).toString()
       )
 
-      agentView
-        .getElementsByClass("govuk-caption-m")
-        .get(0)
-        .text mustBe s"Group: ${Some("Organisation Inc").value} ID: ${Some("somePillar2Ref").value}"
+      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      caption.text mustBe s"Group: ${Some("Organisation Inc").value} ID: ${Some("somePillar2Ref").value}"
+      caption.hasClass("govuk-caption-m") mustBe true
+      caption.hasClass("hmrc-caption-m") mustBe true
     }
 
     "have a unique H1 heading" in {

--- a/test/views/subscriptionview/manageAccount/SecondaryPhonePreferenceViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/SecondaryPhonePreferenceViewSpec.scala
@@ -62,7 +62,7 @@ class SecondaryPhonePreferenceViewSpec extends ViewSpecBase with StringGenerator
         ).toString()
       )
 
-      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      val caption: Element = agentView.select("h2.hmrc-caption-m").first()
       caption.text mustBe s"Group: ${Some("Organisation Inc").value} ID: ${Some("somePillar2Ref").value}"
       caption.hasClass("govuk-caption-m") mustBe true
       caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/subscriptionview/manageAccount/SecondaryPhoneViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/SecondaryPhoneViewSpec.scala
@@ -71,7 +71,7 @@ class SecondaryPhoneViewSpec extends ViewSpecBase {
       val agentView = Jsoup.parse(
         page(formProvider(username), username, isAgent = true, Some("OrgName"), Some("somePillar2Ref"))(request, appConfig, messages).toString()
       )
-      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      val caption: Element = agentView.select("h2.hmrc-caption-m").first()
       caption.text mustBe "Group: OrgName ID: somePillar2Ref"
       caption.hasClass("govuk-caption-m") mustBe true
       caption.hasClass("hmrc-caption-m") mustBe true

--- a/test/views/subscriptionview/manageAccount/SecondaryPhoneViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/SecondaryPhoneViewSpec.scala
@@ -20,7 +20,7 @@ import base.ViewSpecBase
 import controllers.routes
 import forms.CapturePhoneDetailsFormProvider
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
+import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
 import views.behaviours.ViewScenario
 import views.html.subscriptionview.manageAccount.SecondaryPhoneView
@@ -65,6 +65,16 @@ class SecondaryPhoneViewSpec extends ViewSpecBase {
 
     "have a button" in {
       view.getElementsByClass("govuk-button").text mustBe "Continue"
+    }
+
+    "have agent specific content" in {
+      val agentView = Jsoup.parse(
+        page(formProvider(username), username, isAgent = true, Some("OrgName"), Some("somePillar2Ref"))(request, appConfig, messages).toString()
+      )
+      val caption: Element = agentView.select("h2.no-margin-bottom").first()
+      caption.text mustBe "Group: OrgName ID: somePillar2Ref"
+      caption.hasClass("govuk-caption-m") mustBe true
+      caption.hasClass("hmrc-caption-m") mustBe true
     }
 
     val viewScenarios: Seq[ViewScenario] =


### PR DESCRIPTION
Issue found on the following pages: Transaction history; Outstanding payments; Stoodover charges
Problem: The heading captions have been added in a `<span>` above the` <h1>` so may be missed by screen readers.
Fran looked and suggested: It may be that all our captions are `<span><strong>caption</strong></span>` and therefore not in pattern.

Resolution: https://design.tax.service.gov.uk/hmrc-design-patterns/page-heading/#section-heading
`<h2 class="govuk-caption-m hmrc-caption-m"><span class="govuk-!-font-weight-bold">Group:</span> ABC Company <span class="govuk-!-font-weight-bold">ID:</span> XMPLR0123456789</h2> is the GDS pattern, Fran suggests that we do this to fix.`

Implement the fix across all agent pages