### PR TITLE
PIL-3167 Fixes to backend propagating 422 and not sending 500s

### DIFF
--- a/app/connectors/SubscriptionConnector.scala
+++ b/app/connectors/SubscriptionConnector.scala
@@ -201,6 +201,9 @@ class SubscriptionConnector @Inject() (val config: FrontendAppConfig, val http: 
           case OK =>
             logger.info(s"amendSubscriptionV2 - success")
             Done.toFuture
+          case UNPROCESSABLE_ENTITY =>
+            logger.warn(s"amendSubscriptionV2 - 422")
+            Future.failed(UnprocessableEntityError)
           case error =>
             logger.warn(s"amendSubscriptionV2 - $error")
             Future.failed(UnexpectedResponse)

--- a/app/controllers/rfm/RfmContactCheckYourAnswersController.scala
+++ b/app/controllers/rfm/RfmContactCheckYourAnswersController.scala
@@ -20,11 +20,11 @@ import cats.implicits.*
 import config.FrontendAppConfig
 import connectors.UserAnswersConnectors
 import controllers.actions.*
+import models.*
 import models.longrunningsubmissions.LongRunningSubmission.RFM
 import models.rfm.RfmStatus.*
 import models.rfm.{CorporatePosition, RfmStatus}
 import models.subscription.NewFilingMemberDetail
-import models.{InternalIssueError, UnexpectedResponse, UserAnswers}
 import pages.{PlrReferencePage, RfmConfirmationPage, RfmStatusPage}
 import play.api.Logging
 import play.api.i18n.{I18nSupport, MessagesApi}
@@ -127,7 +127,7 @@ class RfmContactCheckYourAnswersController @Inject() (
           case _            => Future.successful(FailException)
         }
         .recover {
-          case InternalIssueError | UnexpectedResponse => FailedInternalIssueError
+          case InternalIssueError | UnexpectedResponse | UnprocessableEntityError => FailedInternalIssueError
           case _: Exception => FailException
         }
       for {

--- a/app/controllers/subscription/manageAccount/ManageContactCheckYourAnswersController.scala
+++ b/app/controllers/subscription/manageAccount/ManageContactCheckYourAnswersController.scala
@@ -169,6 +169,9 @@ class ManageContactCheckYourAnswersController @Inject() (
         case UnexpectedResponse =>
           logger.error(s"[ManageContactCheckYourAnswers] Subscription update failed for $userId due to UnexpectedResponse")
           setStatusOnFailure(userId, ManageContactDetailsStatus.FailException)
+        case UnprocessableEntityError =>
+          logger.error(s"[ManageContactCheckYourAnswers] Subscription update failed for $userId due to UnprocessableEntityError")
+          setStatusOnFailure(userId, ManageContactDetailsStatus.FailedInternalIssueError)
         case e: Exception =>
           logger.error(s"[ManageContactCheckYourAnswers] Subscription update failed for $userId due to generic Exception: ${e.getMessage}", e)
           setStatusOnFailure(userId, ManageContactDetailsStatus.FailException)

--- a/app/controllers/subscription/manageAccount/ManageGroupDetailsCheckYourAnswersController.scala
+++ b/app/controllers/subscription/manageAccount/ManageGroupDetailsCheckYourAnswersController.scala
@@ -223,6 +223,9 @@ class ManageGroupDetailsCheckYourAnswersController @Inject() (
         case InternalIssueError =>
           logger.error(s"[ManageGroupDetailsCheckYourAnswers] Subscription update failed for $userId due to InternalIssueError")
           setStatusOnFailure(userId, ManageGroupDetailsStatus.FailedInternalIssueError)
+        case UnprocessableEntityError =>
+          logger.error(s"[ManageGroupDetailsCheckYourAnswers] Subscription update failed for $userId due to UnprocessableEntityError")
+          setStatusOnFailure(userId, ManageGroupDetailsStatus.FailedInternalIssueError)
         case e: Exception =>
           logger.error(s"[ManageGroupDetailsCheckYourAnswers] Subscription update failed for $userId: ${e.getMessage}")
           setStatusOnFailure(userId, ManageGroupDetailsStatus.FailException)

--- a/app/controllers/subscription/manageAccount/MneOrDomesticController.scala
+++ b/app/controllers/subscription/manageAccount/MneOrDomesticController.scala
@@ -21,7 +21,7 @@ import connectors.SubscriptionConnector
 import controllers.actions.*
 import forms.MneOrDomesticFormProvider
 import models.EntityLocationChangeResult.{EntityLocationChangeAllowed, EntityLocationChangeBlocked}
-import models.MneOrDomestic
+import models.{InternalIssueError, MneOrDomestic, UnprocessableEntityError}
 import navigation.AmendSubscriptionNavigator
 import pages.SubMneOrDomesticPage
 import play.api.Logging
@@ -75,14 +75,22 @@ class MneOrDomesticController @Inject() (
           newMneOrDomesticValue =>
             MneOrDomestic.handleEntityLocationChange(from = request.subscriptionLocalData.subMneOrDomestic, to = newMneOrDomesticValue) match {
               case EntityLocationChangeAllowed =>
-                logger.info(s"Allowed entity location change from ${request.subscriptionLocalData.subMneOrDomestic} to $newMneOrDomesticValue")
-                for {
+                logger.info(
+                  s"MneOrDomestic allowed entity location change from ${request.subscriptionLocalData.subMneOrDomestic} to $newMneOrDomesticValue"
+                )
+                (for {
                   updatedAnswers <- Future.fromTry(request.subscriptionLocalData.set(SubMneOrDomesticPage, newMneOrDomesticValue))
                   _              <- subscriptionService.amendContactOrGroupDetails(request.userId, updatedAnswers.plrReference, updatedAnswers)
                   _              <- subscriptionConnector.save(request.userId, Json.toJson(updatedAnswers))
-                } yield Redirect(navigator.nextPage(SubMneOrDomesticPage, updatedAnswers))
+                } yield Redirect(navigator.nextPage(SubMneOrDomesticPage, updatedAnswers))).recover {
+                  case e @ (UnprocessableEntityError | InternalIssueError) =>
+                    logger.warn(s"MneOrDomestic amend failed for ${request.userId}: ${e.getClass.getSimpleName}")
+                    Redirect(controllers.routes.ViewAmendSubscriptionFailedController.onPageLoad())
+                }
               case EntityLocationChangeBlocked =>
-                logger.info(s"Blocked entity location change from ${request.subscriptionLocalData.subMneOrDomestic} to $newMneOrDomesticValue")
+                logger.info(
+                  s"MneOrDomestic blocked entity location change from ${request.subscriptionLocalData.subMneOrDomestic} to $newMneOrDomesticValue"
+                )
                 Future.successful(Redirect(controllers.subscription.manageAccount.routes.MneToDomesticController.onPageLoad()))
             }
         )

--- a/test/connectors/SubscriptionConnectorSpec.scala
+++ b/test/connectors/SubscriptionConnectorSpec.scala
@@ -292,10 +292,16 @@ class SubscriptionConnectorSpec extends SpecBase with WireMockServerHandler {
         connector.amendSubscriptionV2(id, amendV2Data).futureValue mustBe Done
       }
 
-      "fail with UnexpectedResponse when the backend has returned a non-success status code" in {
+      "fail with UnprocessableEntityError when the backend has returned a 422 status" in {
+        stubResponseForPutRequest(s"$amendSubscriptionV2/$id", UNPROCESSABLE_ENTITY, None)
+        connector.amendSubscriptionV2(id, amendV2Data).failed.futureValue mustEqual UnprocessableEntityError
+      }
+
+      "fail with UnexpectedResponse when the backend has returned a non-success and no 422 status code" in {
         stubResponseForPutRequest(s"$amendSubscriptionV2/$id", errorCodes.sample.value, None)
         connector.amendSubscriptionV2(id, amendV2Data).failed.futureValue mustEqual UnexpectedResponse
       }
+
     }
   }
 

--- a/test/controllers/rfm/RfmContactCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/rfm/RfmContactCheckYourAnswersControllerSpec.scala
@@ -740,6 +740,47 @@ class RfmContactCheckYourAnswersControllerSpec extends SpecBase with SummaryList
         }
       }
 
+      "redirect to waiting page in case of a FailedInternalIssueError, if amend filing details fails with UnprocessableEntityError, and save the API response in the backend" in {
+        val setCount        = new AtomicInteger(0)
+        val secondSetCalled = Promise[Unit]()
+        val ua              = rfmNoID
+          .setOrException(RfmPillar2ReferencePage, "id")
+          .setOrException(RfmRegistrationDatePage, LocalDate.now())
+        val sessionData = emptyUserAnswers
+          .setOrException(RfmStatusPage, FailedInternalIssueError)
+        val application = applicationBuilder(userAnswers = Some(ua))
+          .overrides(
+            bind[SubscriptionService].toInstance(mockSubscriptionService),
+            bind[UserAnswersConnectors].toInstance(mockUserAnswersConnectors),
+            bind[SessionRepository].toInstance(mockSessionRepository)
+          )
+          .build()
+        when(mockSubscriptionService.readSubscription(any())(using any())).thenReturn(Future.successful(subscriptionData))
+        when(
+          mockSubscriptionService.createAmendObjectForReplacingFilingMember(any[SubscriptionData], any[NewFilingMemberDetail], any[UserAnswers])(using
+            any()
+          )
+        ).thenReturn(Future.successful(amendSubscriptionDataV2))
+        when(mockSubscriptionService.amendFilingMemberDetails(any(), any[AmendSubscriptionV2])(using any()))
+          .thenReturn(Future.failed(UnprocessableEntityError))
+        when(mockSessionRepository.set(any())).thenAnswer { (_: InvocationOnMock) =>
+          if setCount.incrementAndGet() == 2 then secondSetCalled.trySuccess(())
+          Future.successful(true)
+        }
+        when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(sessionData)))
+
+        running(application) {
+          val controller = buildController(application, ua, mockSessionRepository)
+          val request    = FakeRequest(POST, controllers.rfm.routes.RfmContactCheckYourAnswersController.onSubmit().url)
+          val result     = controller.onSubmit()(request)
+          await(result)
+          status(result) mustEqual SEE_OTHER
+          redirectLocation(result).value mustEqual routes.WaitingRoomController.onPageLoad(LongRunningSubmission.RFM).url
+          Await.ready(secondSetCalled.future, 15.seconds)
+          verify(mockSessionRepository).set(eqTo(sessionData))
+        }
+      }
+
       "redirect to incomplete data page if they have only partially completed their application" in {
         val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
         running(application) {

--- a/test/controllers/subscription/manageAccount/ManageContactCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/subscription/manageAccount/ManageContactCheckYourAnswersControllerSpec.scala
@@ -446,6 +446,53 @@ class ManageContactCheckYourAnswersControllerSpec extends SpecBase with SummaryL
         }
       }
 
+      "handle UnprocessableEntityError during submission" in {
+        val mockSessionRepository            = mock[SessionRepository]
+        val userAnswers                      = UserAnswers("id")
+        val initialUserAnswersWithInProgress = userAnswers.setOrException(ManageContactDetailsStatusPage, ManageContactDetailsStatus.InProgress)
+
+        val finalUserAnswersWithFailedInternalIssueError =
+          userAnswers.setOrException(ManageContactDetailsStatusPage, ManageContactDetailsStatus.FailedInternalIssueError)
+
+        when(mockSessionRepository.get(userAnswers.id))
+          .thenReturn(Future.successful(Some(userAnswers)))
+          .thenReturn(Future.successful(Some(initialUserAnswersWithInProgress)))
+
+        val finalSetDone = Promise[Unit]()
+        when(mockSessionRepository.set(initialUserAnswersWithInProgress)).thenReturn(Future.successful(true))
+        when(mockSessionRepository.set(finalUserAnswersWithFailedInternalIssueError)).thenAnswer { (_: InvocationOnMock) =>
+          finalSetDone.trySuccess(())
+          Future.successful(true)
+        }
+
+        when(mockSubscriptionService.amendContactOrGroupDetails(any(), any(), any[SubscriptionLocalData])(using any()))
+          .thenReturn(Future.failed(UnprocessableEntityError))
+
+        val application = applicationBuilder(
+          userAnswers = Some(userAnswers),
+          subscriptionLocalData = Some(amendSubscription),
+          enrolments = enrolments
+        )
+          .overrides(
+            bind[SessionRepository].toInstance(mockSessionRepository),
+            bind[SubscriptionService].toInstance(mockSubscriptionService)
+          )
+          .build()
+
+        running(application) {
+          val request = FakeRequest(POST, routes.ManageContactCheckYourAnswersController.onSubmit().url)
+          val result  = route(application, request).value
+
+          await(result)
+          status(result) mustEqual SEE_OTHER
+          redirectLocation(result).value mustEqual controllers.routes.WaitingRoomController.onPageLoad(ManageContactDetails).url
+
+          Await.ready(finalSetDone.future, 15.seconds)
+          verify(mockSessionRepository).set(org.mockito.ArgumentMatchers.eq(initialUserAnswersWithInProgress))
+          verify(mockSessionRepository).set(org.mockito.ArgumentMatchers.eq(finalUserAnswersWithFailedInternalIssueError))
+        }
+      }
+
       "handle InternalIssueError during submission" in {
         val mockSessionRepository            = mock[SessionRepository]
         val userAnswers                      = UserAnswers("id")

--- a/test/controllers/subscription/manageAccount/ManageGroupDetailCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/subscription/manageAccount/ManageGroupDetailCheckYourAnswersControllerSpec.scala
@@ -17,15 +17,17 @@
 package controllers.subscription.manageAccount
 
 import base.SpecBase
+import controllers.payments.OutstandingPaymentsControllerSpec.enrolments
 import controllers.routes
 import controllers.subscription.manageAccount.routes as manageRoutes
 import forms.mappings.Mappings
 import helpers.AllMocks
-import models.UserAnswers
 import models.longrunningsubmissions.LongRunningSubmission.ManageGroupDetails
 import models.subscription.ManageGroupDetailsStatus
+import models.{UnprocessableEntityError, UserAnswers}
 import org.mockito.ArgumentMatchers.{any, argThat}
 import org.mockito.Mockito.{reset, verify, when}
+import org.mockito.invocation.InvocationOnMock
 import org.scalatest.concurrent.ScalaFutures
 import pages.ManageGroupDetailsStatusPage
 import play.api.inject.bind
@@ -37,7 +39,8 @@ import repositories.SessionRepository
 import services.SubscriptionService
 import views.html.subscriptionview.manageAccount.ManageGroupDetailsCheckYourAnswersView
 
-import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, Future, Promise}
 
 class ManageGroupDetailCheckYourAnswersControllerSpec extends SpecBase with ScalaFutures with Mappings with AllMocks {
 
@@ -51,9 +54,9 @@ class ManageGroupDetailCheckYourAnswersControllerSpec extends SpecBase with Scal
 
   "ManageGroupDetailsCheckYourAnswersController" when {
 
-    "onPageLoad" when {
+    "onPageLoad" must {
 
-      "must return OK and the correct view if all answers are complete" in {
+      "return OK and the correct view if all answers are complete" in {
         when(mockSessionRepository.get(any()))
           .thenReturn(Future.successful(Some(emptyUserAnswers)))
         when(mockView.apply(any(), any(), any())(using any(), any(), any())).thenReturn(fakeView)
@@ -74,7 +77,7 @@ class ManageGroupDetailCheckYourAnswersControllerSpec extends SpecBase with Scal
         }
       }
 
-      "must redirect to journey recovery if no user answers are available" in {
+      "redirect to journey recovery if no user answers are available" in {
         when(mockSessionRepository.get(any()))
           .thenReturn(Future.successful(None))
 
@@ -94,7 +97,7 @@ class ManageGroupDetailCheckYourAnswersControllerSpec extends SpecBase with Scal
         }
       }
 
-      "must redirect to waiting room when status is InProgress" in {
+      "redirect to waiting room when status is InProgress" in {
         val userAnswers = emptyUserAnswers
           .setOrException(ManageGroupDetailsStatusPage, ManageGroupDetailsStatus.InProgress)
 
@@ -121,7 +124,7 @@ class ManageGroupDetailCheckYourAnswersControllerSpec extends SpecBase with Scal
         }
       }
 
-      "must display the check your answers page for any non-InProgress status" in {
+      "display the check your answers page for any non-InProgress status" in {
         val userAnswers = emptyUserAnswers
 
         when(mockSessionRepository.get(any()))
@@ -145,7 +148,7 @@ class ManageGroupDetailCheckYourAnswersControllerSpec extends SpecBase with Scal
         }
       }
 
-      "must redirect to Journey Recovery when no session data exists" in {
+      "redirect to Journey Recovery when no session data exists" in {
         when(mockSessionRepository.get(any()))
           .thenReturn(Future.successful(None))
 
@@ -214,6 +217,43 @@ class ManageGroupDetailCheckYourAnswersControllerSpec extends SpecBase with Scal
           })
         }
       }
+
+      "redirect to waiting room when amend fails with UnprocessableEntityError" in {
+        val failedAnswers = emptyUserAnswers.setOrException(ManageGroupDetailsStatusPage, ManageGroupDetailsStatus.FailedInternalIssueError)
+
+        val failureSet = Promise[Unit]()
+        when(mockSessionRepository.get(any())).thenReturn(Future.successful(Some(emptyUserAnswers)))
+        when(mockSessionRepository.set(any())).thenReturn(Future.successful(true))
+        when(mockSessionRepository.set(failedAnswers)).thenAnswer { (_: InvocationOnMock) =>
+          failureSet.trySuccess(())
+          Future.successful(true)
+        }
+        when(mockSubscriptionService.amendContactOrGroupDetails(any(), any(), any())(using any()))
+          .thenReturn(Future.failed(UnprocessableEntityError))
+
+        val application = applicationBuilder(
+          userAnswers = Some(emptyUserAnswers),
+          subscriptionLocalData = Some(emptySubscriptionLocalData),
+          enrolments = enrolments
+        )
+          .overrides(
+            bind[SessionRepository].toInstance(mockSessionRepository),
+            bind[SubscriptionService].toInstance(mockSubscriptionService)
+          )
+          .build()
+
+        running(application) {
+          val request = FakeRequest(POST, manageRoutes.ManageGroupDetailsCheckYourAnswersController.onSubmit().url).withCSRFToken
+          val result  = route(application, request).value
+
+          status(result) mustEqual SEE_OTHER
+          redirectLocation(result).value mustEqual routes.WaitingRoomController.onPageLoad(ManageGroupDetails).url
+
+          Await.ready(failureSet.future, 15.seconds)
+          verify(mockSessionRepository).set(failedAnswers)
+        }
+      }
+
     }
   }
 }

--- a/test/controllers/subscription/manageAccount/MneOrDomesticControllerSpec.scala
+++ b/test/controllers/subscription/manageAccount/MneOrDomesticControllerSpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import connectors.SubscriptionConnector
 import controllers.actions.TestAuthRetrievals.~
 import forms.MneOrDomesticFormProvider
-import models.MneOrDomestic
+import models.{MneOrDomestic, UnprocessableEntityError}
 import navigation.AmendSubscriptionNavigator
 import org.apache.pekko.Done
 import org.mockito.ArgumentMatchers.{any, eq as eqTo}
@@ -199,6 +199,37 @@ class MneOrDomesticControllerSpec extends SpecBase {
         redirectLocation(result).value mustEqual expectedNextPage.url
         verify(mockSubscriptionConnector).save(eqTo("id"), eqTo(Json.toJson(expectedUserAnswers)))(using any[HeaderCarrier])
         verify(mockNavigator).nextPage(SubMneOrDomesticPage, expectedUserAnswers)
+      }
+    }
+
+    "redirect to the amend-subscription failed page when the backend returns a 422" in {
+      val mockNavigator = mock[AmendSubscriptionNavigator]
+
+      when(mockNavigator.nextPage(any(), any())).thenReturn(expectedNextPage)
+      when(mockSubscriptionConnector.save(any(), any())(using any())).thenReturn(Future.successful(Json.obj()))
+      when(mockSubscriptionService.amendContactOrGroupDetails(any(), any(), any())(using any[HeaderCarrier]))
+        .thenReturn(Future.failed(UnprocessableEntityError))
+
+      val previousData = emptySubscriptionLocalData.setOrException(SubMneOrDomesticPage, MneOrDomestic.Uk)
+
+      val application = applicationBuilder(subscriptionLocalData = Some(previousData))
+        .overrides(
+          bind[AmendSubscriptionNavigator].toInstance(mockNavigator),
+          bind[SubscriptionConnector].toInstance(mockSubscriptionConnector),
+          bind[SubscriptionService].toInstance(mockSubscriptionService)
+        )
+        .build()
+
+      running(application) {
+        val request = FakeRequest(POST, controllers.subscription.manageAccount.routes.MneOrDomesticController.onSubmit().url)
+          .withFormUrlEncodedBody("value" -> MneOrDomestic.Uk.toString)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual controllers.routes.ViewAmendSubscriptionFailedController.onPageLoad().url
+        verify(mockSubscriptionConnector, never()).save(any(), any())(using any[HeaderCarrier])
+        verify(mockNavigator, never()).nextPage(any(), any())
       }
     }
 
@@ -418,6 +449,40 @@ class MneOrDomesticControllerSpec extends SpecBase {
 
         status(result) mustEqual SEE_OTHER
         redirectLocation(result).value mustEqual controllers.subscription.manageAccount.routes.MneToDomesticController.onPageLoad().url
+        verify(mockSubscriptionConnector, never()).save(any(), any())(using any[HeaderCarrier])
+        verify(mockNavigator, never()).nextPage(any(), any())
+      }
+    }
+
+    "redirect to the amend-subscription failed page when the backend returns a 422" in {
+      val mockNavigator = mock[AmendSubscriptionNavigator]
+
+      when(mockNavigator.nextPage(any(), any())).thenReturn(expectedNextPage)
+      when(mockSubscriptionConnector.save(any(), any())(using any())).thenReturn(Future.successful(Json.obj()))
+      when(mockSubscriptionService.amendContactOrGroupDetails(any(), any(), any())(using any[HeaderCarrier]))
+        .thenReturn(Future.failed(UnprocessableEntityError))
+
+      val previousData = emptySubscriptionLocalData.setOrException(SubMneOrDomesticPage, MneOrDomestic.Uk)
+
+      val application = applicationBuilder(subscriptionLocalData = Some(previousData))
+        .overrides(
+          bind[AmendSubscriptionNavigator].toInstance(mockNavigator),
+          bind[SubscriptionConnector].toInstance(mockSubscriptionConnector),
+          bind[SubscriptionService].toInstance(mockSubscriptionService),
+          bind[AuthConnector].toInstance(mockAuthConnector)
+        )
+        .build()
+
+      setupAgentAuth()
+
+      running(application) {
+        val request = FakeRequest(POST, controllers.subscription.manageAccount.routes.MneOrDomesticController.onSubmit().url)
+          .withFormUrlEncodedBody("value" -> MneOrDomestic.Uk.toString)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual controllers.routes.ViewAmendSubscriptionFailedController.onPageLoad().url
         verify(mockSubscriptionConnector, never()).save(any(), any())(using any[HeaderCarrier])
         verify(mockNavigator, never()).nextPage(any(), any())
       }


### PR DESCRIPTION
The backend was sending 500 for non-200 cases. Now it propagates 422s and these are being handled by the frontend.