### PR TITLE
PIL-3177: Refactored AmendAccountingPeriodConfirmationView implementation to use ul/li approach instead of dl/dt as requested via accessibility

### DIFF
--- a/app/views/subscriptionview/manageAccount/AmendAccountingPeriodConfirmationView.scala.html
+++ b/app/views/subscriptionview/manageAccount/AmendAccountingPeriodConfirmationView.scala.html
@@ -59,15 +59,13 @@
         @h2(messages("amendAccountingPeriod.confirmation.newPeriod"), size = "m", extraClasses = Seq("govuk-!-margin-bottom-0"))
     }
 
-    <dl class="govuk-summary-list">
+    <ul class="govuk-list">
         @for(period <- newPeriods) {
-            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
-                <dt class="govuk-summary-list__key govuk-!-font-weight-regular govuk-body govuk-!-padding-top-6 govuk-!-padding-bottom-2">
-                    @period.startDate.toDateFormat to @period.endDate.toDateFormat
-                </dt>
-            </div>
+            <li class="govuk-!-font-weight-regular govuk-body govuk-!-padding-top-4 govuk-!-margin-0">
+                @period.startDate.toDateFormat to @period.endDate.toDateFormat
+            </li>
         }
-    </dl>
+    </ul>
 
     @p(messages("amendAccountingPeriod.confirmation.furtherAdjustments"))
 

--- a/test/views/subscriptionview/manageAccount/AmendAccountingPeriodConfirmationViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/AmendAccountingPeriodConfirmationViewSpec.scala
@@ -20,7 +20,7 @@ import base.ViewSpecBase
 import controllers.routes
 import models.subscription.AccountingPeriodV2
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
+import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
 import views.behaviours.ViewScenario
 import views.html.subscriptionview.manageAccount.AmendAccountingPeriodConfirmationView
@@ -101,18 +101,20 @@ class AmendAccountingPeriodConfirmationViewSpec extends ViewSpecBase {
       h2Elements.text() must include("New accounting period")
     }
 
-    "show a single row for one new period with formatted start and end dates" in {
-      val rows = groupView().select(".govuk-summary-list__row")
-      rows.size mustBe 1
-      rows.first().text() must include("1 January 2026 to 31 December 2026")
+    "show a single list item for one new period with formatted start and end dates" in {
+      val list:  Element  = groupView().getElementsByClass("govuk-list").first()
+      val items: Elements = list.getElementsByTag("li")
+      items.size mustBe 1
+      items.first().text() must include("1 January 2026 to 31 December 2026")
     }
 
-    "show multiple rows with formatted start and end dates when multiple new periods exist" in {
-      val doc:  Document = groupView(multipleNewPeriods, hasGapPeriods = true)
-      val rows: Elements = doc.select(".govuk-summary-list__row")
-      rows.size mustBe 2
-      rows.first().text() must include("1 January 2026 to 31 December 2026")
-      rows.get(1).text()  must include("1 July 2025 to 31 December 2025")
+    "show multiple list items with formatted start and end dates when multiple new periods exist" in {
+      val doc:   Document = groupView(multipleNewPeriods, hasGapPeriods = true)
+      val list:  Element  = doc.getElementsByClass("govuk-list").first()
+      val items: Elements = list.getElementsByTag("li")
+      items.size mustBe 2
+      items.first().text() must include("1 January 2026 to 31 December 2026")
+      items.get(1).text()  must include("1 July 2025 to 31 December 2025")
     }
 
     "show the further adjustments paragraph" in {


### PR DESCRIPTION
This ticket was previously tested but has been brought back into progress following the demo to the accessibility team. They weren't happy with us using the approach that we've implemented on the page at the start of the amend journey as those can have change links. The lack of change links on this page means the markup has to be different (move from dl/dt to ul/li).