### PR TITLE
PIL-3003: Added aria-hidden to hr and br tags highlighted in accessibility report

### DIFF
--- a/app/views/RegistrationInProgressView.scala.html
+++ b/app/views/RegistrationInProgressView.scala.html
@@ -31,7 +31,7 @@
    <span><strong>@{messages("homepage.id")}:</strong> @plrReference</span>
   </p>
 
-  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" aria-hidden="true">
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -40,5 +40,5 @@
     </div>
   </div>
   
-  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" aria-hidden="true">
 }

--- a/app/views/components/gds/SectionBreak.scala.html
+++ b/app/views/components/gds/SectionBreak.scala.html
@@ -18,4 +18,4 @@
 
 @(id: Option[String] = None)
 
-<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" @id.map { id => id="@id" }>
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" aria-hidden="true" @id.map { id => id="@id" }>

--- a/app/views/outstandingpayments/_OutstandingPaymentsTable.scala.html
+++ b/app/views/outstandingpayments/_OutstandingPaymentsTable.scala.html
@@ -61,7 +61,7 @@
                 Seq(
                     TableRow(
                         content = if(row.appealFlag.contains(true)) {
-                            HtmlContent(s"""${row.description} <br> <strong class="govuk-tag govuk-tag--red">Appealed</strong>""")
+                            HtmlContent(s"""${row.description} <br aria-hidden="true"> <strong class="govuk-tag govuk-tag--red">Appealed</strong>""")
                         } else {
                             Text(row.description)
                         }),

--- a/app/views/subscriptionview/manageAccount/AmendAccountingPeriodCYAView.scala.html
+++ b/app/views/subscriptionview/manageAccount/AmendAccountingPeriodCYAView.scala.html
@@ -85,7 +85,7 @@
         ) { warningLines =>
             @govukWarningText(WarningText(
                 iconFallbackText = Some(messages("site.warning")),
-                content = HtmlContent(warningLines.mkString("<br>"))
+                content = HtmlContent(warningLines.mkString("<br aria-hidden=true>"))
             ))
         }
 

--- a/app/views/subscriptionview/manageAccount/NewAccountingPeriodView.scala.html
+++ b/app/views/subscriptionview/manageAccount/NewAccountingPeriodView.scala.html
@@ -56,7 +56,7 @@
 
         @heading(messages("newAccountingPeriod.heading"), "govuk-heading-l")
 
-        @govukInsetText(InsetText(content = HtmlContent(s"${messages("newAccountingPeriod.insetText")} <br> ${chosenAccountingPeriod.toString}")))
+        @govukInsetText(InsetText(content = HtmlContent(s"${messages("newAccountingPeriod.insetText")} <br aria-hidden=true> ${chosenAccountingPeriod.toString}")))
 
         @paragraphBody(messages("newAccountingPeriod.p1"))
         @paragraphBody(messages("newAccountingPeriod.p2"))

--- a/test/views/subscriptionview/manageAccount/NewAccountingPeriodViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/NewAccountingPeriodViewSpec.scala
@@ -97,7 +97,7 @@ class NewAccountingPeriodViewSpec extends ViewSpecBase {
       "have inset text" in {
         organisationView().getElementsByClass("govuk-inset-text").text mustBe
           s"You are changing accounting period: ${startDate.toDateFormat} to ${endDate.toDateFormat}"
-        organisationView().getElementsByClass("govuk-inset-text").html must include("<br>")
+        organisationView().getElementsByClass("govuk-inset-text").html must include("<br aria-hidden=\"true\">")
       }
 
       "have the following paragraph content" in {


### PR DESCRIPTION
Description: br and hr tags will be announced by some screen-readers, they have been used heavily on this page meaning a screen-reader user will have a lot of additional noise to navigate through.

Resolve: Do not use br and hr tags for visual styling of elements or show grouping, apply appropriate CSS and semantic HMTL. For example NVDA announces hr as 'separator'
Alternatively add aria-hidden=true attribute, that would prevent assistive technology to announce them

Opted for the aria-hidden approach due to time constraints/service being handed over to live services next week.