### PR TITLE
PIL-3179: Added unique aria-labels for the submission history tables

### DIFF
--- a/app/views/submissionhistory/SubmissionHistoryView.scala.html
+++ b/app/views/submissionhistory/SubmissionHistoryView.scala.html
@@ -55,8 +55,10 @@
     @govukInsetText(InsetText(content = Text(messages("submissionHistory.insetText"))))
     <br>
     @for(table <- SubmissionHistoryHelper.generateSubmissionHistoryTable(accountPeriods)) {
-        @LabelledScrollWrapper(messages("submissionHistory.heading")) {
-            @govukTable(table)
+        @table.caption.map { caption =>
+            @LabelledScrollWrapper(s"$caption ${messages("submissionHistory.heading").toLowerCase}") {
+                @govukTable(table)
+            }
         }
     }
     <br>

--- a/test/views/submissionhistory/SubmissionHistoryViewSpec.scala
+++ b/test/views/submissionhistory/SubmissionHistoryViewSpec.scala
@@ -115,7 +115,7 @@ class SubmissionHistoryViewSpec extends ViewSpecBase with ObligationsAndSubmissi
 
       wrapper.attr("role") mustBe "region"
       wrapper.attr("tabindex") mustBe "0"
-      wrapper.attr("aria-label") mustBe "Submission history table"
+      wrapper.attr("aria-label") mustBe s"Accounting period: ${fromDate.toDateFormat} to ${toDate.toDateFormat} submission history table"
     }
 
     "have a sub heading" in {


### PR DESCRIPTION
The Submission history page contains multiple scrollable tables for different accounting periods. Each table wrapper is defined with role="region" and the same accessible name:
aria-label="Submission history table"
This results in multiple landmarks having the same role and accessible name combination.
This is being flagged on the automated accessibility report and needs to be fixed prior to live handover.

Update the accessible name applied to each Submission history table region so that each role="region" landmark has a unique accessible name.
The accessible name should clearly identify the accounting period associated with the table.