### PR TITLE
PIL-2896: Migrating pillar 2 frontend to the latest version of play-frontend-hmrc

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -44,7 +44,7 @@ class FrontendAppConfig @Inject() (configuration: Configuration, servicesConfig:
     URLEncoder.encode(value, StandardCharsets.UTF_8.toString)
 
   def feedbackUrl(using request: RequestHeader): String =
-    s"$contactHost/contact/beta-feedback?service=$contactFormServiceIdentifier&backUrl=${encode(host + request.uri)}"
+    s"$contactHost/contact/beta-feedback?service=$contactFormServiceIdentifier&backUrl=${encode(host + request.uri)}&useServiceNavigation"
 
   def supportUrl(using request: RequestHeader): String =
     s"$contactHost/contact/report-technical-problem?service=$contactFormServiceIdentifier&referrerUrl=${encode(request.uri)}"
@@ -77,7 +77,7 @@ class FrontendAppConfig @Inject() (configuration: Configuration, servicesConfig:
     s"/accessibility-statement$accessibilityStatementServicePath"
 
   private val exitSurveyBaseUrl: String = configuration.get[Service]("microservice.services.feedback-frontend").baseUrl
-  val exitSurveyUrl:             String = s"$exitSurveyBaseUrl/feedback/pillar2-frontend"
+  val exitSurveyUrl:             String = s"$exitSurveyBaseUrl/feedback/pillar2-frontend?useServiceNavigation"
 
   val timeout:   Int = configuration.get[Int]("timeout-dialog.timeout")
   val countdown: Int = configuration.get[Int]("timeout-dialog.countdown")

--- a/app/viewmodels/govuk/ButtonFluency.scala
+++ b/app/viewmodels/govuk/ButtonFluency.scala
@@ -27,7 +27,6 @@ trait ButtonFluency {
 
     def apply(content: Content): Button =
       Button(
-        element = Some("button"),
         content = content
       )
   }
@@ -36,13 +35,11 @@ trait ButtonFluency {
 
     def asLink(href: String): Button =
       button.copy(
-        element = Some("a"),
         href = Some(href)
       )
 
     def asInput(inputType: String): Button =
       button.copy(
-        element = Some("input"),
         inputType = Some(inputType)
       )
 

--- a/app/views/CheckYourAnswersView.scala.html
+++ b/app/views/CheckYourAnswersView.scala.html
@@ -68,7 +68,6 @@
         @para(messages("checkYourAnswers.submit.p"))
 
         @govukButton(Button(
-            element = Some("button"),
             content = messages("site.confirm.send"),
             preventDoubleClick = Some(true),
             attributes = Map("id" -> "submit"),

--- a/app/views/btn/CheckYourAnswersView.scala.html
+++ b/app/views/btn/CheckYourAnswersView.scala.html
@@ -51,7 +51,6 @@
     @paragraph(messages("btn.cya.p3"))
 
     @govukButton(Button(
-      element = Some("button"),
       content = Text(messages("site.confirm.submit")),
       preventDoubleClick = Some(true),
       attributes = Map("id" -> "submit"),

--- a/app/views/subscriptionview/manageAccount/ManageContactCheckYourAnswersView.scala.html
+++ b/app/views/subscriptionview/manageAccount/ManageContactCheckYourAnswersView.scala.html
@@ -48,7 +48,6 @@
             @govukSummaryList(address)
 
             @govukButton(Button(
-                element = Some("button"),
                 content = messages("site.manage.save-and-continue"),
                 attributes = Map("id" -> "submit"),
                 classes = "govuk-!-margin-top-4")

--- a/app/views/subscriptionview/manageAccount/ManageGroupDetailsCheckYourAnswersView.scala.html
+++ b/app/views/subscriptionview/manageAccount/ManageGroupDetailsCheckYourAnswersView.scala.html
@@ -39,7 +39,6 @@
         @govukSummaryList(list)
 
         @govukButton(Button(
-            element = Some("button"),
             content = messages("site.manage.save-and-continue"),
             attributes = Map("id" -> "submit"),
             classes = "govuk-!-margin-top-6"))

--- a/app/views/templates/Layout.scala.html
+++ b/app/views/templates/Layout.scala.html
@@ -25,7 +25,6 @@
     hmrcStandardHeader: HmrcStandardHeader,
     hmrcStandardFooter: HmrcStandardFooter,
     hmrcTrackingConsentSnippet: HmrcTrackingConsentSnippet,
-    hmrcLanguageSelect: HmrcLanguageSelect,
     hmrcTimeoutDialog: HmrcTimeoutDialog,
     hmrcReportTechnicalIssueHelper: HmrcReportTechnicalIssueHelper,
     autocompleteJavascript : HmrcAccessibleAutocompleteJavascript,

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -14,11 +14,6 @@
 
 include "frontend.conf"
 
-play-frontend-hmrc {
-  useRebrand = true
-}
-
-
 appName = "pillar2-frontend"
 
 play.http.router = prod.Routes

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import sbt.*
 
 object AppDependencies {
   val bootstrapVersion = "10.8.0"
-  val mongoVersion     = "2.12.0"
+  val mongoVersion     = "2.13.0"
 
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,7 +6,7 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"           %% "play-frontend-hmrc-play-30"            % "12.32.0",
+    "uk.gov.hmrc"           %% "play-frontend-hmrc-play-30"            % "13.9.0",
     "uk.gov.hmrc"           %% "play-conditional-form-mapping-play-30" % "3.5.0",
     "uk.gov.hmrc"           %% "bootstrap-frontend-play-30"            % bootstrapVersion,
     "uk.gov.hmrc.mongo"     %% "hmrc-mongo-play-30"                    % mongoVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.3")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.1")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-sass-compiler" % "0.12.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-sass-compiler" % "0.13.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-concat" % "1.0.0")
 

--- a/test/helpers/ViewInstances.scala
+++ b/test/helpers/ViewInstances.scala
@@ -45,36 +45,27 @@ trait ViewInstances extends StubMessageControllerComponents {
 
   val accessibilityConfiguration = new AccessibilityStatementConfig(configuration)
 
-  lazy val tudorCrownConfig: TudorCrownConfig = TudorCrownConfig(configuration)
-
-  lazy val rebrandConfig: RebrandConfig = RebrandConfig(configuration)
-
   lazy val govukLogo = new GovukLogo()
 
-  val govukHeader = new GovukHeader(tudorCrownConfig, rebrandConfig, govukLogo)
+  val govukHeader = new GovukHeader(govukLogo)
 
   val govukTemplate =
-    new GovukTemplate(govukHeader, new GovukFooter(rebrandConfig, govukLogo), new GovukSkipLink, new FixedWidthPageLayout, rebrandConfig)
-
-  val serviceNavigationConfig = new ServiceNavigationConfig(configuration)
+    new GovukTemplate(govukHeader, new GovukFooter(govukLogo), new GovukSkipLink, new FixedWidthPageLayout)
 
   val govukServiceNavigation = new GovukServiceNavigation()
 
   val hmrcStandardHeader = new HmrcStandardHeader(
     hmrcHeader = new HmrcHeader(
-      hmrcBanner = new HmrcBanner(tudorCrownConfig),
+      hmrcBanner = new HmrcBanner(),
       hmrcUserResearchBanner = new HmrcUserResearchBanner(),
       govukPhaseBanner = new GovukPhaseBanner(govukTag = new GovukTag()),
-      tudorCrownConfig = tudorCrownConfig,
-      rebrandConfig = rebrandConfig,
       govukLogo = govukLogo,
       govukServiceNavigation = govukServiceNavigation
     ),
-    serviceNavigationConfig = serviceNavigationConfig,
     configuration = configuration
   )
   val hmrcStandardFooter = new HmrcStandardFooter(
-    new HmrcFooter(new GovukFooter(rebrandConfig, govukLogo)),
+    new HmrcFooter(new GovukFooter(govukLogo)),
     new HmrcFooterItems(new AccessibilityStatementConfig(configuration))
   )
 
@@ -129,10 +120,11 @@ trait ViewInstances extends StubMessageControllerComponents {
   val govukLayout = new GovukLayout(
     govukTemplate = govukTemplate,
     govukHeader = govukHeader,
-    govukFooter = new GovukFooter(rebrandConfig, govukLogo),
+    govukFooter = new GovukFooter(govukLogo),
     govukBackLink = govukBackLink,
     defaultMainContentLayout = new TwoThirdsMainContent,
-    fixedWidthPageLayout = new FixedWidthPageLayout
+    fixedWidthPageLayout = new FixedWidthPageLayout,
+    govukServiceNavigation = govukServiceNavigation
   )
 
   val pillar2layout = new Layout(
@@ -142,7 +134,6 @@ trait ViewInstances extends StubMessageControllerComponents {
     hmrcStandardHeader,
     hmrcStandardFooter,
     hmrcTrackingConsent,
-    new HmrcLanguageSelect(),
     hmrcTimeoutDialogue,
     new HmrcReportTechnicalIssueHelper(new HmrcReportTechnicalIssue(), new ContactFrontendConfig(configuration)),
     new HmrcAccessibleAutocompleteJavascript(assetsConfig),

--- a/test/views/BusinessActivityUKViewSpec.scala
+++ b/test/views/BusinessActivityUKViewSpec.scala
@@ -50,8 +50,11 @@ class BusinessActivityUKViewSpec extends ViewSpecBase {
       }
 
       "have a banner with a link to pillar 2 guidance" in {
-        val className: String = "govuk-header__link govuk-header__service-name"
-        view.getElementsByClass(className).attr("href") mustBe "https://www.gov.uk/guidance/report-pillar-2-top-up-taxes"
+        val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceName.size() mustBe 1
+        serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceName.attr("href") mustBe "https://www.gov.uk/guidance/report-pillar-2-top-up-taxes"
       }
 
       "have a hint" in {

--- a/test/views/GroupTerritoriesViewSpec.scala
+++ b/test/views/GroupTerritoriesViewSpec.scala
@@ -49,8 +49,11 @@ class GroupTerritoriesViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to pillar 2 guidance" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      view.getElementsByClass(className).attr("href") mustBe "https://www.gov.uk/guidance/report-pillar-2-top-up-taxes"
+      val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe "https://www.gov.uk/guidance/report-pillar-2-top-up-taxes"
     }
 
     "have a hint" in {

--- a/test/views/HomepageViewSpec.scala
+++ b/test/views/HomepageViewSpec.scala
@@ -128,8 +128,11 @@ class HomepageViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      organisationView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceName: Elements = organisationView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "display organisation information correctly" in {
@@ -596,8 +599,11 @@ class HomepageViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      agentView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceName: Elements = agentView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "display organisation information correctly" in {

--- a/test/views/Kb750IneligibleViewSpec.scala
+++ b/test/views/Kb750IneligibleViewSpec.scala
@@ -42,8 +42,11 @@ class Kb750IneligibleViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to pillar 2 guidance" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      view.getElementsByClass(className).attr("href") mustBe "https://www.gov.uk/guidance/report-pillar-2-top-up-taxes"
+      val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe "https://www.gov.uk/guidance/report-pillar-2-top-up-taxes"
     }
 
     "have paragraph content" in {

--- a/test/views/KbMnIneligibleViewSpec.scala
+++ b/test/views/KbMnIneligibleViewSpec.scala
@@ -42,8 +42,11 @@ class KbMnIneligibleViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to pillar 2 guidance" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      view.getElementsByClass(className).attr("href") mustBe "https://www.gov.uk/guidance/report-pillar-2-top-up-taxes"
+      val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe "https://www.gov.uk/guidance/report-pillar-2-top-up-taxes"
     }
 
     "have paragraph content" in {

--- a/test/views/KbUKIneligibleViewSpec.scala
+++ b/test/views/KbUKIneligibleViewSpec.scala
@@ -42,8 +42,11 @@ class KbUKIneligibleViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to pillar 2 guidance" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      view.getElementsByClass(className).attr("href") mustBe "https://www.gov.uk/guidance/report-pillar-2-top-up-taxes"
+      val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe "https://www.gov.uk/guidance/report-pillar-2-top-up-taxes"
     }
 
     "have paragraph content" in {

--- a/test/views/RegistrationInProgressViewSpec.scala
+++ b/test/views/RegistrationInProgressViewSpec.scala
@@ -57,8 +57,11 @@ class RegistrationInProgressViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      view.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "use full-width layout without back link" in {

--- a/test/views/TurnOverEligibilityViewSpec.scala
+++ b/test/views/TurnOverEligibilityViewSpec.scala
@@ -51,8 +51,11 @@ class TurnOverEligibilityViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to pillar 2 guidance" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      view.getElementsByClass(className).attr("href") mustBe "https://www.gov.uk/guidance/report-pillar-2-top-up-taxes"
+      val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe "https://www.gov.uk/guidance/report-pillar-2-top-up-taxes"
     }
 
     "have a hint" in {

--- a/test/views/btn/BTNAccountingPeriodViewSpec.scala
+++ b/test/views/btn/BTNAccountingPeriodViewSpec.scala
@@ -86,7 +86,11 @@ class BTNAccountingPeriodViewSpec extends ViewSpecBase {
       }
 
       "have a banner with a link to the Homepage" in {
-        organisationView().getElementsByClass(bannerClassName).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        val serviceName: Elements = organisationView().select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceName.size() mustBe 1
+        serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "have a paragraph" in {
@@ -160,7 +164,11 @@ class BTNAccountingPeriodViewSpec extends ViewSpecBase {
       }
 
       "have a banner with a link to the Homepage" in {
-        agentView().getElementsByClass(bannerClassName).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        val serviceName: Elements = agentView().select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceName.size() mustBe 1
+        serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "have a caption for agent view" in {

--- a/test/views/btn/BTNAlreadyInPlaceViewSpec.scala
+++ b/test/views/btn/BTNAlreadyInPlaceViewSpec.scala
@@ -46,8 +46,11 @@ class BTNAlreadyInPlaceViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      organisationView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceName: Elements = organisationView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have a paragraph" in {

--- a/test/views/btn/BTNAmendDetailsViewSpec.scala
+++ b/test/views/btn/BTNAmendDetailsViewSpec.scala
@@ -59,8 +59,18 @@ class BTNAmendDetailsViewSpec extends ViewSpecBase {
       }
 
       "have a banner with a link to the Homepage" in {
-        organisationViewUkOnly.getElementsByClass(bannerClassName).attr("href") mustBe routes.HomepageController.onPageLoad().url
-        organisationViewUkAndOther.getElementsByClass(bannerClassName).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        val serviceNameUkOnly: Elements = organisationViewUkOnly.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceNameUkOnly.size() mustBe 1
+        serviceNameUkOnly.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceNameUkOnly.attr("href") mustBe routes.HomepageController.onPageLoad().url
+
+        val serviceNameUkAndOther: Elements =
+          organisationViewUkAndOther.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceNameUkAndOther.size() mustBe 1
+        serviceNameUkAndOther.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceNameUkAndOther.attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "have paragraph content and link" in {
@@ -122,8 +132,18 @@ class BTNAmendDetailsViewSpec extends ViewSpecBase {
       }
 
       "have a banner with a link to the Homepage" in {
-        agentViewUkOnly().getElementsByClass(bannerClassName).attr("href") mustBe routes.HomepageController.onPageLoad().url
-        agentViewUkAndOther().getElementsByClass(bannerClassName).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        val serviceNameUkOnly: Elements = agentViewUkOnly().select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceNameUkOnly.size() mustBe 1
+        serviceNameUkOnly.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceNameUkOnly.attr("href") mustBe routes.HomepageController.onPageLoad().url
+
+        val serviceNameUkAndOther: Elements =
+          agentViewUkAndOther().select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceNameUkAndOther.size() mustBe 1
+        serviceNameUkAndOther.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceNameUkAndOther.attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "have paragraph content and link" in {

--- a/test/views/btn/BTNBeforeStartViewSpec.scala
+++ b/test/views/btn/BTNBeforeStartViewSpec.scala
@@ -64,8 +64,11 @@ class BTNBeforeStartViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      organisationView().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceName: Elements = organisationView().select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have two h2 headings" in {

--- a/test/views/btn/BTNCannotReturnViewSpec.scala
+++ b/test/views/btn/BTNCannotReturnViewSpec.scala
@@ -42,8 +42,11 @@ class BTNCannotReturnViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      view.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have no back link" in {

--- a/test/views/btn/BTNChooseAccountingPeriodViewSpec.scala
+++ b/test/views/btn/BTNChooseAccountingPeriodViewSpec.scala
@@ -70,9 +70,17 @@ class BTNChooseAccountingPeriodViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      organisationView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
-      agentView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceNameOrg: Elements = organisationView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceNameOrg.size() mustBe 1
+      serviceNameOrg.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceNameOrg.attr("href") mustBe routes.HomepageController.onPageLoad().url
+
+      val serviceNameAgent: Elements = agentView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceNameAgent.size() mustBe 1
+      serviceNameAgent.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceNameAgent.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have a caption for an agent view" in {

--- a/test/views/btn/BTNConfirmationViewSpec.scala
+++ b/test/views/btn/BTNConfirmationViewSpec.scala
@@ -77,9 +77,17 @@ class BTNConfirmationViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      groupView().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
-      agentView().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceNameGroup: Elements = groupView().select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceNameGroup.size() mustBe 1
+      serviceNameGroup.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceNameGroup.attr("href") mustBe routes.HomepageController.onPageLoad().url
+
+      val serviceNameAgent: Elements = agentView().select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceNameAgent.size() mustBe 1
+      serviceNameAgent.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceNameAgent.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have an H2 heading" in {

--- a/test/views/btn/BTNEntitiesInUKOnlyViewSpec.scala
+++ b/test/views/btn/BTNEntitiesInUKOnlyViewSpec.scala
@@ -53,9 +53,17 @@ class BTNEntitiesInUKOnlyViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      organisationView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
-      agentView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceNameOrg: Elements = organisationView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceNameOrg.size() mustBe 1
+      serviceNameOrg.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceNameOrg.attr("href") mustBe routes.HomepageController.onPageLoad().url
+
+      val serviceNameAgent: Elements = agentView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceNameAgent.size() mustBe 1
+      serviceNameAgent.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceNameAgent.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have radio items" in {

--- a/test/views/btn/BTNEntitiesInsideOutsideUKViewSpec.scala
+++ b/test/views/btn/BTNEntitiesInsideOutsideUKViewSpec.scala
@@ -54,9 +54,17 @@ class BTNEntitiesInsideOutsideUKViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      organisationView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
-      agentView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceNameOrg: Elements = organisationView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceNameOrg.size() mustBe 1
+      serviceNameOrg.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceNameOrg.attr("href") mustBe routes.HomepageController.onPageLoad().url
+
+      val serviceNameAgent: Elements = agentView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceNameAgent.size() mustBe 1
+      serviceNameAgent.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceNameAgent.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have radio items" in {

--- a/test/views/btn/BTNNoAccountingPeriodViewSpec.scala
+++ b/test/views/btn/BTNNoAccountingPeriodViewSpec.scala
@@ -43,8 +43,11 @@ class BTNNoAccountingPeriodViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      organisationView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceName: Elements = organisationView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "display a descriptive paragraph of the problem" in {

--- a/test/views/btn/BTNProblemWithServiceViewSpec.scala
+++ b/test/views/btn/BTNProblemWithServiceViewSpec.scala
@@ -42,8 +42,11 @@ class BTNProblemWithServiceViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      view.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "display a try again later message" in {

--- a/test/views/btn/BTNReturnSubmittedViewSpec.scala
+++ b/test/views/btn/BTNReturnSubmittedViewSpec.scala
@@ -73,9 +73,17 @@ class BTNReturnSubmittedViewSpec extends ViewSpecBase {
       }
 
       "have a banner with a link to the Homepage" in {
-        val className: String = "govuk-header__link govuk-header__service-name"
-        organisationView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
-        agentView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        val serviceNameOrg: Elements = organisationView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceNameOrg.size() mustBe 1
+        serviceNameOrg.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceNameOrg.attr("href") mustBe routes.HomepageController.onPageLoad().url
+
+        val serviceNameAgent: Elements = agentView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceNameAgent.size() mustBe 1
+        serviceNameAgent.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceNameAgent.attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "have a paragraph" in {

--- a/test/views/btn/CheckYourAnswersViewSpec.scala
+++ b/test/views/btn/CheckYourAnswersViewSpec.scala
@@ -80,9 +80,17 @@ class CheckYourAnswersViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      organisationView().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
-      agentView().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceNameOrg: Elements = organisationView().select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceNameOrg.size() mustBe 1
+      serviceNameOrg.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceNameOrg.attr("href") mustBe routes.HomepageController.onPageLoad().url
+
+      val serviceNameAgent: Elements = agentView().select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceNameAgent.size() mustBe 1
+      serviceNameAgent.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceNameAgent.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have a paragraph" in {

--- a/test/views/dueandoverduereturns/DueAndOverdueReturnsViewSpec.scala
+++ b/test/views/dueandoverduereturns/DueAndOverdueReturnsViewSpec.scala
@@ -44,8 +44,11 @@ class DueAndOverdueReturnsViewSpec extends ViewSpecBase with ObligationsAndSubmi
     h1Elements.size() mustBe 1
     h1Elements.text() mustBe pageTitle
 
-    val className: String = "govuk-header__link govuk-header__service-name"
-    view.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+    val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+    serviceName.size() mustBe 1
+    serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+    serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
 
     val headings: Elements = view.getElementsByTag("h2")
 

--- a/test/views/eligibilityview/EligibilityConfirmationViewSpec.scala
+++ b/test/views/eligibilityview/EligibilityConfirmationViewSpec.scala
@@ -42,8 +42,11 @@ class EligibilityConfirmationViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to pillar 2 guidance" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      view.getElementsByClass(className).attr("href") mustBe "https://www.gov.uk/guidance/report-pillar-2-top-up-taxes"
+      val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe "https://www.gov.uk/guidance/report-pillar-2-top-up-taxes"
     }
 
     "have a paragraph body" in {

--- a/test/views/outstandingpayments/OutstandingPaymentsViewSpec.scala
+++ b/test/views/outstandingpayments/OutstandingPaymentsViewSpec.scala
@@ -94,9 +94,17 @@ class OutstandingPaymentsViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      organisationView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
-      agentView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceNameOrg: Elements = organisationView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceNameOrg.size() mustBe 1
+      serviceNameOrg.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceNameOrg.attr("href") mustBe routes.HomepageController.onPageLoad().url
+
+      val serviceNameAgent: Elements = agentView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceNameAgent.size() mustBe 1
+      serviceNameAgent.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceNameAgent.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "display total amount due correctly" in {

--- a/test/views/paymenthistory/NoTransactionHistoryViewSpec.scala
+++ b/test/views/paymenthistory/NoTransactionHistoryViewSpec.scala
@@ -47,9 +47,17 @@ class NoTransactionHistoryViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      groupView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
-      agentView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceNameGroup: Elements = groupView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceNameGroup.size() mustBe 1
+      serviceNameGroup.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceNameGroup.attr("href") mustBe routes.HomepageController.onPageLoad().url
+
+      val serviceNameAgent: Elements = agentView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceNameAgent.size() mustBe 1
+      serviceNameAgent.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceNameAgent.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have paragraph 1" in {

--- a/test/views/paymenthistory/TransactionHistoryErrorViewSpec.scala
+++ b/test/views/paymenthistory/TransactionHistoryErrorViewSpec.scala
@@ -43,8 +43,11 @@ class TransactionHistoryErrorViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      view.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have a paragraph body" in {

--- a/test/views/paymenthistory/TransactionHistoryViewSpec.scala
+++ b/test/views/paymenthistory/TransactionHistoryViewSpec.scala
@@ -108,9 +108,17 @@ class TransactionHistoryViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      groupView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
-      agentView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceNameGroup: Elements = groupView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceNameGroup.size() mustBe 1
+      serviceNameGroup.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceNameGroup.attr("href") mustBe routes.HomepageController.onPageLoad().url
+
+      val serviceNameAgent: Elements = agentView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceNameAgent.size() mustBe 1
+      serviceNameAgent.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceNameAgent.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have correct text for agents at the top of the page" in {

--- a/test/views/registration/RegisteringNfmForThisGroupViewSpec.scala
+++ b/test/views/registration/RegisteringNfmForThisGroupViewSpec.scala
@@ -46,8 +46,11 @@ class RegisteringNfmForThisGroupViewSpec extends ViewSpecBase {
       }
 
       "have a banner with a link to pillar 2 guidance" in {
-        val className: String = "govuk-header__link govuk-header__service-name"
-        view.getElementsByClass(className).attr("href") mustBe "https://www.gov.uk/guidance/report-pillar-2-top-up-taxes"
+        val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceName.size() mustBe 1
+        serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceName.attr("href") mustBe "https://www.gov.uk/guidance/report-pillar-2-top-up-taxes"
       }
 
       "have an H2 heading" in {

--- a/test/views/registration/RegistrationConfirmationViewSpec.scala
+++ b/test/views/registration/RegistrationConfirmationViewSpec.scala
@@ -59,9 +59,17 @@ class RegistrationConfirmationViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Dashboard" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      viewDomestic.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
-      viewMne.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceNameDomestic: Elements = viewDomestic.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceNameDomestic.size() mustBe 1
+      serviceNameDomestic.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceNameDomestic.attr("href") mustBe routes.HomepageController.onPageLoad().url
+
+      val serviceNameMne: Elements = viewMne.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceNameMne.size() mustBe 1
+      serviceNameMne.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceNameMne.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have an H2 heading" in {

--- a/test/views/repayments/BankAccountDetailsViewSpec.scala
+++ b/test/views/repayments/BankAccountDetailsViewSpec.scala
@@ -71,8 +71,11 @@ class BankAccountDetailsViewSpec extends ViewSpecBase with StringGenerators {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      view.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have the correct labels" in {

--- a/test/views/repayments/IncompleteDataViewSpec.scala
+++ b/test/views/repayments/IncompleteDataViewSpec.scala
@@ -42,8 +42,11 @@ class IncompleteDataViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      view.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have a paragraph with a link" in {

--- a/test/views/repayments/JourneyRecoveryViewSpec.scala
+++ b/test/views/repayments/JourneyRecoveryViewSpec.scala
@@ -44,8 +44,11 @@ class JourneyRecoveryViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      view.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have the first paragraph with the correct text" in {

--- a/test/views/repayments/NonUKBankViewSpec.scala
+++ b/test/views/repayments/NonUKBankViewSpec.scala
@@ -64,8 +64,11 @@ class NonUKBankViewSpec extends ViewSpecBase with StringGenerators {
       }
 
       "have a banner with a link to the Homepage" in {
-        val className: String = "govuk-header__link govuk-header__service-name"
-        view.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceName.size() mustBe 1
+        serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "have a paragraph" in {

--- a/test/views/repayments/ReasonForRequestingRefundViewSpec.scala
+++ b/test/views/repayments/ReasonForRequestingRefundViewSpec.scala
@@ -62,8 +62,11 @@ class ReasonForRequestingRefundViewSpec extends ViewSpecBase with Generators wit
       }
 
       "have a banner with a link to the Homepage" in {
-        val className: String = "govuk-header__link govuk-header__service-name"
-        view.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceName.size() mustBe 1
+        serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "have a hint description" in {

--- a/test/views/repayments/RepaymentsCheckYourAnswersViewSpec.scala
+++ b/test/views/repayments/RepaymentsCheckYourAnswersViewSpec.scala
@@ -100,8 +100,11 @@ class RepaymentsCheckYourAnswersViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      view.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have the correct H2 headings" in {

--- a/test/views/repayments/RepaymentsConfirmationViewSpec.scala
+++ b/test/views/repayments/RepaymentsConfirmationViewSpec.scala
@@ -17,6 +17,7 @@
 package views.repayments
 
 import base.ViewSpecBase
+import controllers.routes
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
@@ -51,10 +52,11 @@ class RepaymentsConfirmationViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val headerLink: Element = view.getElementsByClass("govuk-header__content").first().getElementsByTag("a").first()
+      val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
 
-      headerLink.text mustBe "Report Pillar 2 Top-up Taxes"
-      headerLink.attr("href") mustBe controllers.routes.HomepageController.onPageLoad().url
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have a confirmation message" in {

--- a/test/views/repayments/RepaymentsContactByPhoneViewSpec.scala
+++ b/test/views/repayments/RepaymentsContactByPhoneViewSpec.scala
@@ -66,8 +66,11 @@ class RepaymentsContactByPhoneViewSpec extends ViewSpecBase with StringGenerator
       }
 
       "have a banner with a link to the Homepage" in {
-        val className: String = "govuk-header__link govuk-header__service-name"
-        view.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceName.size() mustBe 1
+        serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "have a hint" in {

--- a/test/views/repayments/RepaymentsContactEmailViewSpec.scala
+++ b/test/views/repayments/RepaymentsContactEmailViewSpec.scala
@@ -66,8 +66,11 @@ class RepaymentsContactEmailViewSpec extends ViewSpecBase with StringGenerators 
       }
 
       "have a banner with a link to the Homepage" in {
-        val className: String = "govuk-header__link govuk-header__service-name"
-        view.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceName.size() mustBe 1
+        serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "have a hint" in {

--- a/test/views/repayments/RepaymentsContactNameViewSpec.scala
+++ b/test/views/repayments/RepaymentsContactNameViewSpec.scala
@@ -62,8 +62,11 @@ class RepaymentsContactNameViewSpec extends ViewSpecBase with StringGenerators {
       }
 
       "have a banner with a link to the Homepage" in {
-        val className: String = "govuk-header__link govuk-header__service-name"
-        view.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceName.size() mustBe 1
+        serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "have a hint" in {

--- a/test/views/repayments/RepaymentsErrorReturnViewSpec.scala
+++ b/test/views/repayments/RepaymentsErrorReturnViewSpec.scala
@@ -55,9 +55,11 @@ class RepaymentsErrorReturnViewSpec extends ViewSpecBase {
     }
 
     "have the correct banner link" in {
-      val link: Elements = view.getElementsByClass("govuk-header__link").last().getElementsByTag("a")
-      link.attr("href") mustBe routes.HomepageController.onPageLoad().url
-      link.text mustBe "Report Pillar 2 Top-up Taxes"
+      val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     val viewScenarios: Seq[ViewScenario] =

--- a/test/views/repayments/RepaymentsPhoneDetailsViewSpec.scala
+++ b/test/views/repayments/RepaymentsPhoneDetailsViewSpec.scala
@@ -65,8 +65,11 @@ class RepaymentsPhoneDetailsViewSpec extends ViewSpecBase {
       }
 
       "have a banner with a link to the Homepage" in {
-        val className: String = "govuk-header__link govuk-header__service-name"
-        view.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceName.size() mustBe 1
+        serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "have a hint description" in {

--- a/test/views/repayments/RequestRefundAmountViewSpec.scala
+++ b/test/views/repayments/RequestRefundAmountViewSpec.scala
@@ -59,8 +59,11 @@ class RequestRefundAmountViewSpec extends ViewSpecBase {
       }
 
       "have a banner with a link to the Homepage" in {
-        val className: String = "govuk-header__link govuk-header__service-name"
-        view.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceName.size() mustBe 1
+        serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "have a button" in {

--- a/test/views/repayments/RequestRefundBeforeStartViewSpec.scala
+++ b/test/views/repayments/RequestRefundBeforeStartViewSpec.scala
@@ -52,9 +52,17 @@ class RequestRefundBeforeStartViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      view.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
-      agentView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
+
+      val serviceNameAgent: Elements = agentView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceNameAgent.size() mustBe 1
+      serviceNameAgent.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceNameAgent.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have an H2 heading" in {

--- a/test/views/repayments/UkOrAbroadBankAccountViewSpec.scala
+++ b/test/views/repayments/UkOrAbroadBankAccountViewSpec.scala
@@ -61,8 +61,11 @@ class UkOrAbroadBankAccountViewSpec extends ViewSpecBase {
       }
 
       "have a banner with a link to the Homepage" in {
-        val className: String = "govuk-header__link govuk-header__service-name"
-        view.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceName.size() mustBe 1
+        serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "have radio items" in {

--- a/test/views/rfm/AmendApiFailureViewSpec.scala
+++ b/test/views/rfm/AmendApiFailureViewSpec.scala
@@ -41,9 +41,11 @@ class AmendApiFailureViewSpec extends ViewSpecBase {
     }
 
     "have a non-clickable banner" in {
-      val serviceName = view.getElementsByClass("govuk-header__service-name").first()
-      serviceName.text mustBe "Report Pillar 2 Top-up Taxes"
-      serviceName.getElementsByTag("a") mustBe empty
+      val serviceName = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__text")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe empty
     }
 
     "have a unique H1 heading" in {

--- a/test/views/rfm/IncompleteDataViewSpec.scala
+++ b/test/views/rfm/IncompleteDataViewSpec.scala
@@ -40,9 +40,11 @@ class IncompleteDataViewSpec extends ViewSpecBase {
     }
 
     "have a non-clickable banner" in {
-      val serviceName: Element = view.getElementsByClass("govuk-header__service-name").first()
-      serviceName.text mustBe "Report Pillar 2 Top-up Taxes"
-      serviceName.getElementsByTag("a") mustBe empty
+      val serviceName = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__text")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe empty
     }
 
     "have a unique H1 heading" in {

--- a/test/views/rfm/JourneyRecoveryViewSpec.scala
+++ b/test/views/rfm/JourneyRecoveryViewSpec.scala
@@ -41,9 +41,11 @@ class JourneyRecoveryViewSpec extends ViewSpecBase {
     }
 
     "have a non-clickable banner" in {
-      val serviceName = view.getElementsByClass("govuk-header__service-name").first()
-      serviceName.text mustBe "Report Pillar 2 Top-up Taxes"
-      serviceName.getElementsByTag("a") mustBe empty
+      val serviceName = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__text")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe empty
     }
 
     "have a unique H1 heading" in {

--- a/test/views/rfm/RfmContactByPhoneViewSpec.scala
+++ b/test/views/rfm/RfmContactByPhoneViewSpec.scala
@@ -51,9 +51,11 @@ class RfmContactByPhoneViewSpec extends ViewSpecBase {
     }
 
     "have a non-clickable banner" in {
-      val serviceName = view.getElementsByClass("govuk-header__service-name").first()
-      serviceName.text mustBe "Report Pillar 2 Top-up Taxes"
-      serviceName.getElementsByTag("a") mustBe empty
+      val serviceName = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__text")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe empty
     }
 
     "have a caption" in {

--- a/test/views/rfm/RfmContactCheckYourAnswersViewSpec.scala
+++ b/test/views/rfm/RfmContactCheckYourAnswersViewSpec.scala
@@ -114,9 +114,11 @@ class RfmContactCheckYourAnswersViewSpec extends ViewSpecBase {
     }
 
     "have a non-clickable banner" in {
-      val serviceName = view.getElementsByClass("govuk-header__service-name").first()
-      serviceName.text mustBe "Report Pillar 2 Top-up Taxes"
-      serviceName.getElementsByTag("a") mustBe empty
+      val serviceName = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__text")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe empty
     }
 
     "have a caption" in {

--- a/test/views/rfm/RfmContactDetailsRegistrationViewSpec.scala
+++ b/test/views/rfm/RfmContactDetailsRegistrationViewSpec.scala
@@ -41,9 +41,11 @@ class RfmContactDetailsRegistrationViewSpec extends ViewSpecBase {
     }
 
     "have a non-clickable banner" in {
-      val serviceName = view.getElementsByClass("govuk-header__service-name").first()
-      serviceName.text mustBe "Report Pillar 2 Top-up Taxes"
-      serviceName.getElementsByTag("a") mustBe empty
+      val serviceName = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__text")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe empty
     }
 
     "have a caption" in {

--- a/test/views/rfm/RfmSecondaryContactNameViewSpec.scala
+++ b/test/views/rfm/RfmSecondaryContactNameViewSpec.scala
@@ -49,9 +49,11 @@ class RfmSecondaryContactNameViewSpec extends ViewSpecBase with StringGenerators
     }
 
     "have a non-clickable banner" in {
-      val serviceName = view.getElementsByClass("govuk-header__service-name").first()
-      serviceName.text mustBe "Report Pillar 2 Top-up Taxes"
-      serviceName.getElementsByTag("a") mustBe empty
+      val serviceName = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__text")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe empty
     }
 
     "have the correct caption" in {

--- a/test/views/rfm/SecurityCheckViewSpec.scala
+++ b/test/views/rfm/SecurityCheckViewSpec.scala
@@ -44,9 +44,11 @@ class SecurityCheckViewSpec extends ViewSpecBase {
     }
 
     "have a non-clickable banner" in {
-      val serviceName = view.getElementsByClass("govuk-header__service-name").first()
-      serviceName.text mustBe "Report Pillar 2 Top-up Taxes"
-      serviceName.getElementsByTag("a") mustBe empty
+      val serviceName = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__text")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe empty
     }
 
     "have a caption" in {

--- a/test/views/rfm/SecurityQuestionsCheckYourAnswersViewSpec.scala
+++ b/test/views/rfm/SecurityQuestionsCheckYourAnswersViewSpec.scala
@@ -60,9 +60,11 @@ class SecurityQuestionsCheckYourAnswersViewSpec extends ViewSpecBase {
     }
 
     "have a non-clickable banner" in {
-      val serviceName = view.getElementsByClass("govuk-header__service-name").first()
-      serviceName.text mustBe "Report Pillar 2 Top-up Taxes"
-      serviceName.getElementsByTag("a") mustBe empty
+      val serviceName = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__text")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe empty
     }
 
     "have a caption" in {

--- a/test/views/stoodovercharges/StoodoverChargesViewSpec.scala
+++ b/test/views/stoodovercharges/StoodoverChargesViewSpec.scala
@@ -81,9 +81,17 @@ class StoodoverChargesViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      organisationView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
-      agentView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceNameOrg: Elements = organisationView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceNameOrg.size() mustBe 1
+      serviceNameOrg.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceNameOrg.attr("href") mustBe routes.HomepageController.onPageLoad().url
+
+      val serviceNameAgent: Elements = agentView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceNameAgent.size() mustBe 1
+      serviceNameAgent.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceNameAgent.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "display stoodover total content" in {

--- a/test/views/submissionhistory/SubmissionHistoryNoSubmissionsViewSpec.scala
+++ b/test/views/submissionhistory/SubmissionHistoryNoSubmissionsViewSpec.scala
@@ -51,7 +51,11 @@ class SubmissionHistoryNoSubmissionsViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      organisationView.getElementsByClass(bannerClassName).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceName: Elements = organisationView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have a first paragraph" in {
@@ -79,7 +83,11 @@ class SubmissionHistoryNoSubmissionsViewSpec extends ViewSpecBase {
     val agentViewParagraphs: Elements = agentView.getElementsByTag("p")
 
     "have a banner with a link to the Homepage" in {
-      agentView.getElementsByClass(bannerClassName).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceName: Elements = agentView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have correct text for agents at the top of the page" in {

--- a/test/views/submissionhistory/SubmissionHistoryViewSpec.scala
+++ b/test/views/submissionhistory/SubmissionHistoryViewSpec.scala
@@ -69,7 +69,11 @@ class SubmissionHistoryViewSpec extends ViewSpecBase with ObligationsAndSubmissi
     }
 
     "have a banner with a link to the Homepage" in {
-      organisationView.getElementsByClass(bannerClassName).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceName: Elements = organisationView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have a paragraph detailing submission details" in {
@@ -134,7 +138,11 @@ class SubmissionHistoryViewSpec extends ViewSpecBase with ObligationsAndSubmissi
     val agentViewParagraphs: Elements = agentView.getElementsByTag("p")
 
     "have a banner with a link to the Homepage" in {
-      agentView.getElementsByClass(bannerClassName).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceName: Elements = agentView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have correct text for agents at the top of the page" in {

--- a/test/views/subscriptionview/manageAccount/AddSecondaryContactViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/AddSecondaryContactViewSpec.scala
@@ -53,8 +53,11 @@ class AddSecondaryContactViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      view.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have two description paragraphs" in {

--- a/test/views/subscriptionview/manageAccount/AmendAccountingPeriodCYAViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/AmendAccountingPeriodCYAViewSpec.scala
@@ -75,8 +75,11 @@ class AmendAccountingPeriodCYAViewSpec extends ViewSpecBase with SubscriptionDat
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      view().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceName: Elements = view().select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have summary card with correct content" in {

--- a/test/views/subscriptionview/manageAccount/AmendAccountingPeriodConfirmationViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/AmendAccountingPeriodConfirmationViewSpec.scala
@@ -84,8 +84,11 @@ class AmendAccountingPeriodConfirmationViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className = "govuk-header__link govuk-header__service-name"
-      groupView().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceName: Elements = groupView().select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have no back link" in {

--- a/test/views/subscriptionview/manageAccount/CaptureSubscriptionAddressViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/CaptureSubscriptionAddressViewSpec.scala
@@ -75,9 +75,17 @@ class CaptureSubscriptionAddressViewSpec extends ViewSpecBase with StringGenerat
       }
 
       "have a banner with a link to the Homepage" in {
-        val className: String = "govuk-header__link govuk-header__service-name"
-        view().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
-        view(isAgent = true).getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        val serviceName: Elements = view().select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceName.size() mustBe 1
+        serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
+
+        val serviceNameAgent: Elements = view(isAgent = true).select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceNameAgent.size() mustBe 1
+        serviceNameAgent.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceNameAgent.attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "display the address line 1 label" in {

--- a/test/views/subscriptionview/manageAccount/ContactByPhoneViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/ContactByPhoneViewSpec.scala
@@ -76,9 +76,17 @@ class ContactByPhoneViewSpec extends ViewSpecBase with StringGenerators {
       }
 
       "have a banner with a link to the Homepage" in {
-        val className: String = "govuk-header__link govuk-header__service-name"
-        view().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
-        view(isAgent = true).getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        val serviceName: Elements = view().select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceName.size() mustBe 1
+        serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
+
+        val serviceNameAgent: Elements = view(isAgent = true).select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceNameAgent.size() mustBe 1
+        serviceNameAgent.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceNameAgent.attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "have a hint" in {

--- a/test/views/subscriptionview/manageAccount/ContactCapturePhoneDetailsViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/ContactCapturePhoneDetailsViewSpec.scala
@@ -53,8 +53,11 @@ class ContactCapturePhoneDetailsViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      view.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have a hint description" in {

--- a/test/views/subscriptionview/manageAccount/ContactEmailAddressViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/ContactEmailAddressViewSpec.scala
@@ -50,9 +50,17 @@ class ContactEmailAddressViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      view().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
-      view(isAgent = true).getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceName: Elements = view().select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
+
+      val serviceNameAgent: Elements = view(isAgent = true).select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceNameAgent.size() mustBe 1
+      serviceNameAgent.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceNameAgent.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have a caption" in {

--- a/test/views/subscriptionview/manageAccount/ContactNameComplianceViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/ContactNameComplianceViewSpec.scala
@@ -71,9 +71,17 @@ class ContactNameComplianceViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      view().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
-      view(isAgent = true).getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceName: Elements = view().select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
+
+      val serviceNameAgent: Elements = view(isAgent = true).select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceNameAgent.size() mustBe 1
+      serviceNameAgent.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceNameAgent.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "display the hint text" in {

--- a/test/views/subscriptionview/manageAccount/GroupAccountingPeriodViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/GroupAccountingPeriodViewSpec.scala
@@ -55,9 +55,17 @@ class GroupAccountingPeriodViewSpec extends ViewSpecBase {
       }
 
       "have a banner with a link to the Homepage" in {
-        val className: String = "govuk-header__link govuk-header__service-name"
-        organisationView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
-        agentView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        val serviceName: Elements = organisationView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceName.size() mustBe 1
+        serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
+
+        val serviceNameAgent: Elements = agentView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceNameAgent.size() mustBe 1
+        serviceNameAgent.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceNameAgent.attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "have the following paragraph content" in {

--- a/test/views/subscriptionview/manageAccount/ManageContactCheckYourAnswersViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/ManageContactCheckYourAnswersViewSpec.scala
@@ -103,8 +103,11 @@ class ManageContactCheckYourAnswersViewSpec extends ViewSpecBase with Subscripti
       }
 
       "have a banner with a link to the Homepage" in {
-        val className: String = "govuk-header__link govuk-header__service-name"
-        view.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceName.size() mustBe 1
+        serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "have first contact header" in {

--- a/test/views/subscriptionview/manageAccount/ManageGroupDetailsCheckYourAnswersViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/ManageGroupDetailsCheckYourAnswersViewSpec.scala
@@ -54,8 +54,11 @@ class ManageGroupDetailsCheckYourAnswersViewSpec extends ViewSpecBase with Subsc
       }
 
       "have a banner with a link to the Homepage" in {
-        val className: String = "govuk-header__link govuk-header__service-name"
-        view.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceName.size() mustBe 1
+        serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "have a summary list" in {

--- a/test/views/subscriptionview/manageAccount/MneOrDomesticViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/MneOrDomesticViewSpec.scala
@@ -51,8 +51,11 @@ class MneOrDomesticViewSpec extends ViewSpecBase {
       }
 
       "have a banner with a link to the Homepage" in {
-        val className: String = "govuk-header__link govuk-header__service-name"
-        view().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        val serviceName: Elements = view().select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceName.size() mustBe 1
+        serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "have the following paragraph and list content" in {

--- a/test/views/subscriptionview/manageAccount/MneToDomesticViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/MneToDomesticViewSpec.scala
@@ -53,8 +53,11 @@ class MneToDomesticViewSpec extends ViewSpecBase {
       }
 
       "have a banner with a link to the Homepage" in {
-        val className: String = "govuk-header__link govuk-header__service-name"
-        groupView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        val serviceName: Elements = groupView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceName.size() mustBe 1
+        serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "have the following paragraph content and link" in {
@@ -90,8 +93,11 @@ class MneToDomesticViewSpec extends ViewSpecBase {
       }
 
       "have a banner with a link to the Homepage" in {
-        val className: String = "govuk-header__link govuk-header__service-name"
-        agentView.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        val serviceName: Elements = agentView.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceName.size() mustBe 1
+        serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "have the following paragraph content and link" in {

--- a/test/views/subscriptionview/manageAccount/NewAccountingPeriodViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/NewAccountingPeriodViewSpec.scala
@@ -90,8 +90,11 @@ class NewAccountingPeriodViewSpec extends ViewSpecBase {
       }
 
       "have a banner with a link to the Homepage" in {
-        val className: String = "govuk-header__link govuk-header__service-name"
-        organisationView().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        val serviceName: Elements = organisationView().select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceName.size() mustBe 1
+        serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "have inset text" in {
@@ -251,8 +254,11 @@ class NewAccountingPeriodViewSpec extends ViewSpecBase {
       }
 
       "have a banner with a link to the Homepage" in {
-        val className: String = "govuk-header__link govuk-header__service-name"
-        agentView().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+        val serviceName: Elements = agentView().select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+        serviceName.size() mustBe 1
+        serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+        serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
       }
 
       "have the following paragraph content" in {

--- a/test/views/subscriptionview/manageAccount/SecondaryContactEmailViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/SecondaryContactEmailViewSpec.scala
@@ -50,9 +50,17 @@ class SecondaryContactEmailViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      view().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
-      view(isAgent = true).getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceName: Elements = view().select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
+
+      val serviceNameAgent: Elements = view(isAgent = true).select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceNameAgent.size() mustBe 1
+      serviceNameAgent.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceNameAgent.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have a caption" in {

--- a/test/views/subscriptionview/manageAccount/SecondaryContactNameViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/SecondaryContactNameViewSpec.scala
@@ -71,9 +71,17 @@ class SecondaryContactNameViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      view().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
-      view(isAgent = true).getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceName: Elements = view().select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
+
+      val serviceNameAgent: Elements = view(isAgent = true).select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceNameAgent.size() mustBe 1
+      serviceNameAgent.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceNameAgent.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "include a helpful hint with examples" in {

--- a/test/views/subscriptionview/manageAccount/SecondaryPhonePreferenceViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/SecondaryPhonePreferenceViewSpec.scala
@@ -75,9 +75,17 @@ class SecondaryPhonePreferenceViewSpec extends ViewSpecBase with StringGenerator
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      view().getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
-      view(isAgent = true).getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceName: Elements = view().select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
+
+      val serviceNameAgent: Elements = view(isAgent = true).select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceNameAgent.size() mustBe 1
+      serviceNameAgent.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceNameAgent.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have a hint" in {

--- a/test/views/subscriptionview/manageAccount/SecondaryPhoneViewSpec.scala
+++ b/test/views/subscriptionview/manageAccount/SecondaryPhoneViewSpec.scala
@@ -53,8 +53,11 @@ class SecondaryPhoneViewSpec extends ViewSpecBase {
     }
 
     "have a banner with a link to the Homepage" in {
-      val className: String = "govuk-header__link govuk-header__service-name"
-      view.getElementsByClass(className).attr("href") mustBe routes.HomepageController.onPageLoad().url
+      val serviceName: Elements = view.select(".govuk-service-navigation__service-name > .govuk-service-navigation__link")
+
+      serviceName.size() mustBe 1
+      serviceName.text() mustBe "Report Pillar 2 Top-up Taxes"
+      serviceName.attr("href") mustBe routes.HomepageController.onPageLoad().url
     }
 
     "have a hint description" in {


### PR DESCRIPTION
This major version of play-frontend-hmrc updates services to the latest major version of govuk-frontend (v6), and the latest major version of hmrc-frontend (v7).

This also enables the rebrand and service navigation components by default.