### PR TITLE
PIL-2950 Minor Scalafmt/Scalafix changes

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -3,16 +3,11 @@ rules = [ExplicitResultTypes, OrganizeImports, RemoveUnused, DisableSyntax]
 OrganizeImports {
   targetDialect = Scala3
   groupedImports = Keep
-  coalesceToWildcardImportThreshold = 3
+  coalesceToWildcardImportThreshold = 5
 }
 
 DisableSyntax {
   noVars = true
   noNulls = true
   noReturns = true
-  regex = [{
-    id = implicits
-    pattern = "implicit "
-    message = "Prefer using & given keywords instead. The implicit keyword is scheduled for deprecation."
-  }]
 }

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -6,7 +6,7 @@ lineEndings = unix
 importSelectors = singleLine
 
 align {
-  preset = most
+  preset = more
   tokens = [{code = "=>", owner = "Case|Type.Arg.ByName"}, "=", "<-", "->", "%", "%%", "should", "shouldBe", "must", ":"]
   arrowEnumeratorGenerator = true
   openParenCallSite = false

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,19 +1,13 @@
-version = 3.9.10
+version = 3.11.1
 runner.dialect = scala3
 style = defaultWithAlign
 maxColumn = 150
 lineEndings = unix
 importSelectors = singleLine
-rewrite.scala3.convertToNewSyntax = true
-
-project {
-  git = true
-}
-
-align = most
 
 align {
-  tokens = [ {code = "=>", owner = "Case|Type.Arg.ByName"}, "=", "<-", "->", "%", "%%", "should", "shouldBe", "must", ":" ]
+  preset = most
+  tokens = [{code = "=>", owner = "Case|Type.Arg.ByName"}, "=", "<-", "->", "%", "%%", "should", "shouldBe", "must", ":"]
   arrowEnumeratorGenerator = true
   openParenCallSite = false
   openParenDefnSite = false
@@ -33,7 +27,12 @@ newlines {
   sometimesBeforeColonInMethodReturnType = true
 }
 
+project {
+  git = true
+}
+
 rewrite {
+  scala3.convertToNewSyntax = true
   rules = [RedundantBraces, RedundantParens, AsciiSortImports]
   redundantBraces {
     maxLines = 100

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,6 @@ ThisBuild / scalaVersion := "3.3.5"
 ThisBuild / majorVersion := 0
 ThisBuild / useSuperShell := false
 ThisBuild / semanticdbEnabled := true
-ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 
 lazy val root: Project = (project in file("."))
   .enablePlugins(PlayScala, SbtDistributablesPlugin)


### PR DESCRIPTION
- Removed scalafixSemanticdb.revision (not needed in Scala 3). 
- Bumped scalafmt formatter version