### PR TITLE
PIL-3030: Added aria-describedby to link the payment status to the H2 via the payment-status id

### DIFF
--- a/app/views/HomepageView.scala.html
+++ b/app/views/HomepageView.scala.html
@@ -168,18 +168,15 @@
  @if(maybePaymentBannerScenario.isDefined) {
      <div class="card-half-width">
          <div class="govuk-summary-card__title-wrapper card-with-tag">
-             <h2 class="govuk-heading-m govuk-!-margin-0">@messages("homepage.payments.title")</h2>
+             <h2 class="govuk-heading-m govuk-!-margin-0" aria-describedby="payment-status">@messages("homepage.payments.title")</h2>
              @maybePaymentBannerScenario.map {
                  case Outstanding => {
-                     <span class="govuk-tag govuk-tag--red" title="Outstanding payments">
+                     <span class="govuk-tag govuk-tag--red" id="payment-status">
                      @messages("homepage.payments.tags.outstanding")
                      </span>
                  }
                  case Paid => {
-                     <span
-                     class="govuk-tag govuk-tag--green"
-                     aria-label="Paid payments"
-                     title="Paid payments">
+                     <span class="govuk-tag govuk-tag--green" id="payment-status">
                      @messages("homepage.payments.tags.paid")
                      </span>
                  }

--- a/test/views/HomepageViewSpec.scala
+++ b/test/views/HomepageViewSpec.scala
@@ -492,7 +492,10 @@ class HomepageViewSpec extends ViewSpecBase {
       val statusTags: Elements = returnsCard.getElementsByClass("govuk-tag")
       statusTags.size() mustBe 0
 
-      returnsCard.getElementsByTag("h2").first().ownText() mustBe "Payments"
+      val paymentsHeading: Element = returnsCard.getElementsByTag("h2").first()
+      paymentsHeading.ownText() mustBe "Payments"
+      paymentsHeading.hasAttr("aria-describedby") mustBe false
+      Option(returnsCard.getElementById("payment-status")) mustBe empty
 
       paymentsCardLinks.get(0).text() mustBe "View transaction history"
       paymentsCardLinks.get(0).attr("href") mustBe
@@ -530,14 +533,15 @@ class HomepageViewSpec extends ViewSpecBase {
             messages
           ).toString()
         )
-      val returnsCard: Element  = organisationViewWithOutstandingScenario.getElementsByClass("card-half-width").get(1)
-      val statusTags:  Elements = returnsCard.getElementsByClass("govuk-tag--red")
+      val returnsCard: Element = organisationViewWithOutstandingScenario.getElementsByClass("card-half-width").get(1)
 
-      returnsCard.getElementsByTag("h2").first().ownText() mustBe "Payments"
+      val paymentsHeading: Element = returnsCard.getElementsByTag("h2").first()
+      paymentsHeading.ownText() mustBe "Payments"
+      paymentsHeading.attr("aria-describedby") mustBe "payment-status"
 
-      val outstandingTag: Element = statusTags.first()
+      val outstandingTag: Element = returnsCard.getElementById("payment-status")
       outstandingTag.text() mustBe "Outstanding"
-      outstandingTag.attr("title") mustBe "Outstanding payments"
+      outstandingTag.hasClass("govuk-tag--red") mustBe true
     }
 
     "display Payments Paid tag with green style when Paid scenario is provided" in {
@@ -560,15 +564,15 @@ class HomepageViewSpec extends ViewSpecBase {
           )
             .toString()
         )
-      val returnsCard: Element  = organisationViewWithOutstandingScenario.getElementsByClass("card-half-width").get(1)
-      val statusTags:  Elements = returnsCard.getElementsByClass("govuk-tag--green")
+      val returnsCard: Element = organisationViewWithOutstandingScenario.getElementsByClass("card-half-width").get(1)
 
-      returnsCard.getElementsByTag("h2").first().ownText() mustBe "Payments"
+      val paymentsHeading: Element = returnsCard.getElementsByTag("h2").first()
+      paymentsHeading.ownText() mustBe "Payments"
+      paymentsHeading.attr("aria-describedby") mustBe "payment-status"
 
-      val paidTag: Element = statusTags.first()
+      val paidTag: Element = returnsCard.getElementById("payment-status")
       paidTag.text() mustBe "Paid"
-      paidTag.attr("aria-label") mustBe "Paid payments"
-      paidTag.attr("title") mustBe "Paid payments"
+      paidTag.hasClass("govuk-tag--green") mustBe true
     }
 
     val organisationViewScenarios: Seq[ViewScenario] =


### PR DESCRIPTION
Issue description: Status message implementation (P1) on the Pillar 2 Top-up Taxes homepage

Problem: Status message that displayed on the top of the card section next to its heading have multiple issues:
aria-label not allowed on span. As span is not an interactive element it doesn't require an accessible name to be set. Remove redundant aria-label
screen reader users might find it difficult to identify status for each section when they navigate by headings, they will need to navigate to status text separately and might not even realise it is there. The best way is to associate a status message using 'aria-describedbyon' heading that will announce status text, when they navigate to the section/card heading.

Resolution: 1. Remove redundant aria-label on span
2.The best way is to associate a status message using 'aria-describedbyon' heading that will announce status text, when they navigate to the section/card heading.
3. Addidattribute on the status message that will correspond to thearia-describedbyon the heading. See example onTask list pattern