### PR TITLE
PIL-3174 Added table outline for focus on table-scroll-wrapper

### DIFF
--- a/app/assets/stylesheets/table-scroll-styles.scss
+++ b/app/assets/stylesheets/table-scroll-styles.scss
@@ -4,6 +4,11 @@
     width: 100%;
 }
 
+// Adds outline when the focus is on the table-scroll-wrapper
+.table-scroll-wrapper:focus-visible {
+    outline: 2px solid var(--govuk-focus-text-colour, #0b0c0c);
+}
+
 .govuk-table thead th {
     position: sticky;
     top: 0;


### PR DESCRIPTION
Fix (no) accessibility issue with focus on `table-scroll-wrapper`.
Different browsers implement different colours on focus of the tables.
This PR adds a custom style that overrides the browser default.