### PR TITLE
PIL-3028: Removed manual script implementation that is no longer required due to hmrcScripts component

### DIFF
--- a/app/views/templates/Layout.scala.html
+++ b/app/views/templates/Layout.scala.html
@@ -45,7 +45,6 @@
     @autocompleteJavascript()
     <script @{CSPNonce.attr} src='@controllers.routes.Assets.versioned("javascripts/jquery-3.6.0.min.js")'></script>
     <script @{CSPNonce.attr} src='@controllers.routes.Assets.versioned("javascripts/application.min.js")'></script>
-    <script @{CSPNonce.attr}>window.GOVUKFrontend.initAll();</script>
 }
 
 @head = {


### PR DESCRIPTION
As highlighted in the PIL-3028 ticket comments, the only valid console error appears to be related to our initAll implementation. Our initAll implementation became an outdated approach when version 9.0.0 of play-frontend-hmrc was released. However, this approach also seems to have since become outdated. If you are using the hmrcScripts component (which we are) you no longer need to manually initialise the govuk-frontend script.